### PR TITLE
update service email Oauth 2.0

### DIFF
--- a/docs/email/Service.md
+++ b/docs/email/Service.md
@@ -56,9 +56,7 @@ This can be changed either by a SQL statement (requires access to SQL database)
 
 * Onsite customers who use SuperOffice G9 9.2 R10 or newer
 * Unique/separate serial number for each site/DB to use OAuth/AccessGateway
-  * Only the first site that tries to register with a given serial number will register successfully
-  * Alternatively for those who does not use separate serial number:
-    * use app passwords instead of oauth2 in the second (...or third, or all) sites
+  * Only the first site that tries to register with a given serial number will register successfully. Contact support to change site/DB.
 * Microsoft 365 (Microsoft® Exchange Online)
 * MX Record pointing to the Microsoft® Exchange Online server
 


### PR DESCRIPTION
Knutz provided feedback MS365 app password is neither supported after 1. oct. - and is therefore removed as alternative.