### PR TITLE
Change example on Client config

### DIFF
--- a/docs/api/config/client.md
+++ b/docs/api/config/client.md
@@ -18,7 +18,7 @@ In this section, you add the Reverse proxy override if you want to export larger
 
 ```XML
 <Client>
-  <add key="ExportPageSize" value="10" />
+  <add key="ExportRowLimit" value="20000" />
 </Client>
 ```
 


### PR DESCRIPTION
ExportPageSize option is obsolete, change the example based on request from a consultant.