### PR TITLE
Add separate page for request template variables and add the new ticket message id variable

### DIFF
--- a/common/includes/variable/table-misc.md
+++ b/common/includes/variable/table-misc.md
@@ -3,4 +3,3 @@
 |---|---|
 | diid | Current diary owner |
 | dday | Current DiaryDay date |
-| tiid | Current ticket id |

--- a/common/includes/variable/table-request.md
+++ b/common/includes/variable/table-request.md
@@ -1,0 +1,5 @@
+<!-- markdownlint-disable-file MD041 -->
+| Variable | Description |
+|---|---|
+| tiid | Current ticket id |
+| miid | Current ticket message id |

--- a/docs/en/document/templates/variables/for-request.md
+++ b/docs/en/document/templates/variables/for-request.md
@@ -1,0 +1,13 @@
+---
+uid: tempvar-request
+title: Variables for Request
+description: Variables for Request
+author: David Hollegien
+so.date: 04.25.2023
+keywords: template variable
+so.topic: reference
+---
+
+# Variables for Request
+
+[!include[Table](../../../../../common/includes/variable/table-request.md)]

--- a/docs/en/document/toc.yml
+++ b/docs/en/document/toc.yml
@@ -106,6 +106,8 @@ items:
         href: templates/variables/from-doc-dialog-or-system.md
       - name: From project card
         href: templates/variables/from-project-card.md
+      - name: For request
+        href: templates/variables/for-request.md  
       - name: From senders company card
         href: templates/variables/from-senders-company-card.md
       - name: Misc


### PR DESCRIPTION
see https://github.com/SuperOfficeDocs/superoffice-docs/issues/671

Not sure how to handle that ticket message id is only available starting in 10.2.5? 