### PR TITLE
Update toc.yml with the notifications.md ref

### DIFF
--- a/docs/en/learn/basics/notifications.md
+++ b/docs/en/learn/basics/notifications.md
@@ -55,7 +55,8 @@ These are the different activity notifications:
 
 * **Invitation declined**: A meeting attendee has declined the invitation. Click the link to open the calendar item, or click **Got it** to remove it from your notifications.
 
-    !Note: Invitations and changed activities will not be removed from the notifications panel but will remain until you either **Accept** or **Decline** the invitation.
+> [!NOTE]
+> Invitations and changed activities will not be removed from the notifications panel but will remain until you either **Accept** or **Decline** the invitation.
 
 ## Notification settings
 

--- a/docs/en/learn/basics/toc.yml
+++ b/docs/en/learn/basics/toc.yml
@@ -1,6 +1,8 @@
 items:
   - name: Overview
     href: index.md
+  - name: Notifications
+    href: notifications.md
   - name: Favorites
     href: fav.md
   - name: History list

--- a/docs/no/learn/basics/notifications.md
+++ b/docs/no/learn/basics/notifications.md
@@ -17,7 +17,7 @@ Når du klikker på **bjelleikonet** ![icon][img1] øverst til høyre i SuperOff
 
 * Klikk på et listeelement for å åpne det.
 * Klikk på ![icon][img2] for å angi varslingspreferansene dine.
-* Klikk på**Slett alt** i bunnteksten i varslingsruten for å tømme listen over varsler. Du kan også klikke på **Greit** under et varsel for å fjerne det.
+* Klikk på **Slett alt** i bunnteksten i varslingsruten for å tømme listen over varsler. Du kan også klikke på **Greit** under et varsel for å fjerne det.
 * Klikk på ![icon][img3] eller hvor som helst utenfor varslingsruten for å lukke det.
 
 ![Popup-vinduet med varsel som viser både varsler om saker og invitasjoner -screenshot][img5]
@@ -36,7 +36,8 @@ Dette er de forskjellige saksvarslene:
 * **Favorittsak oppdatert**: En av favorittsakene dine har blitt oppdatert.
 * **Egendefinert melding**: En egendefinert melding er lagt til i en sak.
 
-    ! Notat: Listen over saksvarsler blir slettet hver natt, noe som betyr at eventuelle saksvarsler du har i listen din på slutten av dagen, ikke vil være der i morgen.
+> [!NOTE]
+> Listen over saksvarsler blir slettet hver natt, noe som betyr at eventuelle saksvarsler du har i listen din på slutten av dagen, ikke vil være der i morgen.
 
 ## Aktivitetsvarsler
 
@@ -50,7 +51,8 @@ Dette er de forskjellige aktivitetsvarslene:
 * **Møte avlyst**: Møtet er avlyst. Klikk på koblingen for å åpne kalenderelementet, eller klikk **Greit** for å fjerne det fra varslene.
 * **Invitasjon avslått**: En møtedeltaker har avslått invitasjonen. Klikk på koblingen for å åpne kalenderelementet, eller klikk **Greit** for å fjerne det fra varslene.
 
-    ! Notat: Invitasjoner og endrede aktiviteter fjernes ikke fra varslingsruten, men blir værende til du enten **godtar** eller **avslår** invitasjonen.
+> [!NOTE]
+> Invitasjoner og endrede aktiviteter fjernes ikke fra varslingsruten, men blir værende til du enten **godtar** eller **avslår** invitasjonen.
 
 ## Varslingsinnstillinger
 

--- a/docs/no/learn/basics/toc.yml
+++ b/docs/no/learn/basics/toc.yml
@@ -1,6 +1,8 @@
 items:
   - name: Oversikt
     href: index.md
+  - name: Varsler
+    href: notifications.md
   - name: Favoritter
     href: fav.md
   - name: Historikkliste


### PR DESCRIPTION
Missing the ref to notifications.md file in Learn the basics. Should now show, since it's part of the slow release of new Service.