### PR TITLE
Add enum PersonGender to CRMScript (#723)

### DIFF
--- a/docs/en/automation/crmscript/reference/CRMScript.NetServer.PersonGender.yml
+++ b/docs/en/automation/crmscript/reference/CRMScript.NetServer.PersonGender.yml
@@ -1,0 +1,57 @@
+### YamlMime:ManagedReference
+items:
+- uid: CRMScript.NetServer.PersonGender
+  children:
+  - CRMScript.NetServer.PersonGender.Unknown
+  - CRMScript.NetServer.PersonGender.Female
+  - CRMScript.NetServer.PersonGender.Male
+  langs:
+  - crmscript
+  type: Enum
+  so.intellisense: PersonGender
+  syntax: 
+    content: PersonGender
+  summary: "Male/female. No jokes please. To be used for selecting correct salutations and grammar. 0 = unknown, 1 = female, 2 = male"
+  name: PersonGender
+  nameWithType: PersonGender
+  fullName: CRMScript.NetServer.PersonGender
+- uid: CRMScript.NetServer.PersonGender.Unknown
+  langs:
+  - crmscript
+  type: Field
+  so.intellisense: PersonGender.Unknown
+  syntax: 
+    content: PersonGender.Unknown
+  summary: "0: Unknown - used when initializing"
+  name: Unknown
+  nameWithType: Unknown
+  fullName: CRMScript.NetServer.PersonGender.Unknown
+- uid: CRMScript.NetServer.PersonGender.Female
+  langs:
+  - crmscript
+  type: Field
+  so.intellisense: PersonGender.Female
+  syntax: 
+    content: PersonGender.Female
+  summary: "1: The person is marked as female"
+  name: Female
+  nameWithType: Female
+  fullName: CRMScript.NetServer.PersonGender.Female
+- uid: CRMScript.NetServer.PersonGender.Male
+  langs:
+  - crmscript
+  type: Field
+  so.intellisense: PersonGender.Male
+  syntax: 
+    content: PersonGender.Male
+  summary: "2: The person is marked as male"
+  name: Male
+  nameWithType: Male
+  fullName: CRMScript.NetServer.PersonGender.Male
+references:
+- uid: CRMScript.NetServer.PersonGender
+  commentId: T:CRMScript.NetServer.PersonGender
+  isExternal: true
+  name: PersonGender
+  nameWithType: PersonGender
+  fullName: CRMScript.NetServer.PersonGender

--- a/docs/en/automation/crmscript/reference/CRMScript.NetServer.yml
+++ b/docs/en/automation/crmscript/reference/CRMScript.NetServer.yml
@@ -421,6 +421,7 @@ items:
   - CRMScript.NetServer.NSWebhookResult
   - CRMScript.NetServer.NSWebPanelEntity
   - CRMScript.NetServer.NSWindowPosSize
+  - CRMScript.NetServer.PersonGender
   - CRMScript.NetServer.PrefDescAccessFlags
   - CRMScript.NetServer.PrefDescValueType
   - CRMScript.NetServer.PreferenceLevel
@@ -3292,3 +3293,9 @@ references:
   name: NSTicketMessageHeader
   nameWithType: NSTicketMessageHeader
   fullName: CRMScript.NetServer.NSTicketMessageHeader
+- uid: CRMScript.NetServer.PersonGender
+  commentId: T:CRMScript.NetServer.PersonGender
+  isExternal: true
+  name: PersonGender
+  nameWithType: PersonGender
+  fullName: CRMScript.NetServer.PersonGender

--- a/docs/en/automation/crmscript/reference/toc.yml
+++ b/docs/en/automation/crmscript/reference/toc.yml
@@ -1077,6 +1077,8 @@ items:
       href: CRMScript.NetServer.NotificationPlatform.yml
     - name: OrderBySortType
       href: CRMScript.NetServer.OrderBySortType.yml
+    - name: PersonGender
+      href: CRMScript.NetServer.PersonGender.yml
     - name: PhoneType
       href: CRMScript.NetServer.PhoneType.yml
     - name: PrefDescAccessFlags


### PR DESCRIPTION
![image](https://github.com/SuperOfficeDocs/superoffice-docs/assets/23242792/4a3eac52-94c6-45d1-89af-0df333020b09)

@SuperOfficeDevNet should we add something back to CRMScript.NetServer.AssociateType now that the enum is available?
