### PR TITLE
Update webhook documentation for upcoming 10.2.7 changes

### DIFF
--- a/docs/en/automation/toc.yml
+++ b/docs/en/automation/toc.yml
@@ -61,7 +61,7 @@ items:
       href: webhook/event-details.md
     - name: Subscription
       href: webhook/subscription.md
-    - name: Notifications
+    - name: Notifications and Errors
       href: webhook/notification.md
     - name: Security
       href: webhook/security.md
@@ -81,6 +81,8 @@ items:
         href: webhook/reference/contact-events.md
       - name: Document events
         href: webhook/reference/document-events.md
+      - name: State change events
+        href: webhook/reference/state-events.md
       - name: Person events
         href: webhook/reference/person-events.md
       - name: Project events

--- a/docs/en/automation/webhook/event-details.md
+++ b/docs/en/automation/webhook/event-details.md
@@ -27,6 +27,7 @@ Event name descriptors are a combination of the webhook entity and event type - 
 * [quote][12]
 * [sale][7]
 * [salestakeholder][8]
+* [state][15]
 * [test][13]
 * [ticket][14]
 
@@ -47,6 +48,7 @@ Each entity raises an event when created, changed, or deleted. Therefore, all po
 | | | | quote.approved<br>quote.rejected<br>quote.sent<br>quote.ordered |
 | sale.created | sale.changed | sale.deleted | sale.completed (v8.3 R04)<br>sale.lost (v8.3 R04)<br> sale.sold (v8.3 R04) |
 | salestakeholder.created | salestakeholder.changed | salestakeholder.deleted | |
+| | | | webhook.started<br>webhook.stopped<br>webhook.errors |
 | ticket.created (v8.4) | ticket.changed (v8.4) | | |
 
 <!-- Referenced links -->
@@ -63,3 +65,4 @@ Each entity raises an event when created, changed, or deleted. Therefore, all po
 [12]: reference/quote-events.md
 [13]: reference/test-event.md
 [14]: reference/ticket-events.md
+[15]: reference/state-events.md

--- a/docs/en/automation/webhook/notification.md
+++ b/docs/en/automation/webhook/notification.md
@@ -56,11 +56,15 @@ Fields names that appear in a notification `Changes` property are the names of t
 | Activity | [Appointment table][1] |
 | Associate | [Associate table][2] |
 | Contact | [Contact table][3] |
+| Chat | [ChatSession table][10] |
+| Document | [Document table][12] |
 | Person | [Person table][4] |
 | Project | [Project table][5] |
 | ProjectMember | [ProjectMember table][6] |
+| Quote | [Quote table][11] |
 | Sale | [Sale table][7] |
 | SaleStakeholder | [SaleStakeholder table][8] |
+| Ticket | [Ticket table][9] |
 
 ## WebhookPayload headers
 
@@ -71,11 +75,21 @@ Fields names that appear in a notification `Changes` property are the names of t
 | X-SuperOffice-Retry | The number of retries this webhook has been tried to be sent. |
 | X-SuperOffice-Signature | The hash/base64 encoded secret. |
 
-## Failed Webhook notification attempts
+## Error Handling for Webhooks
 
-There are 3 attempts to send a webhook payload during a single cycle. If the first one fails, then the next attempt is delayed by 1 second. If the second one fails, then the third attempt is delayed by 4 seconds. If the third attempt fails, it is removed from this cycle and sent to the back of the queue. All active webhook payloads have a total of 9 consecutive attempts before the state is set to TooManyErrors(3). After that, it's up to the receiver to manage the webhook state, reset the state to Active (1), to begin sending webhook payloads again.
+There are three attempts to send a webhook payload during a single cycle. If the first one fails, the next attempt is delayed by 1 second. If the second attempt fails, the third attempt is delayed by 4 seconds. If the third attempt fails, it is removed from this cycle and sent to the back of the queue. All active webhook payloads are given a total of 9 consecutive attempts before the state is changed to `TooManyErrors (3)`.
 
-The EventID is the same for each attempt, however, if the HTTP request fails to receive a 200 response for 3 attempts, then the event is discarded, and the webhook `consecutive_errors` count is incremented. When the next consecutive attempt is sent, it will be a new EventID.
+If the HTTP request fails to receive a 200 response for three attempts, the event associated with those attempts is discarded, and the webhook's `consecutive_errors` count is incremented. The next attempt made will feature a new `EventID`.
+
+### Email Notification on Error
+
+In the event that the `EmailErrors` property is set, when a webhook state is set to `TooManyErrors`, an automatic email will be dispatched to the specified email address. This email will detail the error, the associated `EventID`, `Name` and more details.
+
+The `EventID` remains consistent for each attempt, facilitating accurate tracking and management of webhook events. However, if there are three consecutive failed attempts, the event is discarded, and the next attempt will be associated with a new `EventID`.
+
+Following `TooManyErrors` status, it is the responsibility of the receiver to manage the webhook state. The receiver can reset the state to `Active (1)` to resume the sending of webhook payloads. The `EmailErrors` notification system is designed to promptly inform the receiver of any critical issues that might prevent successful data delivery.
+
+
 
 <!-- Referenced links -->
 [1]: ../../database/tables/appointment.md
@@ -86,3 +100,7 @@ The EventID is the same for each attempt, however, if the HTTP request fails to 
 [6]: ../../database/tables/projectmember.md
 [7]: ../../database/tables/sale.md
 [8]: ../../database/tables/salestakeholder.md
+[9]: ../../database/tables/ticket.md
+[10]: ../../database/tables/chat-session.md
+[11]: ../../database/tables/quote.md
+[12]: ../../database/tables/document.md

--- a/docs/en/automation/webhook/overview.md
+++ b/docs/en/automation/webhook/overview.md
@@ -36,6 +36,7 @@ A webhook subscription contains the following properties:
 | Type | Name of webhook plugin that handles dispatching this webhook: "webhook", "CRMScript", etc. |
 | Headers | Hook-specific custom headers to be added to the webhook payload. |
 | Properties | Hook-specific data properties to be added to the webhook payload. |
+| ErrorEmail | Email address to send email notification when webhook disabled. |
 
 While a webhook `name` need not be unique, it should be unique enough to distinguish it from others and describe its purpose.
 
@@ -52,6 +53,8 @@ A webhook `Type` must match the plugin responsible for dispatching notifications
 Webhook `Headers` are any additional header values SuperOffice appends to a request sent with each notification. Headers are a simple "string":"string" value.
 
 Webhook `Properties` are any additional values SuperOffice should append to each request sent with each notification. Properties are a "string": {object} value.
+
+Webhook `ErrorEmail` is one email address used to send error notifications to when a webhook fails too many times and the state is set to TooManyErrors due to an unreachable URL or permanent failure.
 
 ## CRMScript hooks
 

--- a/docs/en/automation/webhook/reference/state-events.md
+++ b/docs/en/automation/webhook/reference/state-events.md
@@ -1,0 +1,90 @@
+---
+title: Error events
+uid: webhook_error_event
+description: Error webhook events
+author: AnthonyYates
+so.date: 06.24.2023
+keywords: automation, webhook
+so.topic: reference
+---
+
+# State change events
+
+In order to subscribe to webhook state change events, you must first create a webhook to get the `WebhookId`, then use that in the webhook subscription `Event` property.
+
+These events are fired when a webhook `State` property changes.
+
+* `webhook{webhookId}.started` - when state is set to `Active`
+* `webhook{webhookId}.stopped` - when state is set to `Stopped`
+* `webhook{webhookId}.errors`  - when state is set to `TooManyErrors`
+
+When webhook 123 is activated, signal webhook123.started
+
+When webhook 123 is disabled, signal webhook123.stopped
+
+When webhook 123 is disabled by errors, signal webhook123.errors
+
+## webhook{webhookId}.started
+
+```json
+POST /webhook HTTP/1.1
+Content-Type: application/json; charset=utf-8
+User-Agent: NetServer-Webhook/{version}
+X-SuperOffice-Event: webhook{webhookId}.started
+X-SuperOffice-EventId: 1848cc1f-d395-49ba-9b35-04a9269996d4
+
+{
+  "EventId": "1848cc1f-d395-49ba-9b35-04a9269996d4",
+  "Timestamp": "2018-07-05T11:58:18.5809908Z",
+  "Changes": [],
+  "Event": "webhook.started",
+  "PrimaryKey": 66,
+  "ContextIdentifier": "Default",
+  "ChangedByAssociateId": 0,
+  "WebhookName": "webhook{webhookId}.started"
+}
+```
+
+## webhook{webhookId}.stopped
+
+```json
+POST /webhook HTTP/1.1
+Content-Type: application/json; charset=utf-8
+User-Agent: NetServer-Webhook/{version}
+X-SuperOffice-Event: webhook{webhookId}.stopped
+X-SuperOffice-EventId: 1848cc1f-d395-49ba-9b35-04a9269996d4
+
+{
+  "EventId": "1848cc1f-d395-49ba-9b35-04a9269996d4",
+  "Timestamp": "2018-07-05T11:58:18.5809908Z",
+  "Changes": [],
+  "Event": "webhook.stopped",
+  "PrimaryKey": 66,
+  "ContextIdentifier": "Default",
+  "ChangedByAssociateId": 0,
+  "WebhookName": "webhook{webhookId}.stopped"
+}
+```
+
+## webhook{webhookId}.errors
+
+Whenever the hook gets disabled due to errors or permanent failure (HTTP STATUS 410 GONE).
+
+```json
+POST /webhook HTTP/1.1
+Content-Type: application/json; charset=utf-8
+User-Agent: NetServer-Webhook/{version}
+X-SuperOffice-Event: webhook{webhookId}.errors
+X-SuperOffice-EventId: 1848cc1f-d395-49ba-9b35-04a9269996d4
+
+{
+  "EventId": "1848cc1f-d395-49ba-9b35-04a9269996d4",
+  "Timestamp": "2018-07-05T11:58:18.5809908Z",
+  "Changes": [],
+  "Event": "webhook.errors",
+  "PrimaryKey": 66,
+  "ContextIdentifier": "Default",
+  "ChangedByAssociateId": 0,
+  "WebhookName": "webhook{webhookId}.errors"
+}
+```

--- a/docs/en/automation/webhook/subscription.md
+++ b/docs/en/automation/webhook/subscription.md
@@ -6,92 +6,13 @@ author: AnthonyYates
 so.date: 04.06.2018
 keywords: automation
 so.topic: howto
-# so.envir:
-# so.client:
 ---
 
 # Webhook subscription
 
 Webhook subscriptions are created using SuperOffice NetServer core and NetServer web services - both SOAP and REST APIs.
 
-Below I will demonstrate how to create a webhook using both NetServer core and web services.
-
-## NetServer Core
-
-There are 2 distinct ways to create webhooks using NetServer core, and there is a difference in behavior between them.
-
-There are the traditional Row classes `SuperOffice.CRM.Rows.WebhookRow`, and then there is the `SuperOffice.CRM.Webhooks.WebhookManager`.
-
-The key difference is when using `WebhookManager`, the `TargetURL` is pre-checked before saving, by sending out a test webhook payload, and is expected to send a 200 OK response. If the `TargetURL` fails to respond, the save operation will fail.
-
-Creating webhooks via the SOAP or REST APIs, NetServer uses the `WebhookManager`, therefore the `TargetURL` must already exist and respond accordingly.
-
-```csharp
-// SuperOffice.CRM.Rows: no verification check for TargetUrl
-
-var name      = "Tonys Contact Handler";
-var events    = "contact.created,contact.changed,contact.deleted";
-var targetUrl = "https://www.myserver.com/superoffice/webhookhandler";
-var secret    = "Something Super Secret";
-var type      = "webhook";
-var state     = SuperOffice.Data.WebhookState.Active;
-
-var webHookRow = WebhookRow.CreateNew();
-
-webHookRow.SetDefaults();
-webHookRow.Name      = name;
-webHookRow.Events    = events;
-webHookRow.TargetUrl = targetUrl;
-webHookRow.Secret    = secret;
-webHookRow.State     = state;
-webHookRow.Type      = type;
-
-webHookRow.Save();
-
-
-// SuperOffice.CRM.Webhooks.WebhookManager: verifies the existence of the TargetUrl
-
-var webhookManager = WebhookManager.GetCurrent();
-var webhook        = new Webhook(0, name, targetUrl, events, secret);
-webhookManager.SaveWebhook(webhook);
-```
-
-## NetServer SOAP Web Services
-
-`SuperOffice.CRM.Services.WebhookAgent` is used to manage webhooks. Using `WebhookAgent.CreateDefaultWebhook` will automatically set the `Type` and `State` to *webhook* and *Active*, respectively. The webhook will also contain two default Events, *contact.created* and *contact.deleted*. These are easy to replace, but nice to have for testing purposes.
-
-Use the `WebhookAgent.SaveWebhook` method to save or update a webhook.
-
-```csharp
-using (var wa = new WebhookAgent())
-{
-  // defines two default events contact.created & contact.deleted
-  var wh = wa.CreateDefaultWebhook(); 
-
-    wh.Name      = "Tonys Contact Handler";
-    wh.Events    = new [] { "contact.created", "contact.changed", "contact.deleted" };
-    wh.TargetUrl = "https://www.myserver.com/superoffice/webhookhandler";
-    wh.Secret    = "Something Super Secret";
-
-    wh = wa.SaveWebhook(wh);
-}
-```
-
-### WebhookAgent methods
-
-The `WebhookAgent` has methods to get an existing webhook by ID `GetWebhook(int id)`, and a delete method to permanently remove a webhook, `DeleteWebhook(int id)`.
-
-The table below lists all available `WebhookAgent` Methods.
-
-| Method Name | Description |
-|---|---|
-| CreateDefaultWebhook() | Returns new Webhook with default values. |
-| DeleteWebhook(id) | Deletes the webhook. |
-| GetLastError(id) | Return the most recent error message received when calling this webhook. |
-| GetAllWebhooks(string, string webhookState) | Returns all webhooks, according to filter criteria. |
-| GetWebhook(id) | Gets a Webhook by ID. |
-| SignalWebhook(string, int, StringObjectDictionary) | Signal webhooks that an event has occurred. All webhooks listening for the event will be notified. |
-| TestWebhook(webhook) | Pings a webhook with a ‘test’ event, returns SUCCESS(true) or FAILURE(false) + the response from the webhook target. |
+Below I will demonstrate how to create a webhook using both NetServer web services and core.
 
 ## NetServer REST web services
 
@@ -109,6 +30,7 @@ To create a new webhook, you can either build the JSON structure yourself, or is
   "contact.created",
   "contact.deleted"
 ],
+"ErrorsEmail": null,
 "TargetUrl": null,
 "Secret": null,
 "State": "Active",
@@ -122,13 +44,53 @@ To create a new webhook, you can either build the JSON structure yourself, or is
 }
 ```
 
+#### Create state change webhook
+
+This is a multi-step process. First create the webhook, then subscribe to the state change events.
+
+1. `Create a new webhook` by issuing a GET request the `api/v1/Webhook/default` URL and get the structure pre-populated with the defaults.
+
+2. `Save the webhook` using the POST `api/v1/Webhook` URL.
+
+3. `Get the webhook ID` from the response.
+
+4. `Create a new webhook subscription`, same as #1, but this time use the webhook ID to set the webhook state events.
+
+5. `Save the webhook subscription` using the POST `api/v1/Webhook` URL.
+
+Assuming webhook ID is `123`:
+
+```json
+{
+"WebhookId": 0,
+"Name": null,
+"Events": [
+  "webhook123.started",
+  "webhook123.stopped",
+  "webhook123.errors"
+],
+"ErrorsEmail": "username@domain.com",
+"TargetUrl": "https://www.myserver.com/webhookhandler",
+"Secret": null,
+"State": "Active",
+"Type": "webhook",
+"Headers": null,
+"Properties": null,
+"Registered": "0001-01-01T00:00:00",
+"RegisteredAssociate": null,
+"Updated": "0001-01-01T00:00:00",
+"UpdatedAssociate": null
+}
+```
+
+
 ### Save
 
 Save: **POST api/v1/Webhook**
 
 ```json
 {
-  "Name": "Tonys Contact Handler",
+  "Name": "Contact Handler",
   "Events": [
         "contact.created",
         "contact.changed",
@@ -137,26 +99,91 @@ Save: **POST api/v1/Webhook**
   "TargetUrl": "https://www.myserver.com/superoffice/webhookhandler",
   "Secret": "Something Super Secret",
   "State": "Active",
+  "ErrorsEmail": "username@domain.com",
   "Type": "webhook"
 }
 ```
 
-### Available REST URLs
-
-| Verb | URL |
-|---|---|
-| GET | api/v1/Webhook/default |
-| GET | api/v1/Webhook/{id} |
-| GET | api/v1/Webhook/{webhookId}/LastError |
-| GET | api/v1/Webhook?nameFilter={nameFilter}&eventFilter={eventFilter}&statusFilter={statusFilter} |
-| POST | api/v1/Webhook |
-| POST | api/v1/Webhook/Test |
-| POST | api/v1/Webhook/{eventName}/{primaryKey} |
-| PUT | api/v1/Webhook/{id} |
-| DELETE | api/v1/Webhook/{id} |
+### REST URL tips
 
 **POST api/v1/Webhook** will register a new webhook definition.
 
 **POST api/v1/Webhook/Test** will check that the webhook definition is OK, and verify that the target URL responds to a test POST with 200 OK.
 
 **POST api/v1/Webhook/foo.bar/123** will signal that the event 'foo.bar' has happened to id 123. Any webhooks registered for the event 'foo.bar' will be notified. You can add additional details (like field changes) in the body of the POST.
+
+See the [RESTful WebAPI documentation][1] for more details.
+
+## NetServer SOAP Web Services
+
+`SuperOffice.CRM.Services.WebhookAgent` is used to manage webhooks. Using `WebhookAgent.CreateDefaultWebhook` will automatically set the `Type` and `State` to *webhook* and *Active*, respectively. The webhook will also contain two default Events, *contact.created* and *contact.deleted*. These are easy to replace, but nice to have for testing purposes.
+
+Use the `WebhookAgent.SaveWebhook` method to save or update a webhook.
+
+```csharp
+using (var wa = new WebhookAgent())
+{
+  // defines two default events contact.created & contact.deleted
+  var wh = wa.CreateDefaultWebhook(); 
+
+    wh.Name      = "Contact Handler";
+    wh.Events    = new [] { "contact.created", "contact.changed", "contact.deleted" };
+    wh.TargetUrl = "https://www.myserver.com/superoffice/webhookhandler";
+    wh.Secret    = "Something Super Secret";
+    wh.ErrorsEmail = "username@domain.com";
+
+    wh = wa.SaveWebhook(wh);
+}
+```
+
+### WebhookAgent methods
+
+The `WebhookAgent` has methods to get an existing webhook by ID `GetWebhook(int id)`, and a delete method to permanently remove a webhook, `DeleteWebhook(int id)`.
+
+The [RESTful Agents API][2] and [SOAP API][3] contains all available `WebhookAgent` Methods.
+
+## NetServer Core
+
+There are 2 distinct ways to create webhooks using NetServer core, and there is a difference in behavior between them.
+
+There are the traditional Row classes `SuperOffice.CRM.Rows.WebhookRow`, and then there is the `SuperOffice.CRM.Webhooks.WebhookManager`.
+
+The key difference is when using `WebhookManager`, the `TargetURL` is pre-checked before saving, by sending out a test webhook payload, and is expected to send a 200 OK response. If the `TargetURL` fails to respond, the save operation will fail.
+
+Creating webhooks via the SOAP or REST APIs, NetServer uses the `WebhookManager`, therefore the `TargetURL` must already exist and respond accordingly.
+
+```csharp
+// SuperOffice.CRM.Rows: no verification check for TargetUrl
+
+var name        = "Contact Handler";
+var events      = "contact.created,contact.changed,contact.deleted";
+var targetUrl   = "https://www.myserver.com/superoffice/webhookhandler";
+var secret      = "Something Super Secret";
+var type        = "webhook";
+var state       = "Active";
+var errorsEmail = "username@domain.com";
+
+var webHookRow = WebhookRow.CreateNew();
+
+webHookRow.SetDefaults();
+webHookRow.Name        = name;
+webHookRow.Events      = events;
+webHookRow.TargetUrl   = targetUrl;
+webHookRow.Secret      = secret;
+webHookRow.State       = state;
+webHookRow.Type        = type;
+webhookRow.ErrorsEmail = errorEmail;
+webHookRow.Save();
+
+
+// SuperOffice.CRM.Webhooks.WebhookManager: verifies the existence of the TargetUrl
+
+var webhookManager = WebhookManager.GetCurrent();
+var webhook        = new Webhook(0, name, targetUrl, events, secret);
+webhookManager.SaveWebhook(webhook);
+```
+
+<!-- Referenced links -->
+[1]: ../../api/reference/restful/rest/Webhook/index.md
+[2]: ../../api/reference/restful/agent/Webhook_Agent/index.md
+[3]: ../../api/reference/soap/Services88/Webhook/index.md

--- a/docs/en/automation/webhook/troubleshooting.md
+++ b/docs/en/automation/webhook/troubleshooting.md
@@ -21,7 +21,7 @@ When things go awry, and your application doesn't seem to be receiving webhook n
 > changes or errors occur.
 >
 > * Use the `ErrorsEmail` property to receive an email notification.
-> * Subscribe to the `webhook{webhookId}.errors` event. [See details][].
+> * Subscribe to the `webhook{webhookId}.errors` event. [See details][1].
 >
 > It is recommended with the latter method that you use the a different webhook URL than your other webhooks.
 

--- a/docs/en/automation/webhook/troubleshooting.md
+++ b/docs/en/automation/webhook/troubleshooting.md
@@ -16,6 +16,15 @@ As developers, it's important to ensure the seamless operation of our applicatio
 
 When things go awry, and your application doesn't seem to be receiving webhook notifications, it's time to put your detective hat on. Here's a systematic guide to help you inspect and diagnose the problem.
 
+> [!TIP]
+> There are two solutions for receiving notifications when a webhook state
+> changes or errors occur.
+>
+> * Use the `ErrorsEmail` property to receive an email notification.
+> * Subscribe to the `webhook{webhookId}.errors` event. [See details][].
+>
+> It is recommended with the latter method that you use the a different webhook URL than your other webhooks.
+
 ## Checking webhook status
 
 First and foremost, check the status of your webhooks. This can be accomplished by calling one of the following APIs:
@@ -66,3 +75,5 @@ This request will return information about the specific webhook, such as the tot
 In some cases, the webhook may be in an Active state, without any errors, yet you suspect it's not delivering notifications as expected. If this happens, please let us know by sending an email to appdev at superoffice dot com. It could indicate a more complex issue requiring further investigation.
 
 To summarize, troubleshooting webhooks requires understanding their current status and digging deeper into the error messages if necessary. Equipped with the right endpoints, you can systematically diagnose and resolve issues, ensuring the smooth operation of your application.
+
+[1]: subscription.md#create-state-change-webhook


### PR DESCRIPTION
Add new webhook status change notifications events:

1. Allow listening to handle when webhooks state changes.

  * When webhook 123 is disabled, signal webhook123.stopped
  * When webhook 123 is activated, signal webhook123.started
  * When webhook 123 is disabled by errors, signal webhook123.errors

  ````csharp
  WebhookAgent.SaveWebhook( {
    Name: "Webhook 123 state changes",
    Type: "webhook",
    TargetUrl: "http://www.example.com/hook",
    Events: ["webhook123.errors"],
    ErrorsEmail: "username@domain.com"
  } );
  ```

2. Added ErrorsEmail property to webhook registration to send an e-mail message whenever the webhook gets disabled due to errors or permanent failure (HTTP STATUS 410 GONE).

  ````csharp
  WebhookAgent.SaveWebhook( {
    Name: "webhook with email errors",
    Type: "webhook",
    TargetUrl: "http://www.example.com/hook",
    Events: ["contact.created"],
    ErrorsEmail: "username@domain.com"
  } );
  ```
