### PR TITLE
Update index.md

### DIFF
--- a/docs/en/developer-portal/message-center/index.md
+++ b/docs/en/developer-portal/message-center/index.md
@@ -37,8 +37,8 @@ The Messaging Center is located in the upper right-hand corner of the developer 
 
 The messages are organized into three categories:
 
-* **Open** - Messages you have not replied to.
-* **Postponed** - Messages waiting for your response.
+* **Waiting For SuperOffice** - Messages you have sent to SuperOffice.
+* **Open** - Messages waiting for your response.
 * **Closed** - Messages that have been resolved.
 
 ![Messaging Center screen -screenshot][img2]


### PR DESCRIPTION
Screenshot and description is for SuperOffice employees, partners sees it as Waiting for SuperOffice / Open and not Open /Postponed

Adding a screenshot from Takeshis (the partner) when logged in and viewing the messaging center, could we use this instead?

![image](https://github.com/SuperOfficeDocs/superoffice-docs/assets/22498774/56ffcf2f-08a5-4e61-a81c-d946bc5ec14b)
