### PR TITLE
Updated provisioning pages #939 

### DIFF
--- a/docs/en/developer-portal/custom-app/activate.md
+++ b/docs/en/developer-portal/custom-app/activate.md
@@ -23,7 +23,8 @@ The first-time activation starts after your [application passes validation][1]. 
 1. We will publish your application from SOD to the production environment.
 2. The user currently signed in to the Developer Portal will receive an automatic email asking for the customer name and customer ID in CRM Online. This is found under **Help** > **About** when signed in to `online.superoffice.com`.
     If you as the application developer is not an employee of the customer, please forward this email to the customer and have them confirm to us that they want us to activate this application on their tenant (SuperOffice installation).
-3. You contact the customer to initiate the [application setup][3].
+3. Wait for confirmation from the SuperOffice app manager that the application has consent to access the tenant.   
+4. You contact the customer to initiate the [application setup][3].
 
 ## Production sandbox
 

--- a/docs/en/developer-portal/custom-app/activate.md
+++ b/docs/en/developer-portal/custom-app/activate.md
@@ -3,7 +3,7 @@ title: First-time activation
 uid: custom-app-first-time-activation
 description: Description of the process of activating a valid custom application for the first-time.
 author: Margrethe
-so.date: 09.05.2022
+so.date: 12.20.2023
 keywords: activate, consent
 so.topic: howto
 so.envir: cloud
@@ -21,9 +21,16 @@ By activating a custom application, the owner of the tenant agrees to [subscribe
 The first-time activation starts after your [application passes validation][1]. You don't need to trigger this step.
 
 1. We will publish your application from SOD to the production environment.
-2. The user currently signed in to the Developer Portal will receive an automatic email asking for the customer name and customer ID in CRM Online. This is found under **Help > About** when signed in to `online.superoffice.com`.
-    If you as the application developer is not an employee of the customer, please forward this email to the customer and have then confirm to us that they want us to activate this application on their tenant (SuperOffice installation).
+2. The user currently signed in to the Developer Portal will receive an automatic email asking for the customer name and customer ID in CRM Online. This is found under **Help** > **About** when signed in to `online.superoffice.com`.
+    If you as the application developer is not an employee of the customer, please forward this email to the customer and have them confirm to us that they want us to activate this application on their tenant (SuperOffice installation).
 3. You contact the customer to initiate the [application setup][3].
+
+## Production sandbox
+
+If you use a [production sandbox][6] to develop and test a custom app, with real data, the app must be **activated twice** - once per production environment.
+
+1. Request to publish the app's configuration to stage (first-time activation) and **send us the customer ID of the production sandbox**.
+1. When the customer is ready to launch the approved application on their production tenant, **reply to the ticket** received when the request to publish was submitted. The customer's administrator must confirm they want us to activate this application on their live tenant too.
 
 ## Request application changes
 
@@ -34,3 +41,4 @@ You can [change the application configuration][5] in the Developer Portal.
 [2]: ../../admin/license/expander-services/index.md
 [3]: ../provisioning/index.md
 [5]: ../faq/update-app.md
+[6]: ../../online/sandbox/index.md

--- a/docs/en/developer-portal/custom-app/checklist.md
+++ b/docs/en/developer-portal/custom-app/checklist.md
@@ -3,7 +3,7 @@ title: Validation checklist
 uid: custom-app-checklist
 description: "The app validation checklist - what to consider before you ask for a validation test."
 author: Margrethe Romnes
-so.date: 02.02.2022
+so.date: 12.20.2023
 keywords: custom app, validation, checklist
 so.topic: reference
 so.envir: cloud
@@ -14,9 +14,9 @@ so.client: online
 
 My custom application is ready, what should I consider before I ask for a validation test?
 
-## Expander service subscription
+## Development Tools subscription
 
-Access to a customer's tenant from a custom application requires an active [Expander service subscription][1] license. The license is purchased by the customer.
+Access to a customer's tenant from a custom application requires an active [Development Tools subscription][1] license. The license is purchased by the customer.
 
 If the subscription is discontinued, any custom applications will lose access to that tenant.
 
@@ -26,7 +26,8 @@ If the subscription is discontinued, any custom applications will lose access to
 
 ## Provisioning
 
-* Workflow for giving [consent to the tenant][2] is implemented so the customer administrator may approve the apps access to the database.
+[!include[Activate app](../includes/explicit-consent.md)]
+Custom apps therefore do not need to implement the [workflow for giving consent][2].
 
 ## Error handling
 
@@ -61,6 +62,6 @@ If the subscription is discontinued, any custom applications will lose access to
 <!-- Referenced links -->
 [4]: validate.md
 [1]: ../../admin/license/expander-services/index.md
-[2]: ../provisioning/consent.md
+[2]: ../provisioning/consent.md#hand-shake
 [3]: ../best-practices/tenant-status/check-status.md
 [5]: ../best-practices/index.md

--- a/docs/en/developer-portal/includes/explicit-consent.md
+++ b/docs/en/developer-portal/includes/explicit-consent.md
@@ -1,0 +1,5 @@
+<!-- markdownlint-disable-file MD041 -->
+The SuperOffice App Manager grants explicit consent to approved custom applications [during activation][1].
+
+<!-- Referenced links -->
+[1]: ../custom-app/activate.md

--- a/docs/en/developer-portal/provisioning/consent.md
+++ b/docs/en/developer-portal/provisioning/consent.md
@@ -3,7 +3,7 @@ title: Consent to app
 uid: provisioning-consent
 description: "Learn about the tenant-approval sequence and when the customer's admin must authorize the application."
 author: Margrethe Romnes
-so.date: 09.05.2022
+so.date: 12.20.2023
 keywords: provisioning, apps, consent, I approve
 so.topic: concept
 so.envir: cloud
@@ -23,13 +23,13 @@ The workflow is different for custom and standard applications.
 
 ## For custom applications
 
-The SuperOffice App Manager grants explicit consent to approved custom applications [during activation][7].
+[!include[Activate app](../includes/explicit-consent.md)]
 
 ## For standard applications in the App Store
 
 The [tenant administrative user must sign in to SuperID and approve the application][6] to establish an **authorization record** between the application and the tenant. If this option is unavailable to you, a strict hand-shake flow must be implemented.
 
-## Tenant approval sequence (hand-shake)
+### <a id="hand-shake"/>Tenant approval sequence (hand-shake)
 
 No one **may** ask for a customer's username and password to gain access to the tenant's resources. Everyone must adhere to the following authorization sequence.
 
@@ -67,7 +67,6 @@ During approval, the customer's administrator should accept the following change
 [4]: ../../mirroring/overview.md
 [5]: index.md
 [6]: get-consent.md
-[7]: ../custom-app/activate.md
 
 <!-- Referenced images -->
 [img1]: media/appvendorconsultants.png

--- a/docs/en/developer-portal/provisioning/get-consent.md
+++ b/docs/en/developer-portal/provisioning/get-consent.md
@@ -3,7 +3,7 @@ uid: tenant-get-consent
 title: Get consent to access a customer's tenant
 description: How to obtain consent to access a customer's tenant
 author: Margrethe Romnes
-so.date: 10.04.2023
+so.date: 12.20.2023
 keywords: tenant, consent, approve
 so.topic: howto
 so.envir: cloud
@@ -16,6 +16,12 @@ Each customer is responsible for their data and must explicitly approve each and
 
 > [!CAUTION]
 > External consultants **MAY NOT** approve access to a customer's production database!
+
+## For custom applications
+
+[!include[Activate app](../includes/explicit-consent.md)]
+
+## For standard applications in the App Store
 
 1. Send the administrator to the authorization endpoint and [authenticate the user][1].
 

--- a/docs/en/developer-portal/provisioning/index.md
+++ b/docs/en/developer-portal/provisioning/index.md
@@ -23,7 +23,7 @@ When the customer clicks **I approve,** it should automatically set up your appl
 
 Provisioning a partner application may involve configuration or settings in both SuperOffice and the other partner service depending on what the application actually does.
 
-## Example
+## Example (standard app)
 
 1. A customer sees your application in the App Store and would like to know more.
 

--- a/docs/en/developer-portal/provisioning/revoke.md
+++ b/docs/en/developer-portal/provisioning/revoke.md
@@ -1,16 +1,16 @@
 ---
 title: Revoke app
 uid: revoke-app
-description: How to revoke access given to an application.
+description: How to revoke access given to a standard application.
 author: Bergfrid Dias
-so.date: 04.28.2022
+so.date: 12.20.2023
 keywords: App Store, revoke, consent
 so.topic: howto
 so.envir: cloud
 so.client: online
 ---
 
-# Revoke access given to an app
+# Revoke access given to standard app
 
 Revoking access to an application is a manual procedure. It will sever the connection between the application and a database tenant. It will not remove any data from the database.
 


### PR DESCRIPTION
- reuse phrase about explicit consent
- add section "Production sandbox" to activate
- change ES to Developer Tools
- clarified when we talk about custom/standard app