### PR TITLE
Add scheduled task section to best practices #958

### DIFF
--- a/docs/da/automation/crmscript/learn/schedule-task.md
+++ b/docs/da/automation/crmscript/learn/schedule-task.md
@@ -57,3 +57,10 @@ Klik på en opgave på listen for at redigere dens egenskaber, f.eks. hvornår d
 1. Indstil **Minutter til genstart efter fejl**. Denne indstilling angiver tidsrummet, før en mislykket opgave (en opgave der er gået ned) udføres igen.
 
 1. Klik på **OK**. Opgaven føjes til listen, og du kan se status og klokkeslæt for næste udførelse af opgaven.
+
+## Relateret indhold
+
+* [Bedste praksis for CRMScript][1]
+
+<!-- Referenced links -->
+[1]: ../../../../en/automation/crmscript/code-quality/best-practices.md

--- a/docs/de/automation/crmscript/learn/schedule-task.md
+++ b/docs/de/automation/crmscript/learn/schedule-task.md
@@ -57,3 +57,10 @@ Klicken Sie in der Liste auf eine Aufgabe, um deren Eigenschaften zu bearbeiten,
 1. Stellen Sie **Minuten vor Neustart** ein. Mit dieser Einstellung legen Sie fest, wie lange es dauert, bis eine fehlgeschlagene (abgestürzte) Aufgabe erneut ausgeführt wird.
 
 1. Klicken Sie auf **OK**. Die Aufgabe wird zur Liste hinzugefügt und der Status und die Uhrzeit der nächsten Ausführung der Aufgabe werden angezeigt.
+
+## Zugehörige Inhalte
+
+* [Beste Praktiken für CRMScript][1]
+
+<!-- Referenced links -->
+[1]: ../../../../en/automation/crmscript/code-quality/best-practices.md

--- a/docs/en/automation/crmscript/code-quality/best-practices.md
+++ b/docs/en/automation/crmscript/code-quality/best-practices.md
@@ -1,8 +1,9 @@
 ---
 uid: crmscript_best_practice
 title: CRMScript best practices
+description: Best practices for SuperOffice CRMScript development and use.
 author: Bergfrid Dias
-so.date: 10.21.2021
+so.date: 01.02.2024
 keywords: CRMScript, best practices, performance
 so.topic: reference
 ---
@@ -59,6 +60,14 @@ Don't use **USEC** variable as login_secret or preview_secret in web panels. Thi
 
 * Don't use the **NetServer agents** in a CRMScript unless absolutely necessary. Using SearchEngine or the classes that don't start with NS... will use fewer resources and be faster.
 
+## Scheduled tasks
+
+If the script is intended to run as a [scheduled task][1]:
+
+* Consider **how often** you really need to run the script. Running a script every minute is not recommended. Take other tasks also set up to run into account.
+
+* Review scheduled tasks regularly at **Settings and maintenance** > **CRMScript** > **Scheduled tasks**. Is the task still needed? Update the schedule or disable the task to reflect current demands.
+
 ## Optimize searches
 
 * Limit searches using SearchEngine to return **only the fields and rows you need**. Use `addCriteria()` for this. Even though not seen when running as a scheduled task, it will still take up resources. Also, for Online, set up the scheduled task to run just when needed, do you really need to be updated all the time?
@@ -66,3 +75,6 @@ Don't use **USEC** variable as login_secret or preview_secret in web panels. Thi
 * Don't add a SearchEngine inside another SearchEngine you're looping through.
 
 * Do you need to search for updated information, or could you use a **webhook**? Be aware of cascading effect, any changes you do to an entity will trigger a webhook to be signaled to those who subscribe to it.
+
+<!-- Referenced links -->
+[1]: ../learn/schedule-task.md

--- a/docs/en/automation/crmscript/learn/schedule-task.md
+++ b/docs/en/automation/crmscript/learn/schedule-task.md
@@ -57,3 +57,10 @@ Click a task in the list to edit its properties, such as when it was last execut
 1. Set **Minutes before restart after error**. This setting specifies the time before a failed task (a task that has crashed) will be re-run.
 
 1. Click **OK**. The task is added to the list, and you can see the status and time of the next execution of the task.
+
+## Related content
+
+* [Best practices][1]
+
+<!-- Referenced links -->
+[1]: ../../../../en/automation/crmscript/code-quality/best-practices.md

--- a/docs/nl/automation/crmscript/learn/schedule-task.md
+++ b/docs/nl/automation/crmscript/learn/schedule-task.md
@@ -57,3 +57,10 @@ Klik op een taak in de lijst om de eigenschappen ervan te bewerken, zoals de laa
 1. Stel **Aantal minuten opnieuw starten na fout** in. Deze instelling geeft aan hoeveel tijd er verstrijkt voordat een mislukte taak (een taak die is vastgelopen) opnieuw wordt uitgevoerd.
 
 1. Klik op **OK**. De taak wordt toegevoegd aan de lijst en de status en het tijdstip van de volgende uitvoering van de taak zijn zichtbaar.
+
+## Gerelateerde inhoud
+
+* [Beste praktijken voor CRMScript][1]
+
+<!-- Referenced links -->
+[1]: ../../../../en/automation/crmscript/code-quality/best-practices.md

--- a/docs/no/automation/crmscript/learn/schedule-task.md
+++ b/docs/no/automation/crmscript/learn/schedule-task.md
@@ -57,3 +57,10 @@ Klikk på en oppgave i listen for å redigere egenskapene, for eksempel når den
 1. Angi **Minutter til omstart etter feil**. Denne innstillingen angir tiden før en mislykket oppgave (en oppgave som har krasjet) kjøres på nytt.
 
 1. Klikk på **OK**. Oppgaven legges til i listen, og du kan se statusen og tidspunktet for neste kjøring av oppgaven.
+
+## Aktuelt innhold
+
+* [Beste praksis for CRMScript][1]
+
+<!-- Referenced links -->
+[1]: ../../../../en/automation/crmscript/code-quality/best-practices.md

--- a/docs/sv/automation/crmscript/learn/schedule-task.md
+++ b/docs/sv/automation/crmscript/learn/schedule-task.md
@@ -57,3 +57,10 @@ Klicka på en uppgift i listan om du vill redigera dess egenskaper, till exempel
 1. Ange **Minuter före omstart efter fel**. Den här inställningen anger tidpunkten före en misslyckad uppgift körs.
 
 1. Klicka på **OK**. Uppgiften läggs till i listan och status och tidpunkt för nästa körning av uppgiften visas.
+
+## Relaterat innehåll
+
+* [Bästa praxis för CRMScript][1]
+
+<!-- Referenced links -->
+[1]: ../../../../en/automation/crmscript/code-quality/best-practices.md


### PR DESCRIPTION
Linked to the learn how-to for scheduling a task. Added a reverse link in each translation to the best practices.

See screenshot of the new section in issue #958.