### PR TITLE
Update blocked-tables.md

### DIFF
--- a/docs/en/mirroring/blocked-tables.md
+++ b/docs/en/mirroring/blocked-tables.md
@@ -94,7 +94,7 @@ Tables not mirrored might have a reason specified in the "reason” field. This 
 | prefdescline                   | Internal configuration, not user data       |
 | registry                       | Internal, not user data       |
 | satellite                      | Part of travel       |
-| script_run_trace               | Debug info, large turnover, not user data       |
+| script_trace_run               | Debug info, large turnover, not user data      |
 | searchcriteria                 | Internal configuration, not user data       |
 | searchcriteriagroup            | Internal configuration, not user data       |
 | searchcriterion                | Internal configuration, not user data       |


### PR DESCRIPTION
Bug in current blocklist, the tablename is wrong. Script_run_trace should be script_trace_run Will cause errors to occur until fixed in next release of OC DevOps ID 52534. Workaround until fixed: Add to Exclude table list preference in admin if