### PR TITLE
Add learn SP documents to toc #1198 

### DIFF
--- a/docs/da/document/learn/toc.yml
+++ b/docs/da/document/learn/toc.yml
@@ -22,8 +22,8 @@ items:
     href: delete.md
   - name: Eksempler på skabelonvariabler
     href: template-variables.md
-#- name: SharePoint document library integration
-#  href: ../cloud/sharepoint-documents/learn/index.md
-#  items:
-#  - name: Set up folders
-#    href: ../cloud/sharepoint-documents/learn/set-up-folders.md
+  - name: Integration af SharePoint-dokumentbibliotek
+    href: ../cloud/sharepoint-documents/learn/index.md
+    items:
+    - name: Konfigurer SharePoint-mapperne
+      href: ../cloud/sharepoint-documents/learn/set-up-folders.md

--- a/docs/de/document/learn/toc.yml
+++ b/docs/de/document/learn/toc.yml
@@ -22,8 +22,8 @@ items:
     href: delete.md
   - name: Vorlagenvariablen - Beispiele
     href: template-variables.md
-#- name: SharePoint document library integration
-#  href: ../cloud/sharepoint-documents/learn/index.md
-#  items:
-#  - name: Set up folders
-#    href: ../cloud/sharepoint-documents/learn/set-up-folders.md
+  - name: Integration der SharePoint-Dokumentbibliothek
+    href: ../cloud/sharepoint-documents/learn/index.md
+    items:
+    - name: SharePoint-Ordner einrichten
+      href: ../cloud/sharepoint-documents/learn/set-up-folders.md

--- a/docs/en/document/learn/toc.yml
+++ b/docs/en/document/learn/toc.yml
@@ -22,8 +22,8 @@ items:
     href: delete.md
   - name: Template variables examples
     href: template-variables.md
-#- name: SharePoint document library integration
-#  href: ../cloud/sharepoint-documents/learn/index.md
-#  items:
-#  - name: Set up folders
-#    href: ../cloud/sharepoint-documents/learn/set-up-folders.md
+  - name: SharePoint document library integration
+    href: ../cloud/sharepoint-documents/learn/index.md
+    items:
+    - name: Set up folders
+      href: ../cloud/sharepoint-documents/learn/set-up-folders.md

--- a/docs/nl/document/learn/toc.yml
+++ b/docs/nl/document/learn/toc.yml
@@ -22,8 +22,8 @@ items:
     href: delete.md
   - name: Sjabloonvariabelen voorbeelden
     href: template-variables.md
-#- name: SharePoint document library integration
-#  href: ../cloud/sharepoint-documents/learn/index.md
-#  items:
-#  - name: Set up folders
-#    href: ../cloud/sharepoint-documents/learn/set-up-folders.md
+  - name: Integratie SharePoint-documentbibliotheek
+    href: ../cloud/sharepoint-documents/learn/index.md
+    items:
+    - name: De SharePoint-mappen instellen
+      href: ../cloud/sharepoint-documents/learn/set-up-folders.md

--- a/docs/no/document/learn/toc.yml
+++ b/docs/no/document/learn/toc.yml
@@ -22,8 +22,8 @@ items:
     href: delete.md
   - name: Eksempler på malvariabler
     href: template-variables.md
-#- name: SharePoint document library integration
-#  href: ../cloud/sharepoint-documents/learn/index.md
-#  items:
-#  - name: Set up folders
-#    href: ../cloud/sharepoint-documents/learn/set-up-folders.md
+  - name: Integrering av SharePoint-dokumentbibliotek
+    href: ../cloud/sharepoint-documents/learn/index.md
+    items:
+    - name: Konfigurere SharePoint-mappene
+      href: ../cloud/sharepoint-documents/learn/set-up-folders.md

--- a/docs/sv/document/learn/toc.yml
+++ b/docs/sv/document/learn/toc.yml
@@ -22,8 +22,8 @@ items:
     href: delete.md
   - name: Mallvariabler - exempel
     href: template-variables.md
-#- name: SharePoint document library integration
-#  href: ../cloud/sharepoint-documents/learn/index.md
-#  items:
-#  - name: Set up folders
-#    href: ../cloud/sharepoint-documents/learn/set-up-folders.md
+  - name: Integration för SharePoint dokumentbibliotek
+    href: ../cloud/sharepoint-documents/learn/index.md
+    items:
+    - name: Konfigurera SharePoint-mapparna
+      href: ../cloud/sharepoint-documents/learn/set-up-folders.md


### PR DESCRIPTION
Not sure why, but I'd commented out cloud/sharepoint-documents/learn from toc. The build picked them up, but put them in the wrong location (outside learn).

**Need to delete _site and obj for the changes to take effect.**