### PR TITLE
remove duplicate toc entries #651 

### DIFF
--- a/docs/en/automation/crmscript/reference/toc.yml
+++ b/docs/en/automation/crmscript/reference/toc.yml
@@ -98,8 +98,6 @@ items:
     href: CRMScript.Native.MacroReturnValue.yml
   - name: MainMenu
     href: CRMScript.Native.MainMenu.yml
-  - name: Map
-    href: CRMScript.Native.Map.yml
   - name: Message
     href: CRMScript.Native.Message.yml
   - name: Notify
@@ -144,8 +142,6 @@ items:
     href: CRMScript.Native.TimeZone.yml
   - name: User
     href: CRMScript.Native.User.yml
-  - name: Vector
-    href: CRMScript.Native.Vector.yml
   - name: WeekSchedule
     href: CRMScript.Native.WeekSchedule.yml
   - name: XMLNode

--- a/docs/en/automation/crmscript/reference/toc.yml
+++ b/docs/en/automation/crmscript/reference/toc.yml
@@ -27,12 +27,8 @@ items:
   items:
   - name: Array
     href: CRMScript.DataStructure.Array.yml
-  - name: Map
-    href: CRMScript.Native.Map.yml
   - name: Struct
     href: CRMScript.DataStructure.Struct.yml
-  - name: Vector
-    href: CRMScript.Native.Vector.yml
 - name: Classes
   href: CRMScript.Native.yml
   items:
@@ -98,6 +94,8 @@ items:
     href: CRMScript.Native.MacroReturnValue.yml
   - name: MainMenu
     href: CRMScript.Native.MainMenu.yml
+  - name: Map
+    href: CRMScript.Native.Map.yml
   - name: Message
     href: CRMScript.Native.Message.yml
   - name: Notify
@@ -142,6 +140,8 @@ items:
     href: CRMScript.Native.TimeZone.yml
   - name: User
     href: CRMScript.Native.User.yml
+  - name: Vector
+    href: CRMScript.Native.Vector.yml
   - name: WeekSchedule
     href: CRMScript.Native.WeekSchedule.yml
   - name: XMLNode


### PR DESCRIPTION
Since moving classes to another name space disrupts intellisense, I've just removed the duplicates under Native.

### Before

![image](https://github.com/user-attachments/assets/13b735a5-6065-4a97-8a9b-a2821ad02a62) ![image](https://github.com/user-attachments/assets/951d5427-acbe-4bff-936f-22a85f05ecdd)

### After

![image](https://github.com/user-attachments/assets/04af2600-9254-4cf7-9b9e-123b1ad62c07) 
![image](https://github.com/user-attachments/assets/9ca95e53-2286-4e64-b352-75513b3fbe88)

