### PR TITLE
Remove references to unnecessary text from archive provider references

### DIFF
--- a/docs/en/api/archive-providers/reference/favourites.md
+++ b/docs/en/api/archive-providers/reference/favourites.md
@@ -14,17 +14,6 @@ This provider name is implemented by the class <see cref="T:SuperOffice.CRM.Arch
 
 Archive provider for the list of favourites
 
-Blah...
-
-
-blah....
-
-
-...
-
-
-........
-
 ## Supported Entities
 | Name | Description |
 | ---- | ----- |

--- a/docs/en/api/archive-providers/reference/listitems.md
+++ b/docs/en/api/archive-providers/reference/listitems.md
@@ -14,17 +14,6 @@ This provider name is implemented by the class <see cref="T:SuperOffice.CRM.Arch
 
 Archive provider for the list of ListItems
 
-Blah...
-
-
-blah....
-
-
-...
-
-
-........
-
 ## Supported Entities
 | Name | Description |
 | ---- | ----- |

--- a/docs/en/api/archive-providers/reference/numbers.md
+++ b/docs/en/api/archive-providers/reference/numbers.md
@@ -14,17 +14,6 @@ This provider name is implemented by the class <see cref="T:SuperOffice.CRM.Arch
 
 Archive provider for the list of userpreferences
 
-Blah...
-
-
-blah....
-
-
-...
-
-
-........
-
 ## Supported Entities
 | Name | Description |
 | ---- | ----- |

--- a/docs/en/api/archive-providers/reference/systemevents.md
+++ b/docs/en/api/archive-providers/reference/systemevents.md
@@ -12,18 +12,7 @@ so.envir: onsite, online
 
 This provider name is implemented by the class <see cref="T:SuperOffice.CRM.ArchiveLists.SystemEventsProviderBase">SuperOffice.CRM.ArchiveLists.SystemEventsProviderBase</see> inside NetServer's SODatabase assembly.
 
-Archive provider
-
-Blah...
-
-
-blah....
-
-
-...
-
-
-........
+Archive provider for list of active system events
 
 ## Supported Entities
 | Name | Description |

--- a/docs/en/api/reference/netserver/core/SuperOffice.CRM.ArchiveLists.FavouritesProvider.yml
+++ b/docs/en/api/reference/netserver/core/SuperOffice.CRM.ArchiveLists.FavouritesProvider.yml
@@ -35,20 +35,7 @@ items:
   - SoDataBase
   namespace: SuperOffice.CRM.ArchiveLists
   summary: Archive provider for the list of favourites
-  remarks: >-
-    Blah...
-
-    <p></p>
-
-    blah....
-
-    <p></p>
-
-    ...
-
-    <p></p>
-
-    ........
+  remarks: 
   example: []
   syntax:
     content: >-


### PR DESCRIPTION
Since we send these pages regularly to end customers, lets remove this unnecessary text.

I know this documentation is generated based on the original source, but I can't edit that 😉

If it could be arranged at your side that this is actually removed from the source code so that it doesn't show up again the next time the files are generated.
