### PR TITLE
Retire Document dialog pilot #1444

### DIFF
--- a/docs/da/document/learn/create.md
+++ b/docs/da/document/learn/create.md
@@ -4,13 +4,12 @@ title: Opret nyt dokument
 description: "Opret et nyt dokument direkte i SuperOffice CRM eller upload eksisterende, så du og dine kolleger altid har adgang til de nyeste dokumenter og versioner. Denne vejledning viser dig, hvordan du gør begge dele."
 keywords: dokument
 author: Bergfrid Dias
-date: 10.08.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: howto
 audience: person
 audience_tooltip: SuperOffice CRM
 language: da
-pilot: yes
 ---
 
 # Oprettelse af nye dokumenter
@@ -102,13 +101,13 @@ Hvis du ikke har installeret SuperOffice Web Tools, skal du downloade dokumenter
 > Mange felter har en liste over foruddefinerede værdier, du kan vælge imellem. Klik på pilen ![icon][img5] for at udvide listen. Vælg derefter en værdi for det pågældende felt. Alternativt kan du begynde at skrive i feltet for at søge efter en bestemt værdi, f.eks. et firmanavn.
 
 <!-- markdownlint-disable MD051 -->
-### [Klassisk](#tab/dialog-old)
-
-![Opret dokument fra skabelon (klassisk) -screenshot][img3]
-
-### [Ny (fra version 10.3.10 pilot)](#tab/dialog-new)
+### [Ny (fra version 10.3.11)](#tab/dialog-new)
 
 ![Opret dokument fra skabelon (ny) -screenshot][img4]
+
+### [Klassisk (onsite)](#tab/dialog-old)
+
+![Opret dokument fra skabelon (klassisk) -screenshot][img3]
 
 ***
 <!-- markdownlint-restore -->
@@ -149,8 +148,8 @@ Hvis du ikke har installeret SuperOffice Web Tools, skal du downloade dokumenter
 
 3. (valgfrit) Marker dokumentet som udført:
 
-    * Klassisk dialog: Klik på flueben-ikonet øverst til højre i dialogboksen.
-    * Ny (fra version 10.3.10 pilot): Vælg afkrydsningsfeltet i footeren.
+    * Ny (fra version 10.3.11): Vælg afkrydsningsfeltet i footeren.
+    * Klassisk dialog (onsite): Klik på flueben-ikonet øverst til højre i dialogboksen.
 
 4. [Indtast de ønskede oplysninger i felterne][2].
 

--- a/docs/da/document/learn/edit.md
+++ b/docs/da/document/learn/edit.md
@@ -10,7 +10,6 @@ topic: howto
 audience: person
 audience_tooltip: SuperOffice CRM
 language: da
-pilot: yes
 ---
 
 # Redigering af dokumenter

--- a/docs/da/document/learn/index.md
+++ b/docs/da/document/learn/index.md
@@ -10,7 +10,6 @@ topic: concept
 audience: person
 audience_tooltip: SuperOffice CRM
 language: da
-pilot: yes
 ---
 
 # Dokument ![ikon][img1]

--- a/docs/da/document/learn/lock.md
+++ b/docs/da/document/learn/lock.md
@@ -4,13 +4,12 @@ title: Indtjekning/udtjekning af dokumenter
 description: Indtjekning/udtjekning af dokumenter
 keywords: dokument, indtjek, udtjek, tilbage til gemt version, redigeringstilstand, læsetilstand, spørg før redigering eller læsning
 author: Bergfrid Dias
-date: 10.08.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: howto
 audience: person
 audience_tooltip: SuperOffice CRM
 language: da
-pilot: yes
 ---
 
 # Indtjekning/udtjekning af dokumenter
@@ -30,7 +29,15 @@ Som standard åbnes et dokument i redigeringstilstand. Hvis du foretrækker at v
 ## Hvordan ved jeg, hvornår et dokument er tjekket ud?
 
 <!-- markdownlint-disable MD051 -->
-### [Klassisk](#tab/lock-old)
+### [Ny (fra version 10.3.11)](#tab/lock-new)
+
+I dialogboksen **Dokument** viser et udtjekket dokument en banner med information om, hvem der redigerer det.
+
+![ikon][img5] **Du** redigerer dette dokument.
+
+![ikon][img5] Du kan ikke redigere dette dokument, fordi det er låst af **NN**.
+
+### [Klassisk (onsite)](#tab/lock-old)
 
 I dialogboksen **Dokument** har et udtjekket dokument et af følgende ikoner:
 
@@ -41,14 +48,6 @@ I dialogboksen **Dokument** har et udtjekket dokument et af følgende ikoner:
 Hold musemarkøren over et ikon for at vise oplysninger om den bruger, der har tjekket dokumentet ud.
 
 Hvis du prøver at åbne et udtjekket dokument, vises en dialogboks med oplysninger om, hvem der har tjekket dokumentet ud. Du kan kun åbne dokumentet i læsetilstand.
-
-### [Ny (fra version 10.3.10 pilot)](#tab/lock-new)
-
-I dialogboksen **Dokument** viser et udtjekket dokument en banner med information om, hvem der redigerer det.
-
-![ikon][img5] **Du** redigerer dette dokument.
-
-![ikon][img5] Du kan ikke redigere dette dokument, fordi det er låst af **NN**.
 
 ***
 <!-- markdownlint-restore -->

--- a/docs/da/document/learn/screen/index.md
+++ b/docs/da/document/learn/screen/index.md
@@ -1,15 +1,15 @@
 ---
 uid: help-da-document-dialog
-title: Dialogboksen Dokument
+title: Dialogboksen Dokument (onsite)
 description: Dialogboksen Dokument
 author: SuperOffice RnD
-date: 08.27.2024
+date: 10.29.2024
 keywords: dokument
 topic: concept
 language: da
 ---
 
-# Dialogboksen Dokument
+# Dialogboksen Dokument (onsite)
 
 Centralt i dokumentfunktionen findes dialogboksen **Dokument**, som du kan åbne på forskellige måder:
 
@@ -23,7 +23,7 @@ Dialogboksen består af en hoveddel med generelle oplysninger om dokumentet samt
 * Mere
 
 > [!NOTE]
-> Beskrivelserne på denne side vedrører den klassiske Dokumentdialog. Hvis du bruger pilotversionen af den nye Dokumentdialog, se [Feltafdelingen][6] i vejledningen for forklaring af dialoger og felter.
+> Beskrivelserne på denne side vedrører den klassiske Dokumentdialog (onsite). Hvis du bruger SuperOffice CRM Online, se [Feltafdelingen][6] i vejledningen for forklaring af dialoger og felter.
 
 ## Hovedafsnit
 

--- a/docs/da/ui/screen-designer/learn/assign-layout.md
+++ b/docs/da/ui/screen-designer/learn/assign-layout.md
@@ -4,8 +4,8 @@ title: Tildel layout til gruppe, type eller skabelon
 description: Sådan tildeler du et layout til en gruppe, salgstype, projekttype eller sagstype ved hjælp af Skærmdesigneren i Indstillinger og vedligeholdelse.
 keywords: Skærmdesigner, layout, tildel layout
 author: Bergfrid Dias
-date: 10.07.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: howto
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -29,7 +29,7 @@ language: da
     * Projekt: brugergruppe eller projekttype
     * Sag: brugergruppe eller sagstype
     * Opfølgning: brugergruppe eller opfølgningstype
-    * Dokument: brugergruppe eller dokumentskabelon (pilot)
+    * Dokument: brugergruppe eller dokumentskabelon
 
 1. Vælg et layout i listen til venstre.
 

--- a/docs/da/ui/screen-designer/learn/index.md
+++ b/docs/da/ui/screen-designer/learn/index.md
@@ -4,8 +4,8 @@ title: Skærmdesigner
 description: Få mere at vide om, hvordan du konfigurerer dine skærmbilleder i denne vejledning.
 keywords: Skærmdesigner, layout, skærmbillede, tilpasningsmulighed
 author: Bergfrid Dias
-date: 10.07.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: concept
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -61,7 +61,7 @@ Du kan tilpasse følgende skærme og dialoger:
 * Projekt
 * Sag
 * Opfølgningsdialog
-* Dokumentdialog (pilot)
+* Dokumentdialog
 
 ## Hvordan fungerer layouts?
 

--- a/docs/da/ui/screen-designer/learn/reference.md
+++ b/docs/da/ui/screen-designer/learn/reference.md
@@ -4,8 +4,8 @@ title: Reference
 description: Reference over elementer, der er tilgængelige i Skærmdesigneren i Indstillinger og vedligeholdelse.
 keywords: Skærmdesigner, layout, felt, standardfelt, fane, standardfane
 author: Bergfrid Dias
-date: 10.07.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: reference
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -274,7 +274,7 @@ For detaljer om værdien af hvert felt, se [databasereferencen][7].
 * Links
 * Mere
 
-## Dokument (i pilot fra version 10.3.10)
+## Dokument
 
 **Standardfelter:**
 

--- a/docs/de/document/learn/create.md
+++ b/docs/de/document/learn/create.md
@@ -4,13 +4,12 @@ title: Neues Dokument erstellen
 description: "Erstellen Sie ein neues Dokument direkt in SuperOffice CRM oder laden Sie ein bestehendes hoch, um sicherzustellen, dass Sie und Ihre Kollegen immer Zugriff auf die neuesten Dokumente und Versionen haben. Diese Anleitung zeigt Ihnen, wie Sie beides machen können."
 keywords: Dokument
 author: Bergfrid Dias
-date: 10.08.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: howto
 audience: person
 audience_tooltip: SuperOffice CRM
 language: de
-pilot: yes
 ---
 
 # Neue Dokumente erstellen
@@ -102,13 +101,13 @@ Wenn Sie SuperOffice WebTools nicht installiert haben, müssen Sie Dokumente zum
 > Viele Felder haben eine Liste von vordefinierten Werten, aus denen Sie wählen können. Klicken Sie auf den Pfeil ![icon][img5], um die Liste zu erweitern. Wählen Sie dann einen Wert für dieses Feld. Alternativ können Sie im Feld mit der Eingabe beginnen, um nach einem bestimmten Wert zu suchen, wie zum Beispiel einem Firmennamen.
 
 <!-- markdownlint-disable MD051 -->
-### [Klassisch](#tab/dialog-old)
-
-![Dokument aus Vorlage erstellen (klassisch) -screenshot][img3]
-
-### [Neu (ab Version 10.3.10 pilot)](#tab/dialog-new)
+### [Neu (ab Version 10.3.11)](#tab/dialog-new)
 
 ![Dokument aus Vorlage erstellen (neu) -screenshot][img4]
+
+### [Klassisch (onsite)](#tab/dialog-old)
+
+![Dokument aus Vorlage erstellen (klassisch) -screenshot][img3]
 
 ***
 <!-- markdownlint-restore -->
@@ -149,8 +148,8 @@ Wenn Sie SuperOffice WebTools nicht installiert haben, müssen Sie Dokumente zum
 
 3. (Optional) Markieren Sie das Dokument als abgeschlossen:
 
-    * Klassischer Dialog: Klicken Sie auf das Häkchensymbol oben rechts im Dialog.
-    * Neu (ab Version 10.3.10 pilot): Wählen Sie das Kontrollkästchen in der Fußzeile aus.
+    * Neu (ab Version 10.3.11): Wählen Sie das Kontrollkästchen in der Fußzeile aus.
+    * Klassischer Dialog (onsite): Klicken Sie auf das Häkchensymbol oben rechts im Dialog.
 
 4. [Geben Sie die erforderlichen Informationen in die betreffenden Felder ein](#fields).
 

--- a/docs/de/document/learn/edit.md
+++ b/docs/de/document/learn/edit.md
@@ -10,7 +10,6 @@ topic: howto
 audience: person
 audience_tooltip: SuperOffice CRM
 language: de
-pilot: yes
 ---
 
 # Dokumente bearbeiten

--- a/docs/de/document/learn/index.md
+++ b/docs/de/document/learn/index.md
@@ -10,7 +10,6 @@ topic: concept
 audience: person
 audience_tooltip: SuperOffice CRM
 language: de
-pilot: yes
 ---
 
 # Mit Dokumenten arbeiten ![Symbol][img1]

--- a/docs/de/document/learn/lock.md
+++ b/docs/de/document/learn/lock.md
@@ -4,13 +4,12 @@ title: Dokumente ein-/auschecken
 description: Dokumente ein-/auschecken
 keywords: Dokument
 author: Bergfrid Dias
-date: 10.08.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: howto
 audience: person
 audience_tooltip: SuperOffice CRM
 language: de
-pilot: yes
 ---
 
 # Dokumente ein-/auschecken
@@ -30,7 +29,15 @@ Standardmäßig werden Dokumente im Bearbeitungsmodus geöffnet. Wenn Sie es vor
 ## Woran erkannt man, ob ein Dokument ausgecheckt wurde?
 
 <!-- markdownlint-disable MD051 -->
-### [Klassisch](#tab/lock-old)
+### [Neu (ab Version 10.3.1)](#tab/lock-new)
+
+Im Dialogfeld **Dokument** zeigt ein ausgechecktes Dokument ein Banner mit Informationen darüber, wer das Dokument bearbeitet.
+
+![Symbol][img5] **Sie** bearbeiten dieses Dokument.
+
+![Symbol][img5] Sie können dieses Dokument nicht bearbeiten, da es von **NN** gesperrt ist.
+
+### [Klassisch (onsite)](#tab/lock-old)
 
 Im Dialogfeld **Dokument** ist ein ausgechecktes Dokument mit einem der folgenden Symbole gekennzeichnet:
 
@@ -41,14 +48,6 @@ Im Dialogfeld **Dokument** ist ein ausgechecktes Dokument mit einem der folgende
 Zeigen Sie mit dem Mauszeiger auf ein Symbol, um Informationen über den Benutzer anzuzeigen, der das Dokument ausgecheckt hat.
 
 Wenn Sie versuchen, ein ausgechecktes Dokument zu öffnen, wird ein Dialogfeld mit Informationen über den Benutzer angezeigt, der das Dokument ausgecheckt hat. Sie können das Dokument nur im Lesemodus öffnen.
-
-### [Neu (ab Version 10.3.10 pilot)](#tab/lock-new)
-
-Im Dialogfeld **Dokument** zeigt ein ausgechecktes Dokument ein Banner mit Informationen darüber, wer das Dokument bearbeitet.
-
-![Symbol][img5] **Sie** bearbeiten dieses Dokument.
-
-![Symbol][img5] Sie können dieses Dokument nicht bearbeiten, da es von **NN** gesperrt ist.
 
 ***
 <!-- markdownlint-restore -->

--- a/docs/de/document/learn/screen/index.md
+++ b/docs/de/document/learn/screen/index.md
@@ -1,15 +1,15 @@
 ---
 uid: help-de-document-dialog
-title: "Dialogfeld Dokument"
-description: "Dialogfeld Dokument"
+title: Dialogfeld Dokument (onsite)
+description: Dialogfeld Dokument
 author: SuperOffice RnD
-date: 08.27.2024
+date: 10.29.2024
 keywords: Dokument
 topic: concept
 language: de
 ---
 
-# Dialogfeld Dokument
+# Dialogfeld Dokument (onsite)
 
 Ein zentraler Bestandteil der Dokumentfunktion ist das Dialogfeld **Dokument**, das Sie auf unterschiedliche Weise öffnen können:
 
@@ -23,7 +23,7 @@ Das Dialogfeld besteht aus einer Hauptkomponente mit allgemeinen Informationen �
 * Mehr
 
 > [!NOTE]
-> Die Beschreibungen auf dieser Seite beziehen sich auf den klassischen Dokumentdialog. Wenn Sie die Pilotversion des neuen Dokument-Dialogs verwenden, sehen Sie im [Abschnitt Felder][6] in der Anleitung zur Erklärung von Dialogen und Feldern nach.
+> Die Beschreibungen auf dieser Seite beziehen sich auf den klassischen Dokumentdialog (onsite). Wenn Sie SuperOffice CRM Online verwenden, sehen Sie im [Abschnitt Felder][6] in der Anleitung zur Erklärung von Dialogen und Feldern nach.
 
 ## Hauptkomponenten
 

--- a/docs/de/ui/screen-designer/learn/assign-layout.md
+++ b/docs/de/ui/screen-designer/learn/assign-layout.md
@@ -4,8 +4,8 @@ title: Layout zu Gruppe, Typ oder Vorlage zuweisen
 description: So weisen Sie mit dem Ansichtsdesigner in Einstellungen und Wartung ein Layout einer Gruppe, Verkaufstyp, Projekttyp oder Anfrageart zu.
 keywords: Ansichtsdesigner, Layout, Layout zuweisen
 author: Bergfrid Dias
-date: 10.07.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: howto
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -29,7 +29,7 @@ language: de
     * Projekt: Benutzergruppe oder Projekttyp
     * Anfrage: Benutzergruppe oder Anfragetyp
     * Folgeaufgabe: Benutzergruppe oder Folgeaufgabstyp
-    * Dokument: Benutzergruppe oder Dokumentvorlage (Pilot)
+    * Dokument: Benutzergruppe oder Dokumentvorlage
 
 1. Wählen Sie ein Layout in der Liste auf der linken Seite aus.
 

--- a/docs/de/ui/screen-designer/learn/index.md
+++ b/docs/de/ui/screen-designer/learn/index.md
@@ -4,8 +4,8 @@ title: Ansichtsdesigner
 description: In dieser Anleitung lernen Sie, wie Sie Ihre Karten/Ansichten konfigurieren.
 keywords: Ansichtsdesigner, Benutzeroberfläche, Layout, anpassen
 author: Bergfrid Dias
-date: 10.07.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: concept
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -61,7 +61,7 @@ Sie können die folgenden Ansichte und Dialoge anpassen:
 * Projekt
 * Anfrage
 * Folgeaufgabedialog
-* Dokumentdialog (Pilot)
+* Dokumentdialog
 
 ## Wie funktionieren Layouts?
 

--- a/docs/de/ui/screen-designer/learn/reference.md
+++ b/docs/de/ui/screen-designer/learn/reference.md
@@ -4,8 +4,8 @@ title: Referenz
 description: Referenz der im Ansichtsdesigner in Einstellungen und Verwaltung verfügbaren Elemente.
 keywords: Ansichtsdesigner, Benutzeroberfläche, Layout, Feld, Standardfeld, Registerkarte, Standardregisterkarte
 author: Bergfrid Dias
-date: 10.07.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: reference
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -274,7 +274,7 @@ Weitere Details zu den Werten jedes Feldes finden Sie in der [Datenbankreferenz]
 * Links
 * Mehr
 
-## Dokument (im Pilotbetrieb ab Version 10.3.10)
+## Dokument
 
 **Standardfelder:**
 

--- a/docs/en/document/learn/create.md
+++ b/docs/en/document/learn/create.md
@@ -4,13 +4,12 @@ title: Create new document
 description: Create a new document directly in SuperOffice CRM or upload existing ones, to make sure you and your colleagues always have access to the latest documents and versions. This how-to guide will show you how to do both.
 keywords: document, SharePoint, create document, upload document, online text-editing
 author: Bergfrid Dias
-date: 10.08.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: howto
 audience: person
 audience_tooltip: SuperOffice CRM
 language: en
-pilot: yes
 ---
 
 # Create new document
@@ -90,7 +89,7 @@ If you have not installed SuperOffice WebTools, you must manually download docum
 
 8. Click the link to upload the document or drag and drop the document from Windows Explorer to the **Document** dialog.
 
-    <!-- TODO: retake screenshot when GA -->
+    <!-- TODO: retake screenshot when GA. Update: postpone to new UX -->
     ![Create a new document -screenshot][img2]
 
 9. Close the **Document** dialog by clicking **Save**.
@@ -103,13 +102,13 @@ If you have not installed SuperOffice WebTools, you must manually download docum
 > Many fields have a list of predefined values you can choose from. Click the arrow ![icon][img5] to expand the list. Then select a value for that field. Alternatively, start typing in the field to search for a specific value, such as a company name.
 
 <!-- markdownlint-disable MD051 -->
-### [Classic](#tab/dialog-old)
-
-![Create document from template (classic) -screenshot][img3]
-
-### [New (from version 10.3.10 pilot)](#tab/dialog-new)
+### [New (from version 10.3.11)](#tab/dialog-new)
 
 ![Create document from template (new) -screenshot][img4]
+
+### [Classic (onsite)](#tab/dialog-old)
+
+![Create document from template (classic) -screenshot][img3]
 
 ***
 <!-- markdownlint-restore -->
@@ -150,8 +149,8 @@ If you have not installed SuperOffice WebTools, you must manually download docum
 
 3. (optional) Mark the document as completed:
 
-    * Classic dialog: Click the checkmark icon at the top-right of the dialog.
-    * New (from version 10.3.10 pilot): Select the checkbox in the footer.
+    * New (from version 10.3.11): Select the checkbox in the footer.
+    * Classic dialog (onsite): Click the checkmark icon at the top-right of the dialog.
 
 4. [Complete the fields with the required information](#fields).
 

--- a/docs/en/document/learn/edit.md
+++ b/docs/en/document/learn/edit.md
@@ -10,7 +10,6 @@ topic: howto
 audience: person
 audience_tooltip: SuperOffice CRM
 language: en
-pilot: yes
 ---
 
 # Edit documents

--- a/docs/en/document/learn/index.md
+++ b/docs/en/document/learn/index.md
@@ -10,7 +10,6 @@ topic: concept
 audience: person
 audience_tooltip: SuperOffice CRM
 language: en
-pilot: yes
 ---
 
 # Document ![icon][img1]

--- a/docs/en/document/learn/lock.md
+++ b/docs/en/document/learn/lock.md
@@ -4,13 +4,12 @@ title: Check in/out documents
 description: Check in/out documents
 keywords: document, check in, lock document, edit mode, read mode, ask to edit or read, revert to saved version
 author: Bergfrid Dias
-date: 10.08.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: concept
 audience: person
 audience_tooltip: SuperOffice CRM
 language: en
-pilot: yes
 ---
 
 # Check in/out documents
@@ -30,7 +29,15 @@ By default, a document is opened in edit mode. If you prefer to select read mode
 ## How do I know when a document is checked out?
 
 <!-- markdownlint-disable MD051 -->
-### [Classic](#tab/lock-old)
+### [New (from version 10.3.11)](#tab/lock-new)
+
+In the **Document** dialog, a checked-out document displays a banner showing who is editing it.
+
+![icon][img5] **You** are editing this document.
+
+![icon][img5] You cannot edit this document because it is locked by **NN**.
+
+### [Classic (onsite)](#tab/lock-old)
 
 In the **Document** dialog, a checked-out document has one of the following icons:
 
@@ -41,14 +48,6 @@ In the **Document** dialog, a checked-out document has one of the following icon
 Hold the mouse pointer over an icon to show information about the user who checked out the document.
 
 If you attempt to open a checked-out document, a dialog appears with information about who checked out the document. You can open the document in read mode only.
-
-### [New (from version 10.3.10 pilot)](#tab/lock-new)
-
-In the **Document** dialog, a checked-out document displays a banner showing who is editing it.
-
-![icon][img5] **You** are editing this document.
-
-![icon][img5] You cannot edit this document because it is locked by **NN**.
 
 ***
 <!-- markdownlint-restore -->

--- a/docs/en/document/learn/screen/index.md
+++ b/docs/en/document/learn/screen/index.md
@@ -1,16 +1,16 @@
 ---
 uid: help-en-document-dialog
-title: Document dialog
+title: Document dialog (onsite)
 description: Document dialog
 author: SuperOffice RnD
-date: 08.12.2024
+date: 10.29.2024
 keywords: document
 topic: concept
 language: en
 ---
 
-<!-- Legacy - page will be removed after pilot -->
-# The Document dialog
+<!-- Legacy - page will be removed soon -->
+# The Document dialog (onsite)
 
 The central feature of the document function is the **Document** dialog, which you can open in different ways:
 
@@ -24,7 +24,7 @@ The dialog consists of a main section with general information about the documen
 * More
 
 > [!NOTE]
-> The descriptions on this page pertain to the **classic** Document dialog. If you use the pilot version of the new **Document** dialog, see the [Fields section][6] in the how-to for explanation of dialogs and fields.
+> The descriptions on this page pertain to the **classic** Document dialog (onsite). If you use SuperOffice CRM Online, see the [Fields section][6] in the how-to for explanation of dialogs and fields.
 
 ## Main section
 

--- a/docs/en/ui/screen-designer/learn/assign-layout.md
+++ b/docs/en/ui/screen-designer/learn/assign-layout.md
@@ -4,8 +4,8 @@ title: Assign layout to group, type, or template
 description: How to assign a layout to a group, sale type, project type, or request type using the Screen Designer in Settings and maintenance.
 keywords: Screen designer, assign layout, layout
 author: Bergfrid Dias
-date: 10.07.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: howto
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -29,7 +29,7 @@ language: en
     * Project: user group or project type
     * Request: user group or request type
     * Follow-up: user group or follow-up type
-    * Document: user group or document template (pilot)
+    * Document: user group or document template
 
 1. Select a layout in the list on the left side.
 

--- a/docs/en/ui/screen-designer/learn/index.md
+++ b/docs/en/ui/screen-designer/learn/index.md
@@ -4,8 +4,8 @@ title: Screen designer
 description: Learn how to configure your screens and dialogs in this how-to guide.
 keywords: Screen designer, layout, UI, screen, customization, configurable screen
 author: Bergfrid Dias
-date: 10.07.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: concept
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -61,7 +61,7 @@ You can customize the following screens and dialogs:
 * Project
 * Request
 * Follow-up dialog
-* Document dialog (pilot)
+* Document dialog
 
 ## How do layouts work?
 

--- a/docs/en/ui/screen-designer/learn/reference.md
+++ b/docs/en/ui/screen-designer/learn/reference.md
@@ -4,8 +4,8 @@ title: Reference
 description: Reference of elements available in the Screen Designer in Settings and maintenance.
 keywords: Screen designer, layout, field, standard field, tab, standard tab
 author: Bergfrid Dias
-date: 10.07.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: reference
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -274,7 +274,7 @@ For details about the value of each field, see the [Appointment database table][
 * Links
 * More
 
-## Document (in pilot from version 10.3.10)
+## Document
 
 **Standard fields:**
 

--- a/docs/nl/document/learn/create.md
+++ b/docs/nl/document/learn/create.md
@@ -4,13 +4,12 @@ title: Nieuw document maken
 description: Maak een nieuw document rechtstreeks in SuperOffice CRM of upload bestaande documenten, om ervoor te zorgen dat u en uw collega's altijd toegang hebben tot de nieuwste documenten en versies. Deze handleiding laat u zien hoe u beide kunt doen.
 keywords: document
 author: Bergfrid Dias
-date: 10.08.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: howto
 audience: person
 audience_tooltip: SuperOffice CRM
 language: nl
-pilot: yes
 ---
 
 # Nieuwe documenten maken
@@ -102,13 +101,13 @@ Als u SuperOffice Web Tools niet hebt geïnstalleerd, moet u documenten handmati
 > Veel velden hebben een lijst met vooraf gedefinieerde waarden waaruit u kunt kiezen. Klik op de pijl ![icon][img5] om de lijst uit te vouwen. Selecteer vervolgens een waarde voor dat veld. Typ alternatief in het veld om te zoeken naar een specifieke waarde, zoals een bedrijfsnaam.
 
 <!-- markdownlint-disable MD051 -->
-### [Klassiek](#tab/dialog-old)
-
-![Document maken vanuit sjabloon (Klassiek) -screenshot][img3]
-
-### [Nieuw (vanaf versie 10.3.10 pilot)](#tab/dialog-new)
+### [Nieuw (vanaf versie 10.3.11)](#tab/dialog-new)
 
 ![Document maken vanuit sjabloon (Nieuw) -screenshot][img4]
+
+### [Klassiek (onsite)](#tab/dialog-old)
+
+![Document maken vanuit sjabloon (Klassiek) -screenshot][img3]
 
 ***
 <!-- markdownlint-restore -->
@@ -149,8 +148,8 @@ Als u SuperOffice Web Tools niet hebt geïnstalleerd, moet u documenten handmati
 
 3. (optioneel) Markeer het document als voltooid:
 
-     * Klassieke dialoog: Klik op het vinkje pictogram rechtsboven in de dialoog.
-     * Nieuw (vanaf versie 10.3.10 pilot): Selecteer het selectievakje in de voettekst.
+     * Nieuw (vanaf versie 10.3.11): Selecteer het selectievakje in de voettekst.
+     * Klassieke dialoog (onsite): Klik op het vinkje pictogram rechtsboven in de dialoog.
 
 4. [Typ de gewenste informatie in de verschillende velden.](#fields)
 

--- a/docs/nl/document/learn/edit.md
+++ b/docs/nl/document/learn/edit.md
@@ -10,7 +10,6 @@ topic: howto
 audience: person
 audience_tooltip: SuperOffice CRM
 language: nl
-pilot: yes
 ---
 
 # Documenten bewerken

--- a/docs/nl/document/learn/index.md
+++ b/docs/nl/document/learn/index.md
@@ -10,7 +10,6 @@ topic: concept
 audience: person
 audience_tooltip: SuperOffice CRM
 language: nl
-pilot: yes
 ---
 
 # Werken met documenten ![pictogram][img1]

--- a/docs/nl/document/learn/lock.md
+++ b/docs/nl/document/learn/lock.md
@@ -4,13 +4,12 @@ title: Documenten aan/afmelden
 description: Documenten aan/afmelden
 keywords: document
 author: Bergfrid Dias
-date: 10.08.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: howto
 audience: person
 audience_tooltip: SuperOffice CRM
 language: nl
-pilot: yes
 ---
 
 # Documenten aan/afmelden
@@ -30,7 +29,15 @@ Een document wordt standaard in de bewerkingsmodus geopend. Als u liever de lees
 ## Hoe weet ik wanneer een document is afgemeld?
 
 <!-- markdownlint-disable MD051 -->
-### [Klassiek](#tab/lock-old)
+### [Nieuw (vanaf versie 10.3.11)](#tab/lock-new)
+
+In het dialoogvenster **Document** toont een afgemeld document een banner die aangeeft wie het bewerkt.
+
+![pictogram][img5] **Jij** bewerkt dit document.
+
+![pictogram][img5] Je kunt dit document niet bewerken omdat het is vergrendeld door **NN**.
+
+### [Klassiek (onsite)](#tab/lock-old)
 
 In het dialoogvenster **Document** heeft een afgemeld document een van de volgende pictogrammen:
 
@@ -41,14 +48,6 @@ In het dialoogvenster **Document** heeft een afgemeld document een van de volgen
 Houd de muisaanwijzer op een pictogram om informatie over de gebruiker weer te geven die het document heeft afgemeld.
 
 Als u probeert een afgemeld document te openen, wordt er een dialoogvenster weergegeven met informatie over de persoon die het document heeft afgemeld. U kunt het document alleen in leesmodus openen.
-
-### [Nieuw (vanaf versie 10.3.10 pilot)](#tab/lock-new)
-
-In het dialoogvenster **Document** toont een afgemeld document een banner die aangeeft wie het bewerkt.
-
-![pictogram][img5] **Jij** bewerkt dit document.
-
-![pictogram][img5] Je kunt dit document niet bewerken omdat het is vergrendeld door **NN**.
 
 ***
 <!-- markdownlint-restore -->

--- a/docs/nl/document/learn/screen/index.md
+++ b/docs/nl/document/learn/screen/index.md
@@ -1,15 +1,15 @@
 ---
 uid: help-nl-document-dialog
-title: Dialoogvenster Document
+title: Dialoogvenster Document (onsite)
 description: Dialoogvenster Document
 keywords: document
 author: SuperOffice RnD
-date: 08.27.2024
+date: 10.29.2024
 topic: concept
 language: nl
 ---
 
-# Het dialoogvenster Document
+# Het dialoogvenster Document (onsite)
 
 De centrale voorziening in de documentfunctie is het dialoogvenster **Document**, dat u op verschillende manieren kunt openen:
 
@@ -23,7 +23,7 @@ Het dialoogvenster bestaat uit een hoofdonderdeel met algemene informatie over h
 * Meer
 
 > [!NOTE]
-> De beschrijvingen op deze pagina hebben betrekking op het klassieke Documentdialoogvenster. Als u de pilotversie van het nieuwe Documentdialoogvenster gebruikt, raadpleeg de [sectie Velden][6] in de handleiding voor uitleg over dialoogvensters en velden.
+> De beschrijvingen op deze pagina hebben betrekking op het klassieke Documentdialoogvenster (onsite). Als u SuperOffice CRM Online gebruikt, raadpleeg de [sectie Velden][6] in de handleiding voor uitleg over dialoogvensters en velden.
 
 ## Hoofdonderdeel
 

--- a/docs/nl/ui/screen-designer/learn/assign-layout.md
+++ b/docs/nl/ui/screen-designer/learn/assign-layout.md
@@ -4,8 +4,8 @@ title: Opmaak toewijzen aan groep, type of sjabloon
 description: Hoe u een opmaak toewijst aan een groep, verkooptype, projecttype of verzoektype met behulp van de Schermontwerper in Instellingen en onderhoud.
 keywords: Schermontwerper, opmaak, opmaak toewijzen
 author: Bergfrid Dias
-date: 10.07.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: howto
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -29,7 +29,7 @@ language: nl
     * Project: gebruikersgroep of projecttype
     * Verzoek: gebruikersgroep of verzoektype
     * Vervolgactiviteit: gebruikersgroep of vervolgactiviteittype
-    * Document: gebruikersgroep of documentsjabloon (pilot)
+    * Document: gebruikersgroep of documentsjabloon
 
 1. Selecteer een opmaak in de lijst aan de linkerkant.
 

--- a/docs/nl/ui/screen-designer/learn/index.md
+++ b/docs/nl/ui/screen-designer/learn/index.md
@@ -4,8 +4,8 @@ title: Schermontwerper
 description: Kom te weten hoe u uw kaarten configureert in deze gids.
 keywords: Schermontwerper, interface, opmaak, lay-out, aanpassen
 author: Bergfrid Dias
-date: 10.07.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: concept
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -61,7 +61,7 @@ U kunt de volgende schermen en dialoogvensters aanpassen:
 * Project
 * Verzoek
 * Vervolgactiviteitdialoog
-* Documentdialoog (pilot)
+* Documentdialoog
 
 ## Hoe werken opmaken?
 

--- a/docs/nl/ui/screen-designer/learn/reference.md
+++ b/docs/nl/ui/screen-designer/learn/reference.md
@@ -4,8 +4,8 @@ title: Referentie
 description: Referentie van elementen beschikbaar in de Schermontwerper in Instellingen en onderhoud.
 keywords: Schermontwerper, opmaak, veld, standaardveld, tabblad, standaardtabblad
 author: Bergfrid Dias
-date: 10.07.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: reference
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -274,7 +274,7 @@ Voor meer details over de waarde van elk veld, zie de [databasereferentie][7].
 * Links
 * Meer
 
-## Document (in pilot vanaf versie 10.3.10)
+## Document
 
 **Standaardvelden:**
 

--- a/docs/no/document/learn/create.md
+++ b/docs/no/document/learn/create.md
@@ -4,13 +4,12 @@ title: Opprett nytt dokument
 description: Opprett et nytt dokument direkte i SuperOffice CRM, eller last opp eksisterende, for å sikre at du og kollegene dine alltid har tilgang til de nyeste dokumentene og versjonene. Denne veiledningen viser deg hvordan du gjør begge deler.
 keywords: dokument
 author: Bergfrid Dias
-date: 10.08.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: howto
 audience: person
 audience_tooltip: SuperOffice CRM
 language: no
-pilot: yes
 ---
 
 # Opprett nye dokument
@@ -102,13 +101,13 @@ Hvis du ikke har installert SuperOffice WebTools, må du laste ned dokumenter ma
 > Mange felt har en liste over forhåndsdefinerte verdier du kan velge fra. Klikk på pilen ![icon][img5] for å utvide listen. Velg deretter en verdi for det feltet. Alternativt kan du begynne å skrive i feltet for å søke etter en bestemt verdi, for eksempel et firmanavn.
 
 <!-- markdownlint-disable MD051 -->
-### [Klassisk](#tab/dialog-old)
-
-![Opprett dokument fra mal (klassisk) -screenshot][img3]
-
-### [Ny (fra version 10.3.10 pilot)](#tab/dialog-new)
+### [Ny (fra version 10.3.11)](#tab/dialog-new)
 
 ![Opprett dokument fra mal (ny) -screenshot][img4]
+
+### [Klassisk (onsite)](#tab/dialog-old)
+
+![Opprett dokument fra mal (klassisk) -screenshot][img3]
 
 ***
 <!-- markdownlint-restore -->
@@ -149,8 +148,8 @@ Hvis du ikke har installert SuperOffice WebTools, må du laste ned dokumenter ma
 
 3. (valgfritt) Marker dokumentet som fullført:
 
-     * Klassisk dialog: Klikk på hakeikonet øverst til høyre i dialogboksen.
-     * Ny (fra versjon 10.3.10 pilot): Velg avmerkingsboksen i footeren.
+     * Ny (fra versjon 10.3.11): Velg avmerkingsboksen i footeren.
+     * Klassisk dialog (onsite): Klikk på hakeikonet øverst til høyre i dialogboksen.
 
 4. [Fyll ut feltene med nødvendig informasjon](#fields).
 

--- a/docs/no/document/learn/edit.md
+++ b/docs/no/document/learn/edit.md
@@ -10,7 +10,6 @@ topic: howto
 audience: person
 audience_tooltip: SuperOffice CRM
 language: no
-pilot: yes
 ---
 
 # Redigere dokument

--- a/docs/no/document/learn/index.md
+++ b/docs/no/document/learn/index.md
@@ -10,7 +10,6 @@ topic: concept
 audience: person
 audience_tooltip: SuperOffice CRM
 language: no
-pilot: yes
 ---
 
 # Dokument ![icon][img1]

--- a/docs/no/document/learn/lock.md
+++ b/docs/no/document/learn/lock.md
@@ -4,13 +4,12 @@ title: Sjekke inn/ut dokumenter
 description: Sjekke inn/ut dokumenter
 keywords: dokument
 author: Bergfrid Dias
-date: 10.08.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: howto
 audience: person
 audience_tooltip: SuperOffice CRM
 language: no
-pilot: yes
 ---
 
 # Sjekke inn/ut dokumenter
@@ -30,7 +29,15 @@ Som standard åpnes et dokument i redigeringsmodus. Hvis du foretrekker å velge
 ## Hvordan vet jeg når et dokument er sjekket ut?
 
 <!-- markdownlint-disable MD051 -->
-### [Klassisk](#tab/lock-old)
+### [Ny (fra version 10.3.11)](#tab/lock-new)
+
+I dialogboksen **Dokument** viser et utsjekket dokument en banner som viser hvem som redigerer det.
+
+![icon][img5] **Du** redigerer dette dokumentet.
+
+![icon][img5] Du kan ikke redigere dette dokumentet fordi det er låst av **NN**.
+
+### [Klassisk (onsite)](#tab/lock-old)
 
 I dialogboksen **Dokument** har et utsjekket dokument ett av følgende ikoner:
 
@@ -41,14 +48,6 @@ I dialogboksen **Dokument** har et utsjekket dokument ett av følgende ikoner:
 Hold musepekeren over et ikon for å vise informasjon om hvem som sjekket ut dokumentet.
 
 Hvis du prøver å åpne et utsjekket dokument, vises en dialogboks med informasjon om hvem som sjekket ut dokumentet. Du kan bare åpne dokumentet i lesemodus.
-
-### [Ny (fra version 10.3.10 pilot)](#tab/lock-new)
-
-I dialogboksen **Dokument** viser et utsjekket dokument en banner som viser hvem som redigerer det.
-
-![icon][img5] **Du** redigerer dette dokumentet.
-
-![icon][img5] Du kan ikke redigere dette dokumentet fordi det er låst av **NN**.
 
 ***
 <!-- markdownlint-restore -->

--- a/docs/no/document/learn/screen/index.md
+++ b/docs/no/document/learn/screen/index.md
@@ -1,15 +1,15 @@
 ---
 uid: help-no-document-dialog
-title: Dialogboks for dokument
+title: Dialogboks for dokument (onsite)
 description: Dialogboks for dokument
 author: SuperOffice RnD
-date: 08.27.2024
+date: 10.29.2024
 keywords: dokument
 topic: concept
 language: no
 ---
 
-# Dialogboksen Dokument
+# Dialogboksen Dokument (onsite)
 
 Sentralt i dokumentfunksjonen står dialogboksen **Dokument**, som du kan åpne på forskjellige måter:
 
@@ -23,7 +23,7 @@ Dialogboksen består av en hovedseksjon med generell informasjon om dokumentet, 
 * Mer
 
 > [!NOTE]
-> Beskrivelsene på denne siden gjelder den klassiske Dokumentdialogen. Hvis du bruker pilotversjonen av den nye Dokumentdialogen, se [seksjonen Felt][6] i veiledningen for forklaring av dialoger og felter.
+> Beskrivelsene på denne siden gjelder den klassiske Dokumentdialogen (onsite). Hvis du bruker SuperOffice CRM Online, se [seksjonen Felt][6] i veiledningen for forklaring av dialoger og felter.
 
 ## Hovedseksjon
 

--- a/docs/no/ui/screen-designer/learn/assign-layout.md
+++ b/docs/no/ui/screen-designer/learn/assign-layout.md
@@ -4,8 +4,8 @@ title: Tilordne layout til gruppe, type eller mal
 description: Hvordan tilordne layout til gruppe eller type ved hjelp av Skjermdesigneren i Innstillinger of vedlikehold.
 keywords: Skjermdesigner, brukergrensesnitt, skjerm, layout, oppsett, tilordne, tildel
 author: Bergfrid Dias
-date: 10.07.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: howto
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -29,7 +29,7 @@ language: no
     * Prosjekt: brukergruppe eller prosjekttype
     * Sak: brukergruppe eller sakstype
     * Oppfølging: brukergruppe eller oppfølgingstype
-    * Dokument: brukergruppe eller dokumentmal (pilot)
+    * Dokument: brukergruppe eller dokumentmal
 
 1. Velg en layout i listen til venstre.
 

--- a/docs/no/ui/screen-designer/learn/index.md
+++ b/docs/no/ui/screen-designer/learn/index.md
@@ -4,8 +4,8 @@ title: Skjermdesigner
 description: Lær hvordan du konfigurerer skjermbilder i denne veiledningen.
 keywords: Skjermdesigner, brukergrensesnitt, skjerm, layout, oppsett, tilpasning
 author: Bergfrid Dias
-date: 10.07.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: concept
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -61,7 +61,7 @@ Du kan tilpasse følgende skjermer og dialoger:
 * Prosjekt
 * Sak
 * Oppfølgingsdialog
-* Dokumentdialog (pilot)
+* Dokumentdialog
 
 ## Hvordan fungerer layouter?
 

--- a/docs/no/ui/screen-designer/learn/reference.md
+++ b/docs/no/ui/screen-designer/learn/reference.md
@@ -4,8 +4,8 @@ title: Referanse
 description: Oversikt over felt tilgjengelig i Skjermdesigneren i Innstillinger of vedlikeholde.
 keywords: Skjermdesigner, felt, standardfelt, fane, standardfane
 author: Bergfrid Dias
-date: 10.07.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: reference
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -274,7 +274,7 @@ For detaljer om verdien av hvert felt, se [databasereferansen][7].
 * Koblinger
 * Mer
 
-## Dokument (i pilot fra versjon 10.3.10)
+## Dokument
 
 **Standardfelt:**
 

--- a/docs/sv/document/learn/create.md
+++ b/docs/sv/document/learn/create.md
@@ -4,13 +4,12 @@ title: Skapa ett nytt dokument
 description: Skapa ett nytt dokument direkt i SuperOffice CRM eller ladda upp befintliga dokument så att du och dina kollegor alltid har tillgång till de senaste dokumenten och versionerna. Den här guiden visar hur du gör båda.
 keywords: dokument
 author: Bergfrid Dias
-date: 10.08.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: howto
 audience: person
 audience_tootip: SuperOffice CRM
 language: sv
-pilot: yes
 ---
 
 # Skapa nya dokument
@@ -102,13 +101,13 @@ Om du inte har installerat SuperOffice WebTools måste du manuellt ladda ner dok
 > Många fält har en lista med fördefinierade värden att välja från. Klicka på pilen ![icon][img5] för att expandera listan. Välj sedan ett värde för det fältet. Alternativt kan du börja skriva i fältet för att söka efter ett specifikt värde, till exempel ett företagsnamn.
 
 <!-- markdownlint-disable MD051 -->
-### [Klassisk](#tab/dialog-old)
-
-![Skapa dokument från mall (klassisk) -screenshot][img3]
-
-### [Ny (från version 10.3.10 pilot)](#tab/dialog-new)
+### [Ny (från version 10.3.11)](#tab/dialog-new)
 
 ![Skapa dokument från mall (ny) -screenshot][img4]
+
+### [Klassisk (onsite)](#tab/dialog-old)
+
+![Skapa dokument från mall (klassisk) -screenshot][img3]
 
 ***
 <!-- markdownlint-restore -->
@@ -149,8 +148,8 @@ Om du inte har installerat SuperOffice WebTools måste du manuellt ladda ner dok
 
 3. (valfritt) Markera dokumentet som slutfört:
 
-    * Klassisk dialog: Klicka på bockikonen uppe till höger i dialogrutan.
-    * Ny (från version 10.3.10 pilot): Välj kryssrutan i sidfoten.
+    * Ny (från version 10.3.11): Välj kryssrutan i sidfoten.
+    * Klassisk dialog (onsite): Klicka på bockikonen uppe till höger i dialogrutan.
 
 4. [Ange den information som behövs i fälten](#fields).
 

--- a/docs/sv/document/learn/edit.md
+++ b/docs/sv/document/learn/edit.md
@@ -10,7 +10,6 @@ topic: howto
 audience: person
 audience_tooltip: SuperOffice CRM
 language: sv
-pilot: yes
 ---
 
 # Redigera dokument

--- a/docs/sv/document/learn/index.md
+++ b/docs/sv/document/learn/index.md
@@ -10,7 +10,6 @@ topic: concept
 audience: person
 audience_tooltip: SuperOffice CRM
 language: sv
-pilot: yes
 ---
 
 # Arbeta med dokument ![ikon][img1]

--- a/docs/sv/document/learn/lock.md
+++ b/docs/sv/document/learn/lock.md
@@ -4,13 +4,12 @@ title: Checka in/ut dokument
 description: Checka in/ut dokument
 keywords: dokument
 author: Bergfrid Dias
-date: 10.08.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: howto
 audience: person
 audience_tooltip: SuperOffice CRM
 language: sv
-pilot: yes
 ---
 
 # Checka in/ut dokument
@@ -30,7 +29,16 @@ Som standard öppnas ett dokument i redigeringsläge. Om du föredrar att välja
 ## Hur vet jag när ett dokument är utcheckat?
 
 <!-- markdownlint-disable MD051 -->
-### [Klassisk](#tab/lock-old)
+
+### [Ny (från version 10.3.11)](#tab/lock-new)
+
+I dialogrutan **Dokument** visar ett utcheckat dokument en banner som visar vem som redigerar det.
+
+![ikon][img5] **Du** redigerar det här dokumentet.
+
+![ikon][img5] Du kan inte redigera det här dokumentet eftersom det är låst av **NN**.
+
+### [Klassisk (onsite)](#tab/lock-old)
 
 I dialogrutan **Dokument** har ett utcheckat dokument någon av följande ikoner:
 
@@ -41,14 +49,6 @@ I dialogrutan **Dokument** har ett utcheckat dokument någon av följande ikoner
 Håll muspekaren över en ikon för att visa information om användaren som har checkat ut dokumentet.
 
 Om du försöker öppna ett utcheckat dokument visas en dialogruta med information om vem som har checkat ut dokumentet. Du kan bara öppna dokumentet i läsläge.
-
-### [Ny (från version 10.3.10 pilot)](#tab/lock-new)
-
-I dialogrutan **Dokument** visar ett utcheckat dokument en banner som visar vem som redigerar det.
-
-![ikon][img5] **Du** redigerar det här dokumentet.
-
-![ikon][img5] Du kan inte redigera det här dokumentet eftersom det är låst av **NN**.
 
 ***
 <!-- markdownlint-restore -->

--- a/docs/sv/document/learn/screen/index.md
+++ b/docs/sv/document/learn/screen/index.md
@@ -1,15 +1,15 @@
 ---
 uid: help-sv-document-dialog
-title: Dialogrutan Dokument
+title: Dialogrutan Dokument (onsite)
 description: Dialogrutan Dokument
 author: SuperOffice RnD
-date: 08.27.2024
+date: 10.29.2024
 keywords: dokument
 topic: concept
 language: sv
 ---
 
-# Dialogrutan Dokument
+# Dialogrutan Dokument (onsite)
 
 Många dokumentfunktioner hanteras via dialogrutan **Dokument**, som du kan öppna på flera olika sätt:
 
@@ -23,7 +23,7 @@ Dialogrutan består av en huvuddel med allmän information om dokumentet samt f�
 * Mer
 
 > [!NOTE]
-> Beskrivningarna på den här sidan avser den klassiska Dokumentdialogen. Om du använder pilotversionen av den nya Dokumentdialogen, se [Fältsektionen][6] i instruktionen för förklaring av dialoger och fält.
+> Beskrivningarna på den här sidan avser den klassiska Dokumentdialogen (onsite). Om du använder SuperOffice CRM Online, se [Fältsektionen][6] i instruktionen för förklaring av dialoger och fält.
 
 ## Huvuddel
 

--- a/docs/sv/ui/screen-designer/learn/assign-layout.md
+++ b/docs/sv/ui/screen-designer/learn/assign-layout.md
@@ -4,8 +4,8 @@ title: Tilldela layout till grupp, typ eller mall
 description: Hur du tilldelar en layout till en grupp, säljtyp, projekttyp eller ärendetyp med hjälp av Skärmdesignern i Inställningar och underhåll.
 keywords: Skärmdesigner, layout, gränssnitt, flik, fält, tilldela layout
 author: Bergfrid Dias
-date: 10.07.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: howto
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -29,7 +29,7 @@ language: sv
     * Projekt: användargrupp eller projekttyp
     * Ärende: användargrupp eller ärendetyp
     * Händelse: användargrupp eller händelsestyp
-    * Dokument: användargrupp eller dokumentmall (pilot)
+    * Dokument: användargrupp eller dokumentmall
 
 1. Välj en layout i listan till vänster.
 

--- a/docs/sv/ui/screen-designer/learn/index.md
+++ b/docs/sv/ui/screen-designer/learn/index.md
@@ -4,8 +4,8 @@ title: Skärmdesigner
 description: Lär dig hur du konfigurerar skärmar i den här guiden.
 keywords: Skärmdesigner, layout, gränssnitt, flik, fält
 author: Bergfrid
-date: 10.07.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: concept
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -55,7 +55,7 @@ Du kan anpassa följande skärmar och dialoger:
 * Projekt
 * Ärende
 * Händelsesdialog
-* Dokumentdialog (pilot)
+* Dokumentdialog
 
 ## Hur fungerar layouter?
 

--- a/docs/sv/ui/screen-designer/learn/reference.md
+++ b/docs/sv/ui/screen-designer/learn/reference.md
@@ -4,8 +4,8 @@ title: Referens
 description: Referens över element som finns tillgängliga i Skärmdesignern i Inställningar och underhåll.
 keywords: Skärmdesigner, fält, flik, standardfält, standardflik
 author: Bergfrid Dias
-date: 10.07.2024
-version: 10.3.10
+date: 10.29.2024
+version: 10.3.11
 topic: reference
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -274,7 +274,7 @@ För detaljer om värdet av varje fält, se [databasreferencen][7].
 * Länkar
 * Mer
 
-## Dokument (i pilot från version 10.3.10)
+## Dokument
 
 **Standardfält:**
 


### PR DESCRIPTION
(which was not a pilot program at all, but marked as such while under feature toggle.

Keeping the tabbed view and old Document dialog page for now (probably until we archive a snapshot for onsite users).

Changed the order of the tabs, so that new is now first.