### PR TITLE
SuperOffice Mobile - Update toc.yml

### DIFF
--- a/docs/en/mobile/toc.yml
+++ b/docs/en/mobile/toc.yml
@@ -4,7 +4,7 @@ items:
   items:
   - name: Introduction
     href: overview.md
-  - name: Superoffice Mobile
+  - name: SuperOffice Mobile
     href: superoffice-mobile/toc.yml
   - name: Pocket CRM
     items:


### PR DESCRIPTION
It was added a small o in SuperOffice Mobile in the main toc.
I have changed it to big O in SuperOffice.

![image](https://github.com/user-attachments/assets/1ef37414-6621-4cf2-b654-1187fb377708)
