### PR TITLE
#1913 Remove inbox set-up video

### DIFF
--- a/docs/da/email/inbox/learn/setup.md
+++ b/docs/da/email/inbox/learn/setup.md
@@ -3,8 +3,9 @@ uid: help-da-email-inbox-setup
 title: Opsætning af SuperOffice Indbakke
 description: SuperOffice-indbakken er en alternativ måde at forbinde din e-mail til din SuperOffice CRM til e-mailklienter, der ikke kan forbindes via WebTools. Lær, hvordan du konfigurerer det og logger ind første gang.
 keywords: e-mail, indbakke
-author: SuperOffice RnD
-date: 02.14.2023
+author: SuperOffice Product and Engineering
+date: 05.12.2025
+version: 10.4
 topic: howto
 language: da
 ---
@@ -25,14 +26,7 @@ SuperOffice-indbakken er en alternativ måde at forbinde din e-mail til din Supe
 
 For at få adgang til e-mail skal du først angive detaljer om din e-mail-konto.
 
-Se denne video for at se, hvor hurtigt og nemt du kan konfigurere din SuperOffice-indbakke, eller følg nedenstående trin:
-
-<!-- markdownlint-disable-next-line MD034 DOCSMD007 -->
-> [!Video https://www.youtube.com/embed/QoAanZgQs5A]
-
-(videoens længde: 1:34)
-
-### Trin
+<!-- Prev YT video tag QoAanZgQs5A -->
 
 1. Klik på ikonet Indbakke i navigatormenuen. Skærmbilledet **Konfigurer e-mail-konto** vises, første gang du åbner indbakken.
 

--- a/docs/de/email/inbox/learn/setup.md
+++ b/docs/de/email/inbox/learn/setup.md
@@ -1,10 +1,11 @@
 ---
 uid: help-de-email-inbox-setup
 title: SuperOffice Posteingang einrichten
-description: "Der SuperOffice Posteingang ist eine alternative Möglichkeit, Ihre E-Mails mit Ihrem SuperOffice CRM für E-Mail-Clients zu verbinden, die nicht über WebTools verbunden werden können. Lernen Sie, wie Sie ihn einrichten und zum ersten Mal einloggen."
-author: SuperOffice RnD
-date: 02.14.2023
+description: Der SuperOffice Posteingang ist eine alternative Möglichkeit, Ihre E-Mails mit Ihrem SuperOffice CRM für E-Mail-Clients zu verbinden, die nicht über WebTools verbunden werden können. Lernen Sie, wie Sie ihn einrichten und zum ersten Mal einloggen.
 keywords: E-Mail, E-Mail
+author: SuperOffice Product and Engineering
+date: 05.12.2025
+version: 10.4
 topic: howto
 language: de
 ---
@@ -25,12 +26,7 @@ Der SuperOffice Posteingang ist eine alternative Möglichkeit, Ihre E-Mails mit 
 
 Um auf E-Mails zugreifen zu können, müssen Sie zunächst Details über Ihr E-Mail-Konto angeben.
 
-Sehen Sie sich dieses Video an, um zu sehen, wie schnell und einfach Sie Ihren SuperOffice-Posteingang einrichten können, oder führen Sie die folgenden Schritte aus (Videolänge -1:34):
-
-<!-- markdownlint-disable-next-line MD034 DOCSMD007 -->
-> [!Video https://www.youtube.com/embed/QoAanZgQs5A]
-
-### Schritte
+<!-- Prev YT video tag QoAanZgQs5A -->
 
 1. Klicken Sie auf das Symbol Posteingang im Navigator-Menü. Wenn Sie die E-Mail-Funktion zum ersten Mal aufrufen, wird die Ansicht **E-Mail-Konto einrichten** angezeigt.
 

--- a/docs/en/email/inbox/learn/setup.md
+++ b/docs/en/email/inbox/learn/setup.md
@@ -2,9 +2,10 @@
 uid: help-en-email-inbox-setup
 title: Set up SuperOffice Inbox
 description: The SuperOffice Inbox is an alternative way to connect your email to your SuperOffice CRM for email clients that cannot be connected via WebTools. Learn how to set it up and log in for the first time.
-author: SuperOffice RnD
-date: 02.14.2023
 keywords: email, inbox
+author: SuperOffice Product and Engineering
+date: 05.12.2025
+version: 10.4
 topic: howto
 language: en
 ---
@@ -25,12 +26,7 @@ The SuperOffice Inbox is an alternative way to connect your email to your SuperO
 
 To access email, you must first specify details about your email account.
 
-Watch this video to see how quickly and easily you can set up your SuperOffice Inbox or follow the steps below (video length -1:34):
-
-<!-- markdownlint-disable-next-line MD034 DOCSMD007 -->
-> [!Video https://www.youtube.com/embed/QoAanZgQs5A]
-
-### Steps
+<!-- Prev YT video tag QoAanZgQs5A -->
 
 1. Click on the Inbox icon in the navigator menu. The **Set up email account** screen appears the first time you open your inbox.
 

--- a/docs/nl/email/inbox/learn/setup.md
+++ b/docs/nl/email/inbox/learn/setup.md
@@ -3,8 +3,9 @@ uid: help-nl-email-inbox-setup
 title: SuperOffice Postvak IN instellen
 description: SuperOffice Postvak IN is een alternatieve manier om uw e-mail te verbinden met uw SuperOffice CRM voor e-mailclients die niet via WebTools kunnen worden verbonden. Leer hoe u het instelt en voor de eerste keer inlogt.
 keywords: e-mail, postvak IN
-author: SuperOffice RnD
-date: 02.14.2023
+author: SuperOffice Product and Engineering
+date: 05.12.2025
+version: 10.4
 topic: howto
 language: nl
 ---
@@ -25,14 +26,7 @@ SuperOffice Postvak IN is een alternatieve manier om uw e-mail te verbinden met 
 
 Als u toegang wilt tot e-mail, moet u eerst details over uw e-mailaccount opgeven.
 
-Bekijk deze video om te zien hoe snel en eenvoudig u uw SuperOffice Postvak IN kunt instellen of volg de onderstaande stappen:
-
-<!-- markdownlint-disable-next-line MD034 DOCSMD007 -->
-> [!Video https://www.youtube.com/embed/QoAanZgQs5A]
-
-(videolengte -1:34)
-
-### Stappen
+<!-- Prev YT video tag QoAanZgQs5A -->
 
 1. Klik op het pictogram Postvak IN in het navigatiemenu. Het scherm **E-mailaccount instellen** wordt weergegeven als u Postvak IN voor de eerste keer opent.
 

--- a/docs/no/email/inbox/learn/setup.md
+++ b/docs/no/email/inbox/learn/setup.md
@@ -2,9 +2,10 @@
 uid: help-no-email-inbox-setup
 title: Konfigurer SuperOffice-innboksen
 description: SuperOffice-innboksen er en alternativ måte å koble e-posten din til SuperOffice CRM for e-postklienter som ikke kan kobles til via WebTools. Finn ut hvordan du konfigurerer og logger på for første gang.
-author: SuperOffice RnD
-date: 02.14.2023
 keywords: E-post, innboks
+author: SuperOffice Product and Engineering
+date: 05.12.2025
+version: 10.4
 topic: howto
 language: no
 ---
@@ -25,12 +26,7 @@ SuperOffice-innboksen er en alternativ måte å koble e-posten din til SuperOffi
 
 For å få tilgang til e-post må du først spesifisere detaljer om e-postkontoen din.
 
-Se denne videoen for å se hvor raskt og enkelt du kan konfigurere SuperOffice-innboksen, eller følg trinnene nedenfor (videolengde -1:34):
-
-<!-- markdownlint-disable-next-line MD034 DOCSMD007 -->
-> [!Video https://www.youtube.com/embed/QoAanZgQs5A]
-
-### Trinn
+<!-- Prev YT video tag QoAanZgQs5A -->
 
 1. Klikk på Innboks-ikonet i navigatormenyen. Skjermbildet **Konfigurer e-postkonto** vises første gang du åpner innboksen.
 

--- a/docs/sv/email/inbox/learn/setup.md
+++ b/docs/sv/email/inbox/learn/setup.md
@@ -3,8 +3,9 @@ uid: help-sv-email-inbox-setup
 title: Konfigurera inkorgen i SuperOffice
 description: Inkorgen i SuperOffice är ett alternativt sätt att koppla din e-post till din SuperOffice CRM för e-postklienter som inte kan anslutas via WebTools. Läs om hur du konfigurerar inkorgen och loggar in första gången.
 keywords: e-post, inkorg
-author: SuperOffice RnD
-date: 02.25.2025
+author: SuperOffice Product and Engineering
+date: 05.12.2025
+version: 10.4
 topic: howto
 language: sv
 ---
@@ -25,14 +26,7 @@ Inkorgen i SuperOffice är ett alternativt sätt att koppla din e-post till din 
 
 För att komma åt e-post måste du ange vissa uppgifter om ditt e-postkonto.
 
-I den här filmen förklarar vi hur du snabbt och enkelt kan konfigurera din SuperOffice-inkorg. Du kan också följa anvisningarna nedan.
-
-<!-- markdownlint-disable-next-line MD034 DOCSMD007 -->
-> [!Video https://www.youtube.com/embed/QoAanZgQs5A]
-
-(filmens längd: 1:34)
-
-### Steg
+<!-- Prev YT video tag QoAanZgQs5A -->
 
 1. Klicka på ikonen Inkorg i navigatormenyn. Fönstret **Konfigurera e-postkonto** visas första gången du öppnar inkorgen.
 


### PR DESCRIPTION
* Updated metadata (using 10.4 to signal it's not updated for new ux yet)
* Kept comment with YT video tag (QoAanZgQs5A)
* Cut both intro, embed link, and length info.
* Cut the "Steps" H3, because its sole purpose was to accommodate the gap from H2 created by the video, which is no longer there.