### PR TITLE
#2107 prune learn toc to fix double breadcrumbs

### DIFF
--- a/docs/da/admin/lists/learn/toc.yml
+++ b/docs/da/admin/lists/learn/toc.yml
@@ -39,8 +39,6 @@ items:
   items:
   - name: Oversigt
     href: specialized-lists.md
-  - name: Dokumentskabelon
-    topicHref: ../../../document/templates/learn/index.md
   - name: E-mailskabelon
     href: email-template.md
     items:
@@ -52,23 +50,8 @@ items:
     - name: Tilføj opfølgningstype
       href: adding-items-to-follow-up-type-list.md
 
-  - name: Salg
-    topicHref: ../../../sale/admin/index.md
-    items:
-    - name: Tilføj salgsfase
-      topicHref: ../../../sale/admin/sale-stage.md
-    - name: Tilføj salgstype
-      topicHref: ../../../sale/admin/sale-type.md
-    - name: Tilføj salgsbeløbsklasse
-      href: sale-amount-class.md
-
-  - name: Projekt
-    topicHref: ../../../project/admin/index.md
-    items:
-    - name: Tilføj projektstatus
-      topicHref: ../../../project/admin/project-status.md
-    - name: Tilføj projekttype
-      topicHref: ../../../project/admin/project-type.md
+  - name: Tilføj salgsbeløbsklasse
+    href: sale-amount-class.md
 
   - name: Generel
     topicHref: country.md

--- a/docs/da/learn/toc.yml
+++ b/docs/da/learn/toc.yml
@@ -90,16 +90,6 @@ items:
     - name: Privacy
       href: ../security/privacy/learn/admin/toc.yml
       topicHref: ../security/privacy/learn/implementation-guide.md
-    - name: Tilbud/Sync
-      topicHref: ../sale/admin/quote/index.md
-
-    - name: Workflow
-      topicHref: ../sale/admin/create-sales-guide.md
-      items:
-      - name: Salgsguide
-        topicHref: ../sale/admin/create-sales-guide.md
-      - name: Projektguide
-        topicHref: ../project/admin/create-project-guide.md
 
     - name: Brugerdefinerede objekter
       href: ../custom-objects/learn/toc.yml
@@ -126,9 +116,6 @@ items:
     - name: CRMScript
       href: ../automation/crmscript/learn/toc.yml
       topicHref: ../automation/crmscript/learn/index.md
-
-    - name: Sager
-      topicHref: ../request/admin/index.md
 
     - name: E-mail
       href: ../email/service/learn/toc.yml

--- a/docs/de/admin/lists/learn/toc.yml
+++ b/docs/de/admin/lists/learn/toc.yml
@@ -39,8 +39,6 @@ items:
   items:
   - name: Überblick
     href: specialized-lists.md
-  - name: Dokumentvorlage
-    topicHref: ../../../document/templates/learn/index.md
   - name: E-Mail-Vorlage
     href: email-template.md
     items:
@@ -52,23 +50,8 @@ items:
     - name: Typ der Folgeaufgabe hinzufügen
       href: adding-items-to-follow-up-type-list.md
 
-  - name: Verkauf
-    topicHref: ../../../sale/admin/index.md
-    items:
-    - name: Verkaufsstufe hinzufügen
-      topicHref: ../../../sale/admin/sale-stage.md
-    - name: Verkaufstyp hinzufügen
-      topicHref: ../../../sale/admin/sale-type.md
-    - name: Verkauf - Betragsklasse hinzufügen
-      href: sale-amount-class.md
-
-  - name: Projekt
-    topicHref: ../../../project/admin/index.md
-    items:
-    - name: Projektstatus hinzufügen
-      topicHref: ../../../project/admin/project-status.md
-    - name: Projekttyp hinzufügen
-      topicHref: ../../../project/admin/project-type.md
+  - name: Verkauf - Betragsklasse hinzufügen
+    href: sale-amount-class.md
 
   - name: Allgemein
     topicHref: country.md

--- a/docs/de/learn/toc.yml
+++ b/docs/de/learn/toc.yml
@@ -90,16 +90,6 @@ items:
     - name: Datenschutz
       href: ../security/privacy/learn/admin/toc.yml
       topicHref: ../security/privacy/learn/implementation-guide.md
-    - name: Angebot/Synchronisierung
-      topicHref: ../sale/admin/quote/index.md
-
-    - name: Workflow
-      topicHref: ../sale/admin/create-sales-guide.md
-      items:
-      - name: Verkaufsleitfaden
-        topicHref: ../sale/admin/create-sales-guide.md
-      - name: Projektleitfaden
-        topicHref: ../project/admin/create-project-guide.md
 
     - name: Benutzerdefinierte Objekte
       href: ../custom-objects/learn/toc.yml
@@ -126,9 +116,6 @@ items:
     - name: CRMScript
       href: ../automation/crmscript/learn/toc.yml
       topicHref: ../automation/crmscript/learn/index.md
-
-    - name: Anfragen
-      topicHref: ../request/admin/index.md
 
     - name: E-Mail
       href: ../email/service/learn/toc.yml

--- a/docs/en/admin/lists/learn/toc.yml
+++ b/docs/en/admin/lists/learn/toc.yml
@@ -39,8 +39,6 @@ items:
   items:
   - name: Overview
     href: specialized-lists.md
-  - name: Document template
-    topicHref: ../../../document/templates/learn/index.md
   - name: Email template
     href: email-template.md
     items:
@@ -52,23 +50,8 @@ items:
     - name: Add follow-up type
       href: adding-items-to-follow-up-type-list.md
 
-  - name: Sale
-    topicHref: ../../../sale/admin/index.md
-    items:
-    - name: Add sale stage
-      topicHref: ../../../sale/admin/sale-stage.md
-    - name: Add sale type
-      topicHref: ../../../sale/admin/sale-type.md
-    - name: Add sale amount class
-      href: sale-amount-class.md
-
-  - name: Project
-    topicHref: ../../../project/admin/index.md 
-    items:
-    - name: Add project status
-      topicHref: ../../../project/admin/project-status.md
-    - name: Add project type
-      topicHref: ../../../project/admin/project-type.md
+  - name: Add sale amount class
+    href: sale-amount-class.md 
 
   - name: General
     topicHref: country.md

--- a/docs/en/learn/toc.yml
+++ b/docs/en/learn/toc.yml
@@ -90,16 +90,6 @@ items:
     - name: Privacy
       href: ../security/privacy/learn/admin/toc.yml
       topicHref: ../security/privacy/learn/implementation-guide.md
-    - name: Quote/Sync
-      topicHref: ../sale/admin/quote/index.md
-
-    - name: Workflow
-      topicHref: ../sale/admin/create-sales-guide.md
-      items:
-      - name: Sales guide
-        topicHref: ../sale/admin/create-sales-guide.md
-      - name: Project guide
-        topicHref: ../project/admin/create-project-guide.md
 
     - name: Custom objects
       href: ../custom-objects/learn/toc.yml
@@ -126,9 +116,6 @@ items:
     - name: CRMScript
       href: ../automation/crmscript/learn/toc.yml
       topicHref: ../automation/crmscript/learn/index.md
-
-    - name: Requests
-      topicHref: ../request/admin/index.md 
 
     - name: Email
       href: ../email/service/learn/toc.yml

--- a/docs/nl/admin/lists/learn/toc.yml
+++ b/docs/nl/admin/lists/learn/toc.yml
@@ -39,8 +39,6 @@ items:
   items:
   - name: Overzicht
     href: specialized-lists.md
-  - name: Documentsjabloon
-    topicHref: ../../../document/templates/learn/index.md
   - name: E-mailsjabloon
     href: email-template.md
     items:
@@ -52,23 +50,8 @@ items:
     - name: Type vervolgactiviteit toevoegen
       href: adding-items-to-follow-up-type-list.md
 
-  - name: Verkoop
-    topicHref: ../../../sale/admin/index.md
-    items:
-    - name: Verkoopfase toevoegen
-      topicHref: ../../../sale/admin/sale-stage.md
-    - name: Verkooptype toevoegen
-      topicHref: ../../../sale/admin/sale-type.md
-    - name: Verkoopbedragklasse toevoegen
-      href: sale-amount-class.md
-
-  - name: Project
-    topicHref: ../../../project/admin/index.md
-    items:
-    - name: Projectstatus toevoegen
-      topicHref: ../../../project/admin/project-status.md
-    - name: Projecttype toevoegen
-      topicHref: ../../../project/admin/project-type.md
+  - name: Verkoopbedragklasse toevoegen
+    href: sale-amount-class.md
 
   - name: Algemeen
     topicHref: country.md

--- a/docs/nl/learn/toc.yml
+++ b/docs/nl/learn/toc.yml
@@ -90,16 +90,6 @@ items:
     - name: Privacy
       href: ../security/privacy/learn/admin/toc.yml
       topicHref: ../security/privacy/learn/implementation-guide.md
-    - name: Offerte/Synchroniseren
-      topicHref: ../sale/admin/quote/index.md
-
-    - name: Workflow
-      topicHref: ../sale/admin/create-sales-guide.md
-      items:
-      - name: Verkoopgids
-        topicHref: ../sale/admin/create-sales-guide.md
-      - name: Projectgids
-        topicHref: ../project/admin/create-project-guide.md
 
     - name: Aangepaste objecten
       href: ../custom-objects/learn/toc.yml
@@ -126,9 +116,6 @@ items:
     - name: CRMScript
       href: ../automation/crmscript/learn/toc.yml
       topicHref: ../automation/crmscript/learn/index.md
-
-    - name: Verzoeken
-      topicHref: ../request/admin/index.md
 
     - name: E-mail
       href: ../email/service/learn/toc.yml

--- a/docs/no/admin/lists/learn/toc.yml
+++ b/docs/no/admin/lists/learn/toc.yml
@@ -39,8 +39,6 @@ items:
   items:
   - name: Oversikt
     href: specialized-lists.md
-  - name: Dokumentmal
-    topicHref: ../../../document/templates/learn/index.md
   - name: E-postmal
     href: email-template.md
     items:
@@ -52,23 +50,8 @@ items:
     - name: Legge til oppfølgingstype
       href: adding-items-to-follow-up-type-list.md
 
-  - name: Salg
-    topicHref: ../../../sale/admin/index.md
-    items:
-    - name: Legg til salgsfase
-      topicHref: ../../../sale/admin/sale-stage.md
-    - name: Legg til salgstype
-      topicHref: ../../../sale/admin/sale-type.md
-    - name: Legg til salgsbeløpsklasse
-      href: sale-amount-class.md
-
-  - name: Prosjekt
-    topicHref: ../../../project/admin/index.md
-    items:
-    - name: Legg til prosjektstatus
-      topicHref: ../../../project/admin/project-status.md
-    - name: Legg til prosjekttype
-      topicHref: ../../../project/admin/project-type.md
+  - name: Legg til salgsbeløpsklasse
+    href: sale-amount-class.md
 
   - name: Generelt
     topicHref: country.md

--- a/docs/no/learn/toc.yml
+++ b/docs/no/learn/toc.yml
@@ -90,16 +90,6 @@ items:
     - name: Personvern
       href: ../security/privacy/learn/admin/toc.yml
       topicHref: ../security/privacy/learn/implementation-guide.md
-    - name: Tilbud/Sync
-      topicHref: ../sale/admin/quote/index.md
-
-    - name: Arbeidsflyt
-      topicHref: ../sale/admin/create-sales-guide.md
-      items:
-      - name: Salgsguide
-        topicHref: ../sale/admin/create-sales-guide.md
-      - name: Prosjektguide
-        topicHref: ../project/admin/create-project-guide.md
 
     - name: Egendefinerte objekter
       href: ../custom-objects/learn/toc.yml
@@ -126,9 +116,6 @@ items:
     - name: CRMScript
       href: ../automation/crmscript/learn/toc.yml
       topicHref: ../automation/crmscript/learn/index.md
-
-    - name: Saksbehandling
-      topicHref: ../request/admin/index.md
 
     - name: E-post
       href: ../email/service/learn/toc.yml

--- a/docs/sv/admin/lists/learn/toc.yml
+++ b/docs/sv/admin/lists/learn/toc.yml
@@ -39,8 +39,6 @@ items:
   items:
   - name: Översikt
     href: specialized-lists.md
-  - name: Dokumentmall
-    topicHref: ../../../document/templates/learn/index.md
   - name: E-post - mall
     href: email-template.md
     items:
@@ -52,23 +50,8 @@ items:
     - name: Lägga till händelsetyp
       href: adding-items-to-follow-up-type-list.md
 
-  - name: Försäljning
-    topicHref: ../../../sale/admin/index.md
-    items:
-    - name: Lägga till försäljningsfas
-      topicHref: ../../../sale/admin/sale-stage.md
-    - name: Lägga till försäljningstyp
-      topicHref: ../../../sale/admin/sale-type.md
-    - name: Lägga till beloppsklass för försäljning
-      href: sale-amount-class.md
-
-  - name: Projekt
-    topicHref: ../../../project/admin/index.md
-    items:
-    - name: Lägga till projektstatus
-      topicHref: ../../../project/admin/project-status.md
-    - name: Lägga till projekttyp
-      topicHref: ../../../project/admin/project-type.md
+  - name: Lägga till beloppsklass för försäljning
+    href: sale-amount-class.md
 
   - name: Allmänt
     topicHref: country.md

--- a/docs/sv/learn/toc.yml
+++ b/docs/sv/learn/toc.yml
@@ -90,16 +90,6 @@ items:
     - name: Integritet
       href: ../security/privacy/learn/admin/toc.yml
       topicHref: ../security/privacy/learn/implementation-guide.md
-    - name: Offert/Synk
-      topicHref: ../sale/admin/quote/index.md
-
-    - name: Arbetsflöde
-      topicHref: ../sale/admin/create-sales-guide.md
-      items:
-      - name: Försäljningsguide
-        topicHref: ../sale/admin/create-sales-guide.md
-      - name: Projektguide
-        topicHref: ../project/admin/create-project-guide.md
 
     - name: Egendefinierade objekt
       href: ../custom-objects/learn/toc.yml
@@ -126,9 +116,6 @@ items:
     - name: CRMScript
       href: ../automation/crmscript/learn/toc.yml
       topicHref: ../automation/crmscript/learn/index.md
-
-    - name: Ärenden
-      topicHref: ../request/admin/index.md
 
     - name: E-post
       href: ../email/service/learn/toc.yml


### PR DESCRIPTION
When listed more than once in the same toc (except for direct items), the extra topicHref produces two breadcrumb entries like this 
<img width="836" height="95" alt="image" src="https://github.com/user-attachments/assets/cae6d6a1-ea8f-43a9-96fa-426fc31a745f" />
