### PR TITLE
#2151 Remove tip about scanning QR code in mobile

### DIFF
--- a/docs/da/search-options/learn/find-screen.md
+++ b/docs/da/search-options/learn/find-screen.md
@@ -49,7 +49,7 @@ Der er nærmest ingen grænser for, hvad du kan søge efter i SuperOffice CRM. I
 > [!TIP]
 > Hvis du for eksempel vil søge efter alle firmaer, kan du bruge procenttegnet (%), når du tilføjer [søgekriterier][3] for **Firma**.
 
-## <a id="or"></a>Udvid din søgning ved hjælp af QR-funktionen
+## <a id="or"></a>Udvid din søgning ved hjælp af OR-funktionen
 
 Funktionen Find gør det muligt for dig at udføre en søgning ved at kombinere søgekriterier med værdioperatoren "ELLER" mellem dem. På denne måde kan du søge efter to sæt uafhængige data og gemme dem i ét udvalg.
 

--- a/docs/da/search-options/learn/find-screen.md
+++ b/docs/da/search-options/learn/find-screen.md
@@ -49,7 +49,7 @@ Der er nærmest ingen grænser for, hvad du kan søge efter i SuperOffice CRM. I
 > [!TIP]
 > Hvis du for eksempel vil søge efter alle firmaer, kan du bruge procenttegnet (%), når du tilføjer [søgekriterier][3] for **Firma**.
 
-## <a id="or"></a>Udvid din søgning ved hjælp af OR-funktionen
+## <a id="or"></a>Udvid din søgning ved hjælp af ELLER-funktionen
 
 Funktionen Find gør det muligt for dig at udføre en søgning ved at kombinere søgekriterier med værdioperatoren "ELLER" mellem dem. På denne måde kan du søge efter to sæt uafhængige data og gemme dem i ét udvalg.
 

--- a/docs/en/mobile/superoffice-mobile/contact/scan-business-card.md
+++ b/docs/en/mobile/superoffice-mobile/contact/scan-business-card.md
@@ -4,7 +4,7 @@ title: Scan a business card
 description: How do I automatically create a new contact in the Mobile CRM app from a business card?
 keywords: business card, contact
 author: Bergfrid Dias
-date: 06.10.2025
+date: 08.25.2025
 version: 11.1
 content_type: howto
 platform: mobile
@@ -29,9 +29,6 @@ Do you receive many business cards from prospects and customers? The fastest way
 1. Tap **+** and select **Scan business card**.
 
 1. When the phone's camera opens, take a picture of the business card and tap <i class="ph ph-check" aria-label="Check"></i>.
-
-    > [!TIP]
-    > Mobile CRM also recognizes QR codes.
 
 1. If Mobile CRM recognizes a company name that already exists in SuperOffice CRM, you can choose between these options: **Add contact to company** that exists in the system or **Add  to a different company**. Otherwise you will get the option **Add new contact and company**.
 


### PR DESCRIPTION
Discovered a typo on the Danish Find screen where it says "QR" but should say "OR", or rather the localized word "ELLER".