### PR TITLE
#2165 Insert redirect_from for virtual netserver folder

### DIFF
--- a/docs/en/api/archive-providers/add-columns.md
+++ b/docs/en/api/archive-providers/add-columns.md
@@ -10,6 +10,7 @@ category: api
 topic: archive providers
 deployment: online
 platform: web
+redirect_from: /en/api/netserver/archive-providers/add-columns
 ---
 
 # Add columns to archive providers

--- a/docs/en/api/archive-providers/aggregate-groupby.md
+++ b/docs/en/api/archive-providers/aggregate-groupby.md
@@ -8,6 +8,7 @@ keywords: aggregate function, GroupBy
 content_type: howto
 category: api
 topic: archive providers
+redirect_from: /en/api/netserver/archive-providers/aggregate-groupby
 ---
 
 # Structured aggregation output with GroupBy

--- a/docs/en/api/archive-providers/architecture.md
+++ b/docs/en/api/archive-providers/architecture.md
@@ -6,6 +6,7 @@ keywords:
 content_type: concept
 category: api
 topic: archive providers
+redirect_from: /en/api/netserver/archive-providers/architecture
 ---
 
 # Archive providers - architecture

--- a/docs/en/api/archive-providers/base-and-helper-classes.md
+++ b/docs/en/api/archive-providers/base-and-helper-classes.md
@@ -7,6 +7,7 @@ keywords: IArchiveProvider
 content_type: concept
 category: api
 topic: archive providers
+redirect_from: /en/api/netserver/archive-providers/base-and-helper-classes
 ---
 
 # Base and helper classes

--- a/docs/en/api/archive-providers/create-plugin.md
+++ b/docs/en/api/archive-providers/create-plugin.md
@@ -7,6 +7,7 @@ keywords:
 content_type: howto
 category: api
 topic: archive providers
+redirect_from: /en/api/netserver/archive-providers/create-plugin
 ---
 
 # Create your own archive provider

--- a/docs/en/api/archive-providers/data-aggregation.md
+++ b/docs/en/api/archive-providers/data-aggregation.md
@@ -8,6 +8,7 @@ keywords: data aggregation, aggregate function
 content_type: concept
 category: api
 topic: archive providers
+redirect_from: /en/api/netserver/archive-providers/data-aggregation
 ---
 
 # Data aggregation

--- a/docs/en/api/archive-providers/data-classes.md
+++ b/docs/en/api/archive-providers/data-classes.md
@@ -7,6 +7,7 @@ keywords: ArchiveColumnInfo, ArchiveEntityInfo, ArchiveRestrictionInfo, ArchiveR
 content_type: concept
 category: api
 topic: archive providers
+redirect_from: /en/api/netserver/archive-providers/data-classes
 ---
 
 # Data classes

--- a/docs/en/api/archive-providers/encoded-values.md
+++ b/docs/en/api/archive-providers/encoded-values.md
@@ -8,6 +8,7 @@ keywords: DisplayValue
 content_type: concept
 category: api
 topic: archive providers
+redirect_from: /en/api/netserver/archive-providers/encoded-values
 ---
 
 # Encoded values

--- a/docs/en/api/archive-providers/extenders.md
+++ b/docs/en/api/archive-providers/extenders.md
@@ -6,6 +6,7 @@ keywords: archive extender
 content_type: concept
 category: api
 topic: archive providers
+redirect_from: /en/api/netserver/archive-providers/extenders
 ---
 
 # Extenders

--- a/docs/en/api/archive-providers/how-to-query.md
+++ b/docs/en/api/archive-providers/how-to-query.md
@@ -8,6 +8,7 @@ keywords: archive provider query, query database
 content_type: howto
 category: api
 topic: archive providers
+redirect_from: /en/api/netserver/archive-providers/how-to-query
 ---
 
 # How to perform an archive provider query

--- a/docs/en/api/archive-providers/howto/diary/index.md
+++ b/docs/en/api/archive-providers/howto/diary/index.md
@@ -10,6 +10,7 @@ topic: archive providers
 redirect_from:
   - /en/diary/howto/archive/index
   - /en/diary/howto/archive/invitation-archive
+  - /en/api/netserver/archive-providers/howto/diary/index
 ---
 
 # Diary - archive

--- a/docs/en/api/archive-providers/howto/diary/invitation-archive.md
+++ b/docs/en/api/archive-providers/howto/diary/invitation-archive.md
@@ -8,6 +8,7 @@ date: 11.04.2021
 content_type: howto
 category: api
 topic: archive providers
+redirect_from: /en/api/netserver/archive-providers/howto/diary/invitation-archive
 ---
 
 # Invitation Archive

--- a/docs/en/api/archive-providers/index.md
+++ b/docs/en/api/archive-providers/index.md
@@ -8,6 +8,7 @@ keywords: archive provider, NetServer, search
 content_type: concept
 category: api
 topic: archive providers
+redirect_from: /en/api/netserver/archive-providers/index
 ---
 
 # NetServer archive providers

--- a/docs/en/api/archive-providers/interfaces.md
+++ b/docs/en/api/archive-providers/interfaces.md
@@ -7,6 +7,7 @@ keywords:
 content_type: concept
 category: api
 topic: archive providers
+redirect_from: /en/api/netserver/archive-providers/interfaces
 ---
 
 # Interface definition and composition

--- a/docs/en/api/archive-providers/joiners.md
+++ b/docs/en/api/archive-providers/joiners.md
@@ -6,6 +6,7 @@ keywords: Joiner class, joiners
 content_type: concept
 category: api
 topic: archive providers
+redirect_from: /en/api/netserver/archive-providers/joiners
 ---
 
 # Joiners

--- a/docs/en/api/archive-providers/metadata.md
+++ b/docs/en/api/archive-providers/metadata.md
@@ -7,6 +7,7 @@ keywords: archive provider column list, GetAvailableColumns
 content_type: concept
 category: api
 topic: archive providers
+redirect_from: /en/api/netserver/archive-providers/metadata
 ---
 
 # Metadata

--- a/docs/en/api/archive-providers/nested-aggregate-functions.md
+++ b/docs/en/api/archive-providers/nested-aggregate-functions.md
@@ -8,6 +8,7 @@ keywords: aggregate function
 content_type: howto
 category: api
 topic: archive providers
+redirect_from: /en/api/netserver/archive-providers/nested-aggregate-functions
 ---
 
 # Nested aggregate functions

--- a/docs/en/api/archive-providers/providers.md
+++ b/docs/en/api/archive-providers/providers.md
@@ -6,6 +6,7 @@ keywords: IArchiveProvider, QueryProvider, provider
 content_type: concept
 category: api
 topic: archive providers
+redirect_from: /en/api/netserver/archive-providers/providers
 ---
 
 # Providers

--- a/docs/en/api/archive-providers/restriction-types.md
+++ b/docs/en/api/archive-providers/restriction-types.md
@@ -6,6 +6,7 @@ keywords: RestrictionType, restrict archive provider, archive provider restricti
 content_type: reference
 category: api
 topic: archive providers
+redirect_from: /en/api/netserver/archive-providers/restriction-types
 ---
 
 # Archive Provider Restriction Types

--- a/docs/en/api/archive-providers/scenarios.md
+++ b/docs/en/api/archive-providers/scenarios.md
@@ -7,6 +7,7 @@ keywords: IArchiveProvider interface, archive provider - client interaction
 content_type: concept
 category: api
 topic: archive providers
+redirect_from: /en/api/netserver/archive-providers/scenarios
 ---
 
 # Client usage scenarios

--- a/docs/en/api/bulk-operations/bulk-update/entities-field-types.md
+++ b/docs/en/api/bulk-operations/bulk-update/entities-field-types.md
@@ -10,6 +10,7 @@ category: api
 topic: bulk update
 deployment: online
 platform: web
+redirect_from: /en/api/netserver/bulk-operations/bulk-update/entities-field-types
 ---
 
 # Entities and field types

--- a/docs/en/api/bulk-operations/bulk-update/field-value-info.md
+++ b/docs/en/api/bulk-operations/bulk-update/field-value-info.md
@@ -10,6 +10,7 @@ category: api
 topic: bulk update
 deployment: online
 platform: web
+redirect_from: /en/api/netserver/bulk-operations/bulk-update/field-value-info
 ---
 
 # BulkUpdateSystem FieldValueInfo

--- a/docs/en/api/bulk-operations/bulk-update/index.md
+++ b/docs/en/api/bulk-operations/bulk-update/index.md
@@ -10,6 +10,7 @@ category: api
 topic: bulk update
 deployment: online
 platform: web
+redirect_from: /en/api/netserver/bulk-operations/bulk-update/index
 ---
 
 # Bulk Update API

--- a/docs/en/api/bulk-operations/bulk-update/ns-core-examples.md
+++ b/docs/en/api/bulk-operations/bulk-update/ns-core-examples.md
@@ -10,6 +10,7 @@ category: api
 topic: bulk update
 deployment: online
 platform: web
+redirect_from: /en/api/netserver/bulk-operations/bulk-update/ns-core-examples
 ---
 
 # Bulk update examples using NetServer Core API

--- a/docs/en/api/bulk-operations/bulk-update/operations-and-values.md
+++ b/docs/en/api/bulk-operations/bulk-update/operations-and-values.md
@@ -10,6 +10,7 @@ category: api
 topic: bulk update
 deployment: online
 platform: web
+redirect_from: /en/api/netserver/bulk-operations/bulk-update/operations-and-values
 ---
 
 # Operations and values

--- a/docs/en/api/bulk-operations/bulk-update/using-bulk-update.md
+++ b/docs/en/api/bulk-operations/bulk-update/using-bulk-update.md
@@ -10,6 +10,7 @@ category: api
 topic: bulk update
 deployment: online
 platform: web
+redirect_from: /en/api/netserver/bulk-operations/bulk-update/using-bulk-update
 ---
 
 # Practical details - how to use Bulk Update API

--- a/docs/en/api/bulk-operations/index.md
+++ b/docs/en/api/bulk-operations/index.md
@@ -4,6 +4,7 @@ description: How to insert, update and delete large numbers of records in bulk.
 author: AnthonyYates
 date: 02.29.2021
 keywords: data-access, bulk-update, mass-operations
+redirect_from: /en/api/netserver/bulk-operations/index
 ---
 
 # Bulk Operations

--- a/docs/en/api/bulk-operations/mass-operations/delete.md
+++ b/docs/en/api/bulk-operations/mass-operations/delete.md
@@ -8,6 +8,7 @@ version: 9.2 R04
 content_type: howto
 category: api
 topic: mass operations
+redirect_from: /en/api/netserver/bulk-operations/mass-operations/delete
 ---
 
 <!-- markdownlint-disable-file MD051 -->

--- a/docs/en/api/bulk-operations/mass-operations/index.md
+++ b/docs/en/api/bulk-operations/mass-operations/index.md
@@ -8,6 +8,7 @@ version: 9.2 R04
 content_type: concept
 category: api
 topic: mass operations
+redirect_from: /en/api/netserver/bulk-operations/mass-operations/index
 ---
 
 # Mass Operations

--- a/docs/en/api/bulk-operations/mass-operations/insert.md
+++ b/docs/en/api/bulk-operations/mass-operations/insert.md
@@ -8,6 +8,7 @@ version: 9.2 R04
 content_type: howto
 category: api
 topic: mass operations
+redirect_from: /en/api/netserver/bulk-operations/mass-operations/insert
 ---
 
 <!-- markdownlint-disable-file MD051 -->

--- a/docs/en/api/bulk-operations/mass-operations/protected-tables.md
+++ b/docs/en/api/bulk-operations/mass-operations/protected-tables.md
@@ -7,6 +7,7 @@ date: 01.02.2021
 content_type: reference
 category: api
 topic: mass operations
+redirect_from: /en/api/netserver/bulk-operations/mass-operations/protected-tables
 ---
 
 # Protected tables

--- a/docs/en/api/bulk-operations/mass-operations/truncate.md
+++ b/docs/en/api/bulk-operations/mass-operations/truncate.md
@@ -8,6 +8,7 @@ version: 9.2 R04
 content_type: howto
 category: api
 topic: mass operations
+redirect_from: /en/api/netserver/bulk-operations/mass-operations/truncate
 ---
 
 <!-- markdownlint-disable-file MD051 -->

--- a/docs/en/api/bulk-operations/mass-operations/upsert.md
+++ b/docs/en/api/bulk-operations/mass-operations/upsert.md
@@ -8,6 +8,7 @@ version: 9.2 R04
 content_type: howto
 category: api
 topic: mass operations
+redirect_from: /en/api/netserver/bulk-operations/mass-operations/upsert
 ---
 
 <!-- markdownlint-disable-file MD051 -->

--- a/docs/en/api/caching/associate-cache.md
+++ b/docs/en/api/caching/associate-cache.md
@@ -6,6 +6,7 @@ author: Bergfrid Dias
 date: 02.22.2022
 keywords: cache, list, AssociateCache
 content_type: concept
+redirect_from: /en/api/netserver/caching/associate-cache
 ---
 
 # AssociateCache

--- a/docs/en/api/caching/cached-tables.md
+++ b/docs/en/api/caching/cached-tables.md
@@ -8,6 +8,7 @@ keywords: database
 content_type: concept
 deployment: onsite
 platform: win
+redirect_from: /en/api/netserver/caching/cached-tables
 ---
 
 # Cached tables

--- a/docs/en/api/caching/category-cache.md
+++ b/docs/en/api/caching/category-cache.md
@@ -6,6 +6,7 @@ author: Bergfrid Dias
 date: 02.22.2022
 keywords: cache, list, CategoryCache
 content_type: concept
+redirect_from: /en/api/netserver/caching/category-cache
 ---
 
 # CategoryCache

--- a/docs/en/api/caching/flush-cache.md
+++ b/docs/en/api/caching/flush-cache.md
@@ -6,6 +6,7 @@ author: Eivind Fasting
 date: 08.14.2024
 keywords: cache, flush
 content_type: concept
+redirect_from: /en/api/netserver/caching/flush-cache
 ---
 
 # Flush Cache

--- a/docs/en/api/caching/index.md
+++ b/docs/en/api/caching/index.md
@@ -6,6 +6,7 @@ author: Bergfrid Dias
 date: 02.22.2022
 keywords: cache, performance
 content_type: concept
+redirect_from: /en/api/netserver/caching/index
 ---
 
 # Caching

--- a/docs/en/api/caching/superoffice-crm-cache.md
+++ b/docs/en/api/caching/superoffice-crm-cache.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 02.22.2022
 keywords: cache
 content_type: reference
+redirect_from: /en/api/netserver/caching/superoffice-crm-cache
 ---
 
 # SuperOffice.CRM.Cache

--- a/docs/en/api/caching/superoffice-crm-security.md
+++ b/docs/en/api/caching/superoffice-crm-security.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords: cache
 content_type: reference
+redirect_from: /en/api/netserver/caching/superoffice-crm-security
 ---
 
 # SuperOffice.CRM.Security

--- a/docs/en/api/config/accessgateway.md
+++ b/docs/en/api/config/accessgateway.md
@@ -6,6 +6,7 @@ date: 12.08.2021
 author: Bergfrid Dias
 keywords: config, NetServer, web.config, AccessGateway, BaseUrl
 content_type: reference
+redirect_from: /en/api/netserver/config/accessgateway
 ---
 
 # NetServer AccessGateway element

--- a/docs/en/api/config/batchservice.md
+++ b/docs/en/api/config/batchservice.md
@@ -8,6 +8,7 @@ keywords: NetServer, web.config, BatchService, DiagnosticsWebUri
 content_type: reference
 deployment: onsite
 platform: win
+redirect_from: /en/api/netserver/config/batchservice
 ---
 
 # NetServer BatchService element

--- a/docs/en/api/config/client.md
+++ b/docs/en/api/config/client.md
@@ -8,6 +8,7 @@ keywords: NetServer, web.config, ClientConfigurationProvider, Client, export
 content_type: reference
 deployment: onsite
 platform: web
+redirect_from: /en/api/netserver/config/client
 ---
 
 # NetServer Client element (SuperOffice only)

--- a/docs/en/api/config/clientconfigurationprovider.md
+++ b/docs/en/api/config/clientconfigurationprovider.md
@@ -8,6 +8,7 @@ keywords: web.config, ClientConfigurationProvider, FilePath, cache, CustomPath
 content_type: reference
 deployment: onsite
 platform: web
+redirect_from: /en/api/netserver/config/clientconfigurationprovider
 ---
 
 # NetServer ClientConfigurationProvider element (SuperOffice only)

--- a/docs/en/api/config/cloud.md
+++ b/docs/en/api/config/cloud.md
@@ -8,6 +8,7 @@ keywords: web.config, Cloud element, TemplatePath, ArchivePath, DefaultCallbackU
 content_type: reference
 deployment: online
 platform: web
+redirect_from: /en/api/netserver/config/cloud
 ---
 
 # NetServer Cloud element (SuperOffice only)

--- a/docs/en/api/config/csssprite.md
+++ b/docs/en/api/config/csssprite.md
@@ -8,6 +8,7 @@ keywords: NetServer, web.config, CssSprite, paths, MaxHeight
 content_type: reference
 deployment: onsite
 platform: web
+redirect_from: /en/api/netserver/config/csssprite
 ---
 
 # NetServer CssSprite element (SuperOffice only)

--- a/docs/en/api/config/customerservice.md
+++ b/docs/en/api/config/customerservice.md
@@ -6,6 +6,7 @@ date: 12.08.2021
 author: Bergfrid Dias
 keywords: config, NetServer, web.config, CustomerService, CsCgiUrl, CsCgiUrlDirect, CsCgiUrlInternal, CsDomain, CsPassword, CsUserName, ImpersonateCsUser, CS, base path
 content_type: reference
+redirect_from: /en/api/netserver/config/customerservice
 ---
 
 # NetServer CustomerService element

--- a/docs/en/api/config/customproxy.md
+++ b/docs/en/api/config/customproxy.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, CustomProxy, CustomProxyHost, CustomProxyPort, CustomProxySSLPort, UseCustomProxyForIntegrationServer, UseCustomProxyForPublicAccess, UseCustomProxyForWebhooks
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/customproxy
 ---
 
 # NetServer CustomProxy element

--- a/docs/en/api/config/data.md
+++ b/docs/en/api/config/data.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, Database, CommandTimeout, ConnectionString, DatabaseMajor, DatabaseMinor, DatabaseName, DefaultReadUncommitted, DisableSqlTrackingComments, DisableUserInSqlTrackingComments, DynamicLoadedConnectionType, DynamicLoadedDataBaseDriver, ImpersonateDatabaseUser, Server, TablePrefix, Explicit, PartnerAllowed, EmployeeAllowed, AnonymousAllowed, DBUser, DBPassword, CommonDBConnection, Session, Mode, ReauthenticateOnDeserialization, CacheCheckInterval, ForceCacheRefreshInterval, SystemAllowed
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/data
 ---
 
 # NetServer Data element

--- a/docs/en/api/config/diagnostics.md
+++ b/docs/en/api/config/diagnostics.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, Diagnostics, log, CheckBrowserVersion, EnableResourceTracer, EnableScaffolding, EnableStackTracing, LogDebug, LogError, LogWarning, LogFolder, LoggedServices, LogInformation, LogWarning, LogTrace, LogToFile, LogToSuperOffice, LogServiceCalls, AppInsightInstrumentationKey, EnableQAAttributes, LogLongQueries, ShowExceptionsFromBackend
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/diagnostics
 ---
 
 # NetServer Diagnostics element

--- a/docs/en/api/config/documents.md
+++ b/docs/en/api/config/documents.md
@@ -9,6 +9,7 @@ content_type: reference
 deployment: onsite
 audience: api
 audience_tooltip: SuperOffice APIs and database
+redirect_from: /en/api/netserver/config/documents
 ---
 
 # NetServer Documents element

--- a/docs/en/api/config/downloads.md
+++ b/docs/en/api/config/downloads.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, WebTools, Downloads, DownloadFolder, NewTrayAppUrl, ReportingInterval, WebSiteEndPoint, WebToolVersion
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/downloads
 ---
 
 # NetServer Downloads element (SuperOffice only)

--- a/docs/en/api/config/factory.md
+++ b/docs/en/api/config/factory.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: NetServer, web.config, Factory, CustomFactories, DynamicLoad
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/factory
 ---
 
 # NetServer Factory element

--- a/docs/en/api/config/featuretoggles.md
+++ b/docs/en/api/config/featuretoggles.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, FeatureToggles, State, feature toggles
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/featuretoggles
 ---
 
 # NetServer FeatureToggles element

--- a/docs/en/api/config/globalization.md
+++ b/docs/en/api/config/globalization.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, Globalization, ApplicationCountryCode, AllwaysUseGsmPhoneStyle, UseApplicationCountryForPersons
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/globalization
 ---
 
 # NetServer Globalization element

--- a/docs/en/api/config/googlerecaptcha.md
+++ b/docs/en/api/config/googlerecaptcha.md
@@ -6,6 +6,7 @@ keywords: config, NetServer, web.config, Google reCAPTCHA, GoogleRecaptcha, Secr
 author: Bergfrid Dias
 date: 03.05.2024
 content_type: reference
+redirect_from: /en/api/netserver/config/googlerecaptcha
 ---
 
 # NetServer GoogleRecaptcha element

--- a/docs/en/api/config/index.md
+++ b/docs/en/api/config/index.md
@@ -7,6 +7,7 @@ date: 12.07.2021
 keywords: config, web.config, NetServer
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/index
 ---
 
 # NetServer configuration

--- a/docs/en/api/config/infrastructure.md
+++ b/docs/en/api/config/infrastructure.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, Infrastructure
 content_type: reference
 deployment: online
+redirect_from: /en/api/netserver/config/infrastructure
 ---
 
 # NetServer Infrastructure element

--- a/docs/en/api/config/intellisyncconnector.md
+++ b/docs/en/api/config/intellisyncconnector.md
@@ -8,6 +8,7 @@ keywords: config, NetServer, web.config, SoIntellisyncConnector
 content_type: reference
 deployment: onsite
 version: 6
+redirect_from: /en/api/netserver/config/intellisyncconnector
 ---
 
 # IntellisyncConnector element (Legacy - SuperOffice only)

--- a/docs/en/api/config/mail.md
+++ b/docs/en/api/config/mail.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, Mail, NumberOfDaysToDownload, Reader, Sender
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/mail
 ---
 # NetServer Mail element (SuperOffice only)
 

--- a/docs/en/api/config/messaging.md
+++ b/docs/en/api/config/messaging.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, SuperOffice.CRM.Messaging, SoMessaging.dll, Messaging, BrokerAutoAliveMessage, BrokerBroadcastAddress, BrokerBroadcastPort, BrokerExternalListening, BrokerInternalListening, ClientAutoAliveMessage, ClientAutoCreateBroker, ClientBroadcastAddress, ClientBroadcastPort, ClientListening, MessagingSoAuthentication, MessagingSoPassword, MessagingSoUser
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/messaging
 ---
 
 # NetServer Messaging element

--- a/docs/en/api/config/oidclogin.md
+++ b/docs/en/api/config/oidclogin.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, OidcLogin, OIDC
 content_type: reference
 deployment: online
+redirect_from: /en/api/netserver/config/oidclogin
 ---
 
 # NetServer OidcLogin element

--- a/docs/en/api/config/pocket.md
+++ b/docs/en/api/config/pocket.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, Pocket, AzureNotificationHubConnectionString, AzureNotificationHubName
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/pocket
 ---
 
 # NetServer Pocket element (SuperOffice only)

--- a/docs/en/api/config/reporter.md
+++ b/docs/en/api/config/reporter.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, Reporter, ExePath, ODBC, Timeout
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/reporter
 ---
 
 # NetServer Reporter element

--- a/docs/en/api/config/scripting.md
+++ b/docs/en/api/config/scripting.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, Scripting, EnableScripting, ScriptPath, MaxTimeouts, TimeoutLimit
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/scripting
 ---
 
 # NetServer Scripting element

--- a/docs/en/api/config/security.md
+++ b/docs/en/api/config/security.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, Security, ActiveDirectoryCredentialPlugin, Active Directory, DisableIntegration, Cryptography, SymmetricIV, SymmetricKey, SymmetricSecret, Rijndael, Sentry, SoPasswordCredentialPlugin, DisableUseExternalAssociate, DisableUseInternalAssociate, DisableUseSystemAssociate, session, PriorityInternalAssociate
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/security
 ---
 
 # NetServer Security element

--- a/docs/en/api/config/services.md
+++ b/docs/en/api/config/services.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, Services, web services, ApplicationToken, DefaultMode, RemoteBaseURL, SwitchDefault, SwitchFailover
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/services
 ---
 
 # NetServer Services element

--- a/docs/en/api/config/soformsauthentication.md
+++ b/docs/en/api/config/soformsauthentication.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, SoFormsAuthentication, FormsAuthentication, IgnoreList, Pages, LoginUrl, DefaultUrl, LogoutUrl, PocketCrmLoginPage
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/soformsauthentication
 ---
 
 # NetServer SoFormsAuthentication element

--- a/docs/en/api/config/subclients.md
+++ b/docs/en/api/config/subclients.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, SubClients
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/subclients
 ---
 
 # NetServer SubClients element (SuperOffice only)

--- a/docs/en/api/config/superid.md
+++ b/docs/en/api/config/superid.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, SuperID, TenantKey, TenantId, Environment
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/superid
 ---
 
 # NetServer SuperId element (SuperOffice only)

--- a/docs/en/api/config/suspendedsite.md
+++ b/docs/en/api/config/suspendedsite.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, SuspendedSite, download_baseurl, suspended
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/suspendedsite
 ---
 
 # NetServer SuspendedSite element (SuperOffice only)

--- a/docs/en/api/config/sync.md
+++ b/docs/en/api/config/sync.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, Sync, SoSync, synchronization, SoSyncAdmin, SettingsAbsoluteExpiration, SettingsSlidingExpiration
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/sync
 ---
 
 # NetServer Sync element (legacy SuperOffice only)

--- a/docs/en/api/config/threading.md
+++ b/docs/en/api/config/threading.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, Threading, DisableMultithreading, ForceMultithreading, MaxParellalThreads, single-threaded, multi-threaded, parallel
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/threading
 ---
 
 # NetServer Threading element

--- a/docs/en/api/config/timezone.md
+++ b/docs/en/api/config/timezone.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, TimeZone, ServiceUrl
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/timezone
 ---
 
 # NetServer TimeZone element (SuperOffice only)

--- a/docs/en/api/config/webapi.md
+++ b/docs/en/api/config/webapi.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: config, NetServer, web.config, authentication, WebAPI, AuthorizeWithImplicit, AuthorizeWithTicket, AuthorizeWithUsername, CORSEnable, CORSOrigin, CORS, authorize, authentication, security
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/webapi
 ---
 
 # NetServer WebApi element

--- a/docs/en/api/config/webhooks.md
+++ b/docs/en/api/config/webhooks.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: NetServer, web.config, Webhooks, NumThreads, RequireHttps
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/webhooks
 ---
 
 # NetServer Webhooks element

--- a/docs/en/api/config/webservices.md
+++ b/docs/en/api/config/webservices.md
@@ -7,6 +7,7 @@ author: Bergfrid Dias
 keywords: NetServer, web.config, web services, AllowWebServiceRequests, RemoteBaseURL, RemoveInvalidXMLText, WrapExceptions
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/config/webservices
 ---
 
 # NetServer WebServices element

--- a/docs/en/api/entities/activity-links.md
+++ b/docs/en/api/entities/activity-links.md
@@ -7,6 +7,7 @@ author: AnthonyYates
 date: 11.05.2016
 version: 8.5
 content_type: concept
+redirect_from: /en/api/netserver/entities/activity-links
 ---
 
 # Activity links sub-object on models

--- a/docs/en/api/entities/collections.md
+++ b/docs/en/api/entities/collections.md
@@ -8,6 +8,7 @@ keywords: data access, entity, entities, RDB
 content_type: concept
 deployment: online, onsite
 platform: web, win
+redirect_from: /en/api/netserver/entities/collections
 ---
 
 # Collections

--- a/docs/en/api/entities/create-entity-in-entity.md
+++ b/docs/en/api/entities/create-entity-in-entity.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/entities/create-entity-in-entity
 ---
 
 # Create an Entity through an Entity

--- a/docs/en/api/entities/create-entity.md
+++ b/docs/en/api/entities/create-entity.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/entities/create-entity
 ---
 
 # How to create an Entity

--- a/docs/en/api/entities/delete-entity-from-entity.md
+++ b/docs/en/api/entities/delete-entity-from-entity.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/entities/delete-entity-from-entity
 ---
 
 # Delete an Entity through an Entity

--- a/docs/en/api/entities/delete-entity.md
+++ b/docs/en/api/entities/delete-entity.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/entities/delete-entity
 ---
 
 # Delete an Entity

--- a/docs/en/api/entities/events.md
+++ b/docs/en/api/entities/events.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords: hook
 content_type: concept
+redirect_from: /en/api/netserver/entities/events
 ---
 
 # Events in Entity objects

--- a/docs/en/api/entities/get-entity-from-entity.md
+++ b/docs/en/api/entities/get-entity-from-entity.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/entities/get-entity-from-entity
 ---
 
 # Retrieve an Entity property through an Entity

--- a/docs/en/api/entities/get-entity.md
+++ b/docs/en/api/entities/get-entity.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/entities/get-entity
 ---
 
 # How to retrieve an Entity

--- a/docs/en/api/entities/howto/company/create-contact-entity-in-collection.md
+++ b/docs/en/api/entities/howto/company/create-contact-entity-in-collection.md
@@ -6,7 +6,9 @@ keywords: contact, company, entity, API, collection, ContactCollection
 author: Tony Yates
 date: 05.11.2016
 content_type: howto
-redirect_from: /en/company/howto/entity/create-contact-entity-in-collection
+redirect_from:
+  - /en/company/howto/entity/create-contact-entity-in-collection
+  - /en/api/netserver/entities/howto/company/create-contact-entity-in-collection
 ---
 
 # Create a Contact entity through an entity collection

--- a/docs/en/api/entities/howto/company/create-contact-entity-in-entity.md
+++ b/docs/en/api/entities/howto/company/create-contact-entity-in-entity.md
@@ -6,7 +6,9 @@ keywords: contact, company, entity, API
 author: Tony Yates
 date: 05.11.2016
 content_type: howto
-redirect_from: /en/company/howto/entity/create-contact-entity-in-entity
+redirect_from:
+  - /en/company/howto/entity/create-contact-entity-in-entity
+  - /en/api/netserver/entities/howto/company/create-contact-entity-in-entity
 ---
 
 # Create a Contact entity through an entity

--- a/docs/en/api/entities/howto/company/create-contact-entity.md
+++ b/docs/en/api/entities/howto/company/create-contact-entity.md
@@ -6,7 +6,9 @@ keywords: contact, company, entity, API, assert, SetDefaults
 author: Bergfrid Dias
 date: 02.22.2022
 content_type: howto
-redirect_from: /en/company/howto/entity/create-contact-entity
+redirect_from:
+  - /en/company/howto/entity/create-contact-entity
+  - /en/api/netserver/entities/howto/company/create-contact-entity
 ---
 
 # Create a Contact entity

--- a/docs/en/api/entities/howto/company/get-catlist-generic-provider.md
+++ b/docs/en/api/entities/howto/company/get-catlist-generic-provider.md
@@ -6,7 +6,9 @@ keywords: category, list provider, CategoryList
 author: Tony Yates
 date: 05.11.2016
 content_type: howto
-redirect_from: /en/company/howto/entity/get-catlist-generic-provider
+redirect_from:
+  - /en/company/howto/entity/get-catlist-generic-provider
+  - /en/api/netserver/entities/howto/company/get-catlist-generic-provider
 ---
 
 # Get a CategoryList through generic list providers

--- a/docs/en/api/entities/howto/company/get-catlist-typed-provider.md
+++ b/docs/en/api/entities/howto/company/get-catlist-typed-provider.md
@@ -6,7 +6,9 @@ keywords: category, list provider, CategoryList
 author: Tony Yates
 date: 05.11.2016
 content_type: howto
-redirect_from: /en/company/howto/entity/get-catlist-typed-provider
+redirect_from:
+  - /en/company/howto/entity/get-catlist-typed-provider
+  - /en/api/netserver/entities/howto/company/get-catlist-typed-provider
 ---
 
 # Get a CategoryList through typed list providers

--- a/docs/en/api/entities/howto/company/get-contact-via-entities-layer.md
+++ b/docs/en/api/entities/howto/company/get-contact-via-entities-layer.md
@@ -6,7 +6,9 @@ keywords: contact, company, entity, API, GetFromIdxContactId
 author: Tony Yates
 date: 05.11.2016
 content_type: howto
-redirect_from: /en/company/howto/entity/get-contact-via-entities-layer
+redirect_from:
+  - /en/company/howto/entity/get-contact-via-entities-layer
+  - /en/api/netserver/entities/howto/company/get-contact-via-entities-layer
 ---
 
 # Get a contact through entities layer

--- a/docs/en/api/entities/howto/company/get-interests-for-contact-entity.md
+++ b/docs/en/api/entities/howto/company/get-interests-for-contact-entity.md
@@ -6,7 +6,9 @@ keywords: contact, company, interest, entity, API, ContactInterestHelper, Select
 author: Tony Yates
 date: 05.11.2016
 content_type: howto
-redirect_from: /en/company/howto/entity/get-interests-for-contact-entity
+redirect_from:
+  - /en/company/howto/entity/get-interests-for-contact-entity
+  - /en/api/netserver/entities/howto/company/get-interests-for-contact-entity
 ---
 
 # How to list all selected interests for a contact

--- a/docs/en/api/entities/howto/company/index.md
+++ b/docs/en/api/entities/howto/company/index.md
@@ -6,7 +6,9 @@ keywords: contact, company, entity, API
 author: Bergfrid Skaara Dias
 date: 02.22.2022
 content_type: concept
-redirect_from: /en/company/howto/entity/index
+redirect_from:
+  - /en/company/howto/entity/index
+  - /en/api/netserver/entities/howto/company/index
 ---
 
 # Contact - entity

--- a/docs/en/api/entities/howto/company/set-interest-on-off-entity.md
+++ b/docs/en/api/entities/howto/company/set-interest-on-off-entity.md
@@ -6,7 +6,9 @@ keywords: contact, company, interest, entity, API, ContactInterestHelper, SetIte
 author: Tony Yates
 date: 05.11.2016
 content_type: howto
-redirect_from: /en/company/howto/entity/set-interest-on-off-entity
+redirect_from:
+  - /en/company/howto/entity/set-interest-on-off-entity
+  - /en/api/netserver/entities/howto/company/set-interest-on-off-entity
 ---
 
 # How to set an interest on or off for a contact (data layer)

--- a/docs/en/api/entities/howto/contact/display-image-from-blob-table-entity.md
+++ b/docs/en/api/entities/howto/contact/display-image-from-blob-table-entity.md
@@ -6,7 +6,9 @@ keywords: person, contact, entity, API, BinaryObject, BLOB, image, BinaryObjectR
 author: Bergfrid Skaara Dias
 date: 11.02.2021
 content_type: howto
-redirect_from: /en/contact/howto/entity/display-image-from-blob-table-entity
+redirect_from:
+  - /en/contact/howto/entity/display-image-from-blob-table-entity
+  - /en/api/netserver/entities/howto/contact/display-image-from-blob-table-entity
 ---
 
 # How to display an image from the Blob table (data layer)

--- a/docs/en/api/entities/howto/contact/get-associate-list.md
+++ b/docs/en/api/entities/howto/contact/get-associate-list.md
@@ -6,7 +6,9 @@ keywords: associate, list, GetAssociateList
 author: Tony Yates
 date: 02.22.2022
 content_type: howto
-redirect_from: /en/contact/howto/entity/get-associate-list
+redirect_from:
+  - /en/contact/howto/entity/get-associate-list
+  - /en/api/netserver/entities/howto/contact/get-associate-list
 ---
 
 # Get the associate list

--- a/docs/en/api/entities/howto/contact/get-persons-from-contact-entities.md
+++ b/docs/en/api/entities/howto/contact/get-persons-from-contact-entities.md
@@ -6,7 +6,9 @@ keywords: person, contact, entity, API, PersonCollection
 author: Bergfrid Skaara Dias
 date: 11.02.2021
 content_type: howto
-redirect_from: /en/contact/howto/entity/get-persons-from-contact-entities
+redirect_from:
+  - /en/contact/howto/entity/get-persons-from-contact-entities
+  - /en/api/netserver/entities/howto/contact/get-persons-from-contact-entities
 ---
 
 # Retrieve a list of people using entities

--- a/docs/en/api/entities/howto/contact/index.md
+++ b/docs/en/api/entities/howto/contact/index.md
@@ -6,7 +6,9 @@ keywords: person, contact, entity, API
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: reference
-redirect_from: /en/contact/howto/entity/index
+redirect_from:
+  - /en/contact/howto/entity/index
+  - /en/api/netserver/entities/howto/contact/index
 ---
 
 # Contact - entity

--- a/docs/en/api/entities/howto/contact/update-person-entity.md
+++ b/docs/en/api/entities/howto/contact/update-person-entity.md
@@ -6,7 +6,9 @@ keywords: person, contact, entity, API
 author: Tony Yates
 date: 05.11.2016
 content_type: howto
-redirect_from: /en/contact/howto/entity/update-person-entity
+redirect_from:
+  - /en/contact/howto/entity/update-person-entity
+  - /en/api/netserver/entities/howto/contact/update-person-entity
 ---
 
 # Update a person with a new name, address, position using entities

--- a/docs/en/api/entities/howto/custom-objects/get-udef-field-value.md
+++ b/docs/en/api/entities/howto/custom-objects/get-udef-field-value.md
@@ -8,7 +8,9 @@ keywords: udef, user-defined field, custom field, API
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/custom-objects/udef/howto/entity/get-udef-field-value
+redirect_from:
+  - /en/custom-objects/udef/howto/entity/get-udef-field-value
+  - /en/api/netserver/entities/howto/custom-objects/get-udef-field-value
 ---
 
 # How to get the value of a user-defined field in NetServer

--- a/docs/en/api/entities/howto/custom-objects/index.md
+++ b/docs/en/api/entities/howto/custom-objects/index.md
@@ -8,7 +8,9 @@ keywords: udef, user-defined field, custom field, API
 content_type: concept
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/custom-objects/udef/howto/entity/index
+redirect_from:
+  - /en/custom-objects/udef/howto/entity/index
+  - /en/api/netserver/entities/howto/custom-objects/index
 ---
 
 # Udef - entity layer

--- a/docs/en/api/entities/howto/custom-objects/set-udef-listitem-value.md
+++ b/docs/en/api/entities/howto/custom-objects/set-udef-listitem-value.md
@@ -8,7 +8,9 @@ keywords: udef, user-defined field, custom field, API, UdefHelper, ListTableId, 
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/custom-objects/udef/howto/entity/set-udef-listitem-value
+redirect_from:
+  - /en/custom-objects/udef/howto/entity/set-udef-listitem-value
+  - /en/api/netserver/entities/howto/custom-objects/set-udef-listitem-value
 ---
 
 # How to set a user-defined list item on a Udef field

--- a/docs/en/api/entities/howto/custom-objects/udef-on-contact.md
+++ b/docs/en/api/entities/howto/custom-objects/udef-on-contact.md
@@ -7,7 +7,9 @@ keywords: entity
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/custom-objects/udef/howto/entity/udef-on-contact
+redirect_from:
+  - /en/custom-objects/udef/howto/entity/udef-on-contact
+  - /en/api/netserver/entities/howto/custom-objects/udef-on-contact
 ---
 
 # Udef on contact

--- a/docs/en/api/entities/howto/custom-objects/udefhelper-class.md
+++ b/docs/en/api/entities/howto/custom-objects/udefhelper-class.md
@@ -8,7 +8,9 @@ keywords: udef, user-defined field, custom field, API, UDFHelper, SyncRoot, GetU
 content_type: reference
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/custom-objects/udef/howto/entity/udefhelper-class
+redirect_from:
+  - /en/custom-objects/udef/howto/entity/udefhelper-class
+  - /en/api/netserver/entities/howto/custom-objects/udefhelper-class
 ---
 
 # Complete UDFHelper class and UDFInfo struct source

--- a/docs/en/api/entities/howto/custom-objects/update-udef.md
+++ b/docs/en/api/entities/howto/custom-objects/update-udef.md
@@ -8,7 +8,9 @@ keywords: udef, user-defined field, custom field, API, UdefHelper, UdefLarge, Ud
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/custom-objects/udef/howto/entity/update-udef
+redirect_from:
+  - /en/custom-objects/udef/howto/entity/update-udef
+  - /en/api/netserver/entities/howto/custom-objects/update-udef
 ---
 
 # How to update a Udef field

--- a/docs/en/api/entities/howto/custom-objects/using-udefhelper.md
+++ b/docs/en/api/entities/howto/custom-objects/using-udefhelper.md
@@ -8,7 +8,9 @@ keywords: udef, user-defined field, custom field, API, UDFHelper, UDFSearch, Get
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/custom-objects/udef/howto/entity/using-udefhelper
+redirect_from:
+  - /en/custom-objects/udef/howto/entity/using-udefhelper
+  - /en/api/netserver/entities/howto/custom-objects/using-udefhelper
 ---
 
 # How to use the UDFHelper class

--- a/docs/en/api/entities/howto/diary/accept-invitation-entity.md
+++ b/docs/en/api/entities/howto/diary/accept-invitation-entity.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, API, entity, InvitationProvider, Archive
 author: Bergfrid Skaara Dias
 date: 03.04.2022
 content_type: howto
-redirect_from: /en/diary/howto/entity/accept-invitation-entity
+redirect_from:
+  - /en/diary/howto/entity/accept-invitation-entity
+  - /en/api/netserver/entities/howto/diary/accept-invitation-entity
 ---
 
 # How to accept an invitation (data layer)

--- a/docs/en/api/entities/howto/diary/appointment-matrix.md
+++ b/docs/en/api/entities/howto/diary/appointment-matrix.md
@@ -6,7 +6,9 @@ keywords: entity
 author: Bergfrid Skaara Dias
 date: 03.04.2022
 content_type: howto
-redirect_from: /en/diary/howto/entity/appointment-matrix
+redirect_from:
+  - /en/diary/howto/entity/appointment-matrix
+  - /en/api/netserver/entities/howto/diary/appointment-matrix
 ---
 
 # AppointmentMatrix

--- a/docs/en/api/entities/howto/diary/create-apt-entity-in-collection.md
+++ b/docs/en/api/entities/howto/diary/create-apt-entity-in-collection.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, API, entity, collection, AppointmentColl
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/diary/howto/entity/create-apt-entity-in-collection
+redirect_from:
+  - /en/diary/howto/entity/create-apt-entity-in-collection
+  - /en/api/netserver/entities/howto/diary/create-apt-entity-in-collection
 ---
 
 # Create an Appointment entity through an entity collection

--- a/docs/en/api/entities/howto/diary/create-apt-entity-in-entity.md
+++ b/docs/en/api/entities/howto/diary/create-apt-entity-in-entity.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, API, entity
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/diary/howto/entity/create-apt-entity-in-entity
+redirect_from:
+  - /en/diary/howto/entity/create-apt-entity-in-entity
+  - /en/api/netserver/entities/howto/diary/create-apt-entity-in-entity
 ---
 
 # Create an Appointment entity through an entity

--- a/docs/en/api/entities/howto/diary/create-apt-entity.md
+++ b/docs/en/api/entities/howto/diary/create-apt-entity.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, API, entity, SuperOffice.CRM.Entities
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/diary/howto/entity/create-apt-entity
+redirect_from:
+  - /en/diary/howto/entity/create-apt-entity
+  - /en/api/netserver/entities/howto/diary/create-apt-entity
 ---
 
 # Create an Appointment entity

--- a/docs/en/api/entities/howto/diary/create-invitation-entity.md
+++ b/docs/en/api/entities/howto/diary/create-invitation-entity.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, API, entity, ParticipantInfo, AddPartici
 author: Bergfrid Skaara Dias
 date: 03.04.2022
 content_type: howto
-redirect_from: /en/diary/howto/entity/create-invitation-entity
+redirect_from:
+  - /en/diary/howto/entity/create-invitation-entity
+  - /en/api/netserver/entities/howto/diary/create-invitation-entity
 ---
 
 # How to create an invitation (data layer)

--- a/docs/en/api/entities/howto/diary/create-recurring-appointment-entity.md
+++ b/docs/en/api/entities/howto/diary/create-recurring-appointment-entity.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, API, entity, AppointmentMatrix, Recurren
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/diary/howto/entity/create-recurring-appointment-entity
+redirect_from:
+  - /en/diary/howto/entity/create-recurring-appointment-entity
+  - /en/api/netserver/entities/howto/diary/create-recurring-appointment-entity
 ---
 
 # How to create a recurring appointment (data layer)

--- a/docs/en/api/entities/howto/diary/index.md
+++ b/docs/en/api/entities/howto/diary/index.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, API, entity
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: reference
-redirect_from: /en/diary/howto/entity/index
+redirect_from:
+  - /en/diary/howto/entity/index
+  - /en/api/netserver/entities/howto/diary/index
 ---
 
 # Diary - entity

--- a/docs/en/api/entities/howto/sale/index.md
+++ b/docs/en/api/entities/howto/sale/index.md
@@ -7,7 +7,9 @@ author: Bergfrid Skaara Dias
 date: 06.02.2023
 version: 10
 content_type: howto
-redirect_from: /en/sale/howto/entity/index
+redirect_from:
+  - /en/sale/howto/entity/index
+  - /en/api/netserver/entities/howto/sale/index
 ---
 
 # Sale - entity

--- a/docs/en/api/entities/howto/sale/link-sale-to-appointment.md
+++ b/docs/en/api/entities/howto/sale/link-sale-to-appointment.md
@@ -7,7 +7,9 @@ author: Bergfrid Skaara Dias
 date: 11.05.2021
 version: 10
 content_type: howto
-redirect_from: /en/sale/howto/entity/link-sale-to-appointment
+redirect_from:
+  - /en/sale/howto/entity/link-sale-to-appointment
+  - /en/api/netserver/entities/howto/sale/link-sale-to-appointment
 ---
 
 # How to link a sale to a follow-up (data layer)

--- a/docs/en/api/entities/index.md
+++ b/docs/en/api/entities/index.md
@@ -8,6 +8,7 @@ keywords: data access, entity, entities, RDB
 content_type: concept
 deployment: online, onsite
 platform: web, win
+redirect_from: /en/api/netserver/entities/index
 ---
 
 # Relational database layer (Entities)

--- a/docs/en/api/entities/nested-persist.md
+++ b/docs/en/api/entities/nested-persist.md
@@ -6,6 +6,7 @@ author: Tony Yates
 date: 06.12.2009
 keywords: NetServer
 content_type: concept
+redirect_from: /en/api/netserver/entities/nested-persist
 ---
 
 # NetServer Nested Persist

--- a/docs/en/api/entities/setdefaults.md
+++ b/docs/en/api/entities/setdefaults.md
@@ -7,6 +7,7 @@ date: 11.05.2016
 keywords: entity,row
 content_type: concept
 deployment: onsite
+redirect_from: /en/api/netserver/entities/setdefaults
 ---
 
 # SetDefaults method

--- a/docs/en/api/entities/update-entity-in-entity.md
+++ b/docs/en/api/entities/update-entity-in-entity.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/entities/update-entity-in-entity
 ---
 
 # Update an Entity through an Entity

--- a/docs/en/api/entities/update-entity.md
+++ b/docs/en/api/entities/update-entity.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/entities/update-entity
 ---
 
 # Update a basic property of an Entity

--- a/docs/en/api/entities/using-collections.md
+++ b/docs/en/api/entities/using-collections.md
@@ -7,6 +7,7 @@ date: 11.05.2016
 keywords: entity, collection
 content_type: concept
 deployment: onsite
+redirect_from: /en/api/netserver/entities/using-collections
 ---
 
 # Use and misuse of collections

--- a/docs/en/api/entities/using-customsearch.md
+++ b/docs/en/api/entities/using-customsearch.md
@@ -5,6 +5,7 @@ description: CustomSearch
 author: SuperOffice Product and Engineering
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/entities/using-customsearch
 ---
 
 # CustomSearch

--- a/docs/en/api/foreign-keys/erp-integration.md
+++ b/docs/en/api/foreign-keys/erp-integration.md
@@ -6,6 +6,7 @@ author:
 date: 11.08.2021
 keywords: database, ERP, foreignapp, FK
 content_type: concept
+redirect_from: /en/api/netserver/foreign-keys/erp-integration
 ---
 
 # System integration

--- a/docs/en/api/foreign-keys/foreignkey.md
+++ b/docs/en/api/foreign-keys/foreignkey.md
@@ -7,6 +7,7 @@ keywords:
 topic:
 deployment: online
 platform: web
+redirect_from: /en/api/netserver/foreign-keys/foreignkey
 ---
 
 # ForeignKeys – to fluent or not to fluent, that is the question

--- a/docs/en/api/foreign-keys/index.md
+++ b/docs/en/api/foreign-keys/index.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 06.24.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/foreign-keys/index
 ---
 
 # Foreign keys

--- a/docs/en/api/foreign-keys/set-and-get.md
+++ b/docs/en/api/foreign-keys/set-and-get.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 
 keywords: 
 content_type: howto
+redirect_from: /en/api/netserver/foreign-keys/set-and-get
 ---
 
 # How to set and get foreign keys

--- a/docs/en/api/lists/entity/generic-list.md
+++ b/docs/en/api/lists/entity/generic-list.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/lists/entity/generic-list
 ---
 
 # Generic list providers

--- a/docs/en/api/lists/entity/group-view.md
+++ b/docs/en/api/lists/entity/group-view.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/lists/entity/group-view
 ---
 
 # Group view providers

--- a/docs/en/api/lists/entity/how-to/create-list-plugin.md
+++ b/docs/en/api/lists/entity/how-to/create-list-plugin.md
@@ -5,6 +5,7 @@ description: Create a plugin list provider
 author: SuperOffice Product and Engineering
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/lists/entity/how-to/create-list-plugin
 ---
 
 # Create your own list plugin

--- a/docs/en/api/lists/entity/how-to/get-list.md
+++ b/docs/en/api/lists/entity/how-to/get-list.md
@@ -5,6 +5,7 @@ description: Retrieve a list
 author: SuperOffice Product and Engineering
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/lists/entity/how-to/get-list
 ---
 
 # Retrieve a list

--- a/docs/en/api/lists/entity/index.md
+++ b/docs/en/api/lists/entity/index.md
@@ -7,6 +7,7 @@ date: 05.11.2016
 keywords:
 content_type: concept
 area: api-core
+redirect_from: /en/api/netserver/lists/entity/index
 ---
 
 # SoListProviders

--- a/docs/en/api/lists/entity/typed-list.md
+++ b/docs/en/api/lists/entity/typed-list.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/lists/entity/typed-list
 ---
 
 # Typed list providers

--- a/docs/en/api/lists/entity/udef-list.md
+++ b/docs/en/api/lists/entity/udef-list.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/lists/entity/udef-list
 ---
 
 # User-defined list providers

--- a/docs/en/api/lists/index.md
+++ b/docs/en/api/lists/index.md
@@ -5,6 +5,7 @@ author: AnthonyYates
 date: 03.03.2022
 keywords: Lists, 
 content_type: concept
+redirect_from: /en/api/netserver/lists/index
 ---
 
 # Lists

--- a/docs/en/api/lists/row/how-to/add-list-item.md
+++ b/docs/en/api/lists/row/how-to/add-list-item.md
@@ -6,7 +6,9 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords: row, list, category, CategoryRow, CategoryGroupLinkRow
 content_type: howto
-redirect_from: /en/api/lists/row/index
+redirect_from:
+  - /en/api/lists/row/index
+  - /en/api/netserver/lists/row/how-to/add-list-item
 ---
 
 # How to add a list item

--- a/docs/en/api/lists/services/how-to/create-list-item.md
+++ b/docs/en/api/lists/services/how-to/create-list-item.md
@@ -7,6 +7,7 @@ content_type: howto
 date: 03.03.2022
 category: list
 area: api-services
+redirect_from: /en/api/netserver/lists/services/how-to/create-list-item
 ---
 
 <!-- markdownlint-disable-file MD051 -->

--- a/docs/en/api/lists/services/how-to/create-list.md
+++ b/docs/en/api/lists/services/how-to/create-list.md
@@ -7,6 +7,7 @@ content_type: howto
 date: 03.03.2022
 category: list
 area: api-services
+redirect_from: /en/api/netserver/lists/services/how-to/create-list
 ---
 
 <!-- markdownlint-disable-file MD051 -->

--- a/docs/en/api/lists/services/how-to/delete-list-item.md
+++ b/docs/en/api/lists/services/how-to/delete-list-item.md
@@ -7,6 +7,7 @@ content_type: howto
 date: 03.03.2022
 category: list
 area: api-services
+redirect_from: /en/api/netserver/lists/services/how-to/delete-list-item
 ---
 
 # How to delete a list item

--- a/docs/en/api/lists/services/how-to/delete-list.md
+++ b/docs/en/api/lists/services/how-to/delete-list.md
@@ -7,6 +7,7 @@ content_type: howto
 date: 03.03.2022
 category: list
 area: api-services
+redirect_from: /en/api/netserver/lists/services/how-to/delete-list
 ---
 
 <!-- markdownlint-disable-file MD051 -->

--- a/docs/en/api/lists/services/how-to/get-all-lists.md
+++ b/docs/en/api/lists/services/how-to/get-all-lists.md
@@ -7,6 +7,7 @@ content_type: howto
 date: 03.03.2022
 category: list
 area: api-services
+redirect_from: /en/api/netserver/lists/services/how-to/get-all-lists
 ---
 
 

--- a/docs/en/api/lists/services/how-to/get-list-entity.md
+++ b/docs/en/api/lists/services/how-to/get-list-entity.md
@@ -7,6 +7,7 @@ content_type: howto
 date: 03.03.2022
 category: list
 area: api-services
+redirect_from: /en/api/netserver/lists/services/how-to/get-list-entity
 ---
 
 # How to get list entity by name

--- a/docs/en/api/lists/services/how-to/get-list-item.md
+++ b/docs/en/api/lists/services/how-to/get-list-item.md
@@ -7,6 +7,7 @@ content_type: howto
 date: 03.03.2022
 category: list
 area: api-services
+redirect_from: /en/api/netserver/lists/services/how-to/get-list-item
 ---
 
 <!-- markdownlint-disable-file MD051 -->

--- a/docs/en/api/lists/services/how-to/get-list-items.md
+++ b/docs/en/api/lists/services/how-to/get-list-items.md
@@ -7,6 +7,7 @@ content_type: howto
 date: 03.03.2022
 category: list
 area: api-services
+redirect_from: /en/api/netserver/lists/services/how-to/get-list-items
 ---
 
 # How to get all list items

--- a/docs/en/api/lists/services/how-to/index.md
+++ b/docs/en/api/lists/services/how-to/index.md
@@ -7,6 +7,7 @@ content_type: howto
 date: 03.03.2022
 category: list
 area: api-services
+redirect_from: /en/api/netserver/lists/services/how-to/index
 ---
 
 # How-to work with lists

--- a/docs/en/api/lists/services/index.md
+++ b/docs/en/api/lists/services/index.md
@@ -2,6 +2,7 @@
 title: Lists in web services
 description: Discusses how to programmatically work with lists using web services.
 date: 03.03.2022
+redirect_from: /en/api/netserver/lists/services/index
 ---
 
 # SuperOffice Lists

--- a/docs/en/api/lists/services/listagent/index.md
+++ b/docs/en/api/lists/services/listagent/index.md
@@ -7,6 +7,7 @@ content_type: concept
 date: 03.03.2022
 category: list
 area: api-services
+redirect_from: /en/api/netserver/lists/services/listagent/index
 ---
 
 # Lists

--- a/docs/en/api/lists/services/listagent/show-countrylist-in-combobox.md
+++ b/docs/en/api/lists/services/listagent/show-countrylist-in-combobox.md
@@ -8,6 +8,7 @@ content_type: howto
 date:
 category: list
 area: api-services
+redirect_from: /en/api/netserver/lists/services/listagent/show-countrylist-in-combobox
 ---
 
 # Show list data in UI combo box

--- a/docs/en/api/lists/services/mdoagent/index.md
+++ b/docs/en/api/lists/services/mdoagent/index.md
@@ -7,6 +7,7 @@ content_type: concept
 date: 03.03.2022
 category: list
 area: api-services
+redirect_from: /en/api/netserver/lists/services/mdoagent/index
 ---
 
 # Multi-Departmental Organizational (MDO) API

--- a/docs/en/api/lists/services/mdoagent/mdo-how-to.md
+++ b/docs/en/api/lists/services/mdoagent/mdo-how-to.md
@@ -8,6 +8,7 @@ date: 03.03.2022
 content_type: concept
 category: list
 area: api-services
+redirect_from: /en/api/netserver/lists/services/mdoagent/mdo-how-to
 ---
 
 # Working with the MDO list API

--- a/docs/en/api/lists/sql/add-list-item-sql.md
+++ b/docs/en/api/lists/sql/add-list-item-sql.md
@@ -6,7 +6,9 @@ keywords: add list item, category list
 author: SuperOffice Product and Engineering
 date: 11.08.2021
 content_type: howto
-redirect_from: /en/api/lists/sql/index
+redirect_from:
+  - /en/api/lists/sql/index
+  - /en/api/netserver/lists/sql/add-list-item-sql
 ---
 
 <!-- markdownlint-disable-file MD013 -->

--- a/docs/en/api/logging/configure-serilog.md
+++ b/docs/en/api/logging/configure-serilog.md
@@ -5,6 +5,7 @@ keywords: configure Serilog, logging
 author: xt1
 date: 05.07.2021
 content_type: howto
+redirect_from: /en/api/netserver/logging/configure-serilog
 ---
 
 <!-- markdownlint-disable-file MD013 -->

--- a/docs/en/api/logging/create-custom-logger.md
+++ b/docs/en/api/logging/create-custom-logger.md
@@ -6,6 +6,7 @@ author: xt1
 date: 05.07.2021
 keywords: logging
 content_type: howto
+redirect_from: /en/api/netserver/logging/create-custom-logger
 ---
 
 # Create a custom logger

--- a/docs/en/api/logging/filter-logs.md
+++ b/docs/en/api/logging/filter-logs.md
@@ -6,6 +6,7 @@ author: xt1
 date: 05.07.2021
 keywords: logging
 content_type: howto
+redirect_from: /en/api/netserver/logging/filter-logs
 ---
 
 # Filtering the logs

--- a/docs/en/api/logging/index.md
+++ b/docs/en/api/logging/index.md
@@ -6,6 +6,7 @@ author: xt1
 date: 05.07.2021
 keywords: logging
 content_type: concept
+redirect_from: /en/api/netserver/logging/index
 ---
 
 # Logging in NetServer

--- a/docs/en/api/logging/serilog.md
+++ b/docs/en/api/logging/serilog.md
@@ -5,6 +5,7 @@ author: xt1
 date: 05.07.2021
 keywords: logging
 content_type: concept
+redirect_from: /en/api/netserver/logging/serilog
 ---
 
 # SuperOffice.Serilog

--- a/docs/en/api/logging/standard-netserver-log.md
+++ b/docs/en/api/logging/standard-netserver-log.md
@@ -6,6 +6,7 @@ author: xt1
 date: 05.07.2021
 keywords: logging
 content_type: concept
+redirect_from: /en/api/netserver/logging/standard-netserver-log
 ---
 
 # SuperOffice.Logging

--- a/docs/en/api/mdo-providers/index.md
+++ b/docs/en/api/mdo-providers/index.md
@@ -7,6 +7,7 @@ keywords:
   - "mdo provider"
 date: 03.17.2021
 content_type: concept
+redirect_from: /en/api/netserver/mdo-providers/index
 ---
 
 # MDO providers

--- a/docs/en/api/osql/alias.md
+++ b/docs/en/api/osql/alias.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/osql/alias
 ---
 
 # Alias

--- a/docs/en/api/osql/and-clause.md
+++ b/docs/en/api/osql/and-clause.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/osql/and-clause
 ---
 
 # AND clause

--- a/docs/en/api/osql/count.md
+++ b/docs/en/api/osql/count.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/osql/count
 ---
 
 # COUNT

--- a/docs/en/api/osql/delete.md
+++ b/docs/en/api/osql/delete.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/osql/delete
 ---
 
 # DELETE

--- a/docs/en/api/osql/groupby.md
+++ b/docs/en/api/osql/groupby.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/osql/groupby
 ---
 
 # GroupBy

--- a/docs/en/api/osql/howto/add-numbers.md
+++ b/docs/en/api/osql/howto/add-numbers.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/osql/howto/add-numbers
 ---
 
 # Adding numbers

--- a/docs/en/api/osql/howto/add-strings.md
+++ b/docs/en/api/osql/howto/add-strings.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/osql/howto/add-strings
 ---
 
 # Adding strings

--- a/docs/en/api/osql/howto/company/create-contact-osql.md
+++ b/docs/en/api/osql/howto/company/create-contact-osql.md
@@ -6,7 +6,9 @@ keywords: contact, company, OSQL, API
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/company/howto/osql/create-contact-osql
+redirect_from:
+  - /en/company/howto/osql/create-contact-osql
+  - /en/api/netserver/osql/howto/company/create-contact-osql
 ---
 
 # Create a contact through OSQL

--- a/docs/en/api/osql/howto/company/get-catlist-sodatareader.md
+++ b/docs/en/api/osql/howto/company/get-catlist-sodatareader.md
@@ -6,7 +6,9 @@ keywords: category, CategoryHeadingLinkTableInfo, CategoryList
 author: Bergfrid Dias
 date: 02.22.2022
 content_type: howto
-redirect_from: /en/company/howto/osql/get-catlist-sodatareader
+redirect_from:
+  - /en/company/howto/osql/get-catlist-sodatareader
+  - /en/api/netserver/osql/howto/company/get-catlist-sodatareader
 ---
 
 # Get the CategoryList through SODataReader

--- a/docs/en/api/osql/howto/company/index.md
+++ b/docs/en/api/osql/howto/company/index.md
@@ -6,8 +6,10 @@ keywords: contact, company, OSQL, API
 author: Bergfrid Skaara Dias
 date: 02.22.2022
 content_type: concept
-redirect_from: 
+redirect_from:
   - /en/company/howto/osql/index
+  - /en/api/netserver/osql/howto/index
+  - /en/api/netserver/osql/howto/company/index
   - /en/api/osql/howto/index
 ---
 

--- a/docs/en/api/osql/howto/contact/get-persons-from-contact-sodatareader.md
+++ b/docs/en/api/osql/howto/contact/get-persons-from-contact-sodatareader.md
@@ -6,7 +6,9 @@ keywords: person, contact, SoReader, SODataReader, API, OSQL
 author: Tony Yates
 date: 05.11.2016
 content_type: howto
-redirect_from: /en/contact/howto/osql/get-persons-from-contact-sodatareader
+redirect_from:
+  - /en/contact/howto/osql/get-persons-from-contact-sodatareader
+  - /en/api/netserver/osql/howto/contact/get-persons-from-contact-sodatareader
 ---
 
 # Retrieve a list of people using SODataReader

--- a/docs/en/api/osql/howto/contact/index.md
+++ b/docs/en/api/osql/howto/contact/index.md
@@ -6,7 +6,9 @@ keywords: person, contact, OSQL, API
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: reference
-redirect_from: /en/contact/howto/osql/index
+redirect_from:
+  - /en/contact/howto/osql/index
+  - /en/api/netserver/osql/howto/contact/index
 ---
 
 # Contact - OSQL

--- a/docs/en/api/osql/howto/contact/update-person-osql.md
+++ b/docs/en/api/osql/howto/contact/update-person-osql.md
@@ -6,7 +6,9 @@ keywords: person, contact, API, OSQL, update
 author: Tony Yates
 date: 05.11.2016
 content_type: howto
-redirect_from: /en/contact/howto/osql/update-person-osql
+redirect_from:
+  - /en/contact/howto/osql/update-person-osql
+  - /en/api/netserver/osql/howto/contact/update-person-osql
 ---
 
 # Update a person with a new name, address, position using OSQL

--- a/docs/en/api/osql/howto/create-connection.md
+++ b/docs/en/api/osql/howto/create-connection.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/osql/howto/create-connection
 ---
 
 # How to create a new connection

--- a/docs/en/api/osql/howto/diary/create-apt-osql.md
+++ b/docs/en/api/osql/howto/diary/create-apt-osql.md
@@ -7,7 +7,9 @@ author: Bergfrid Skaara Dias
 date: 03.02.2022
 content_type: howto
 
-redirect_from: /en/diary/howto/osql/create-apt-osql
+redirect_from:
+  - /en/diary/howto/osql/create-apt-osql
+  - /en/api/netserver/osql/howto/diary/create-apt-osql
 ---
 
 # Create an appointment through OSQL

--- a/docs/en/api/osql/howto/diary/index.md
+++ b/docs/en/api/osql/howto/diary/index.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, API, OSQL
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: reference
-redirect_from: /en/diary/howto/osql/index
+redirect_from:
+  - /en/diary/howto/osql/index
+  - /en/api/netserver/osql/howto/diary/index
 ---
 
 # Diary - OSQL

--- a/docs/en/api/osql/howto/using-delete.md
+++ b/docs/en/api/osql/howto/using-delete.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/osql/howto/using-delete
 ---
 
 # How to use DELETE in OSQL

--- a/docs/en/api/osql/howto/using-insert.md
+++ b/docs/en/api/osql/howto/using-insert.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/osql/howto/using-insert
 ---
 
 # How to use INSERT in OSQL

--- a/docs/en/api/osql/howto/using-select.md
+++ b/docs/en/api/osql/howto/using-select.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/osql/howto/using-select
 ---
 
 # How to use SELECT in OSQL

--- a/docs/en/api/osql/howto/using-sentry.md
+++ b/docs/en/api/osql/howto/using-sentry.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/osql/howto/using-sentry
 ---
 
 # Sentry

--- a/docs/en/api/osql/howto/using-update.md
+++ b/docs/en/api/osql/howto/using-update.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/osql/howto/using-update
 ---
 
 # How to use UPDATE in OSQL

--- a/docs/en/api/osql/in-enum.md
+++ b/docs/en/api/osql/in-enum.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/osql/in-enum
 ---
 
 # Enum values with IN

--- a/docs/en/api/osql/index.md
+++ b/docs/en/api/osql/index.md
@@ -8,6 +8,7 @@ keywords: data access, OSQL, objectified SQL, SuperOffice.CRM.Data, SuperOffice.
 content_type: concept
 deployment: online, onsite
 platform: web, win
+redirect_from: /en/api/netserver/osql/index
 ---
 
 # SuperOffice Objectified SQL (OSQL)

--- a/docs/en/api/osql/insert.md
+++ b/docs/en/api/osql/insert.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/osql/insert
 ---
 
 # INSERT

--- a/docs/en/api/osql/join.md
+++ b/docs/en/api/osql/join.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/osql/join
 ---
 
 # Joins

--- a/docs/en/api/osql/like.md
+++ b/docs/en/api/osql/like.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/osql/like
 ---
 
 # LIKE

--- a/docs/en/api/osql/orderby.md
+++ b/docs/en/api/osql/orderby.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/osql/orderby
 ---
 
 # OrderBy

--- a/docs/en/api/osql/osql-evolution.md
+++ b/docs/en/api/osql/osql-evolution.md
@@ -6,6 +6,7 @@ author: Tony Yates
 date: 09.06.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/osql/osql-evolution
 ---
 
 # Evolution of NetServer Objectified SQL

--- a/docs/en/api/osql/outerjoin.md
+++ b/docs/en/api/osql/outerjoin.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/osql/outerjoin
 ---
 
 # SuperOffice Objectified SQL - RIGHT OUTER JOIN

--- a/docs/en/api/osql/so-data-reader.md
+++ b/docs/en/api/osql/so-data-reader.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/osql/so-data-reader
 ---
 
 # SoDataReader class

--- a/docs/en/api/osql/soundx.md
+++ b/docs/en/api/osql/soundx.md
@@ -7,6 +7,7 @@ keywords:
 content_type: article
 deployment: online
 platform: web
+redirect_from: /en/api/netserver/osql/soundx
 ---
 
 # Soundex comes to NetServer

--- a/docs/en/api/osql/update.md
+++ b/docs/en/api/osql/update.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/osql/update
 ---
 
 # UPDATE

--- a/docs/en/api/osql/upper.md
+++ b/docs/en/api/osql/upper.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/osql/upper
 ---
 
 # Upper

--- a/docs/en/api/plugins/document/soarc-document-plugin.md
+++ b/docs/en/api/plugins/document/soarc-document-plugin.md
@@ -7,6 +7,7 @@ date: 06.03.2006
 keywords:
 content_type: howto
 deployment: onsite
+redirect_from: /en/api/netserver/plugins/document/soarc-document-plugin
 ---
 
 # How to create a managed document plugin

--- a/docs/en/api/plugins/erp-connectors/api/erp-actor-carrier.md
+++ b/docs/en/api/plugins/erp-connectors/api/erp-actor-carrier.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords: dto
 content_type: reference
+redirect_from: /en/api/netserver/plugins/erp-connectors/api/erp-actor-carrier
 ---
 
 # ErpActor

--- a/docs/en/api/plugins/erp-connectors/api/field-meta-data-carrier.md
+++ b/docs/en/api/plugins/erp-connectors/api/field-meta-data-carrier.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords: dto
 content_type: reference
+redirect_from: /en/api/netserver/plugins/erp-connectors/api/field-meta-data-carrier
 ---
 
 # FieldMetadataInfo

--- a/docs/en/api/plugins/erp-connectors/api/field-value-formats-and-conventions.md
+++ b/docs/en/api/plugins/erp-connectors/api/field-value-formats-and-conventions.md
@@ -5,6 +5,7 @@ description: ERP field-value formats and conventions
 author: SuperOffice Product and Engineering
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/plugins/erp-connectors/api/field-value-formats-and-conventions
 ---
 
 # Field-value formats and conventions

--- a/docs/en/api/plugins/erp-connectors/api/ierpconnector.md
+++ b/docs/en/api/plugins/erp-connectors/api/ierpconnector.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: reference
+redirect_from: /en/api/netserver/plugins/erp-connectors/api/ierpconnector
 ---
 
 # IErpConnector

--- a/docs/en/api/plugins/erp-connectors/api/index.md
+++ b/docs/en/api/plugins/erp-connectors/api/index.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/plugins/erp-connectors/api/index
 ---
 
 # Sync Connector API

--- a/docs/en/api/plugins/erp-connectors/api/pluginresponseinfo.md
+++ b/docs/en/api/plugins/erp-connectors/api/pluginresponseinfo.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: reference
+redirect_from: /en/api/netserver/plugins/erp-connectors/api/pluginresponseinfo
 ---
 
 # PluginResponseInfo

--- a/docs/en/api/plugins/erp-connectors/architecture/index.md
+++ b/docs/en/api/plugins/erp-connectors/architecture/index.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/plugins/erp-connectors/architecture/index
 ---
 
 # Architecture

--- a/docs/en/api/plugins/erp-connectors/architecture/soap-service.md
+++ b/docs/en/api/plugins/erp-connectors/architecture/soap-service.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords: soap
 content_type: concept
+redirect_from: /en/api/netserver/plugins/erp-connectors/architecture/soap-service
 ---
 
 # SOAP Sync Service

--- a/docs/en/api/plugins/erp-connectors/architecture/sync-service.md
+++ b/docs/en/api/plugins/erp-connectors/architecture/sync-service.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords: .net
 content_type: concept
+redirect_from: /en/api/netserver/plugins/erp-connectors/architecture/sync-service
 ---
 
 # Sync Service

--- a/docs/en/api/plugins/erp-connectors/architecture/wcf-host.md
+++ b/docs/en/api/plugins/erp-connectors/architecture/wcf-host.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords: soap,web.config
 content_type: howto
+redirect_from: /en/api/netserver/plugins/erp-connectors/architecture/wcf-host
 ---
 
 # ERP Sync Service WCF host

--- a/docs/en/api/plugins/erp-connectors/automatic-field-mapping.md
+++ b/docs/en/api/plugins/erp-connectors/automatic-field-mapping.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: reference
+redirect_from: /en/api/netserver/plugins/erp-connectors/automatic-field-mapping
 ---
 
 # ERP Sync engine automatic field mapping

--- a/docs/en/api/plugins/erp-connectors/client-gui.md
+++ b/docs/en/api/plugins/erp-connectors/client-gui.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/plugins/erp-connectors/client-gui
 ---
 
 # ERP sync client GUI

--- a/docs/en/api/plugins/erp-connectors/default-values.md
+++ b/docs/en/api/plugins/erp-connectors/default-values.md
@@ -5,6 +5,7 @@ description: Default values
 author: SuperOffice Product and Engineering
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/plugins/erp-connectors/default-values
 ---
 
 # Default values

--- a/docs/en/api/plugins/erp-connectors/getting-started.md
+++ b/docs/en/api/plugins/erp-connectors/getting-started.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords: ERP, ErpConnector, DynamicLoad
 content_type: tutorial
+redirect_from: /en/api/netserver/plugins/erp-connectors/getting-started
 ---
 
 # Getting started with ERP development

--- a/docs/en/api/plugins/erp-connectors/helpers.md
+++ b/docs/en/api/plugins/erp-connectors/helpers.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/plugins/erp-connectors/helpers
 ---
 
 # Helper classes

--- a/docs/en/api/plugins/erp-connectors/import.md
+++ b/docs/en/api/plugins/erp-connectors/import.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/plugins/erp-connectors/import
 ---
 
 # Importing from ERP

--- a/docs/en/api/plugins/erp-connectors/index.md
+++ b/docs/en/api/plugins/erp-connectors/index.md
@@ -5,6 +5,7 @@ description: ERP Sync Connector Interface
 author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
+redirect_from: /en/api/netserver/plugins/erp-connectors/index
 ---
 
 # ERP Sync Connector Interface

--- a/docs/en/api/plugins/erp-connectors/online/example-api.md
+++ b/docs/en/api/plugins/erp-connectors/online/example-api.md
@@ -7,6 +7,7 @@ keywords:
 content_type: concept
 deployment: online
 platform: web
+redirect_from: /en/api/netserver/plugins/erp-connectors/online/example-api
 ---
 
 # ERP Connector API Changes

--- a/docs/en/api/plugins/erp-connectors/online/index.md
+++ b/docs/en/api/plugins/erp-connectors/online/index.md
@@ -4,6 +4,7 @@ uid: erp_sync
 description: ERP Sync Connectors
 author: AnthonyYates
 keywords: ERP, EIS, sync connector
+redirect_from: /en/api/netserver/plugins/erp-connectors/online/index
 ---
 
 # ERP Sync Connectors

--- a/docs/en/api/plugins/erp-connectors/online/secure-in-online.md
+++ b/docs/en/api/plugins/erp-connectors/online/secure-in-online.md
@@ -7,6 +7,7 @@ keywords: sync
 content_type: concept
 deployment: online
 platform: web
+redirect_from: /en/api/netserver/plugins/erp-connectors/online/secure-in-online
 ---
 
 # Securing ERP Connectors for SuperOffice Online

--- a/docs/en/api/plugins/erp-connectors/ranking-fields.md
+++ b/docs/en/api/plugins/erp-connectors/ranking-fields.md
@@ -1,5 +1,6 @@
 ---
 date: 05.11.2016
+redirect_from: /en/api/netserver/plugins/erp-connectors/ranking-fields
 ---
 
 # Ranking Fields

--- a/docs/en/api/plugins/erp-connectors/sample.md
+++ b/docs/en/api/plugins/erp-connectors/sample.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/plugins/erp-connectors/sample
 ---
 
 # Example connector

--- a/docs/en/api/plugins/erp-connectors/search/index.md
+++ b/docs/en/api/plugins/erp-connectors/search/index.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords: find
 content_type: concept
+redirect_from: /en/api/netserver/plugins/erp-connectors/search/index
 ---
 
 # Search in ERP

--- a/docs/en/api/plugins/erp-connectors/search/search-operators.md
+++ b/docs/en/api/plugins/erp-connectors/search/search-operators.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: reference
+redirect_from: /en/api/netserver/plugins/erp-connectors/search/search-operators
 ---
 
 # ERP search operators

--- a/docs/en/api/plugins/erp-connectors/search/show-fields.md
+++ b/docs/en/api/plugins/erp-connectors/search/show-fields.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/plugins/erp-connectors/search/show-fields
 ---
 
 # Showing fields in GUI or search results

--- a/docs/en/api/plugins/erp-connectors/setup-connection.md
+++ b/docs/en/api/plugins/erp-connectors/setup-connection.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/plugins/erp-connectors/setup-connection
 ---
 
 # Setting up ERP Sync connection

--- a/docs/en/api/plugins/erp-connectors/setup-defaults.md
+++ b/docs/en/api/plugins/erp-connectors/setup-defaults.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/plugins/erp-connectors/setup-defaults
 ---
 
 # Setting up default values

--- a/docs/en/api/plugins/erp-connectors/setup-mapping.md
+++ b/docs/en/api/plugins/erp-connectors/setup-mapping.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/plugins/erp-connectors/setup-mapping
 ---
 
 # Setting up mapping of fields

--- a/docs/en/api/plugins/erp-connectors/sync-operation.md
+++ b/docs/en/api/plugins/erp-connectors/sync-operation.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: concept
+redirect_from: /en/api/netserver/plugins/erp-connectors/sync-operation
 ---
 
 # Erp Sync engine operation

--- a/docs/en/api/plugins/erp-connectors/terminology.md
+++ b/docs/en/api/plugins/erp-connectors/terminology.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: reference
+redirect_from: /en/api/netserver/plugins/erp-connectors/terminology
 ---
 
 # Terminology

--- a/docs/en/api/plugins/erp-connectors/tutorial.md
+++ b/docs/en/api/plugins/erp-connectors/tutorial.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords:
 content_type: tutorial
+redirect_from: /en/api/netserver/plugins/erp-connectors/tutorial
 ---
 
 # Tutorial (company)

--- a/docs/en/api/plugins/index.md
+++ b/docs/en/api/plugins/index.md
@@ -6,6 +6,7 @@ author: Bergfrid Dias
 date: 11.29.2016
 keywords: API, NetServer, plugin pattern, factory pattern
 content_type: concept
+redirect_from: /en/api/netserver/plugins/index
 ---
 
 # Plug-ins

--- a/docs/en/api/plugins/quote-connectors/adding-products.md
+++ b/docs/en/api/plugins/quote-connectors/adding-products.md
@@ -6,6 +6,7 @@ keywords: add product, ProductInfo, priceListKey, erpProductKey, QuoteConnectorE
 author: SuperOffice Product and Engineering
 date: 09.09.2022
 content_type: howto
+redirect_from: /en/api/netserver/plugins/quote-connectors/adding-products
 ---
 
 # Adding products to a quote

--- a/docs/en/api/plugins/quote-connectors/addresses.md
+++ b/docs/en/api/plugins/quote-connectors/addresses.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: howto
+redirect_from: /en/api/netserver/plugins/quote-connectors/addresses
 ---
 
 # Address Provider

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/addressinfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/addressinfo.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/addressinfo
 ---
 
 # AddressInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/extradatafieldtypeinfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/extradatafieldtypeinfo.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/extradatafieldtypeinfo
 ---
 
 # ExtraDataFieldTypeInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/fieldmetadatainfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/fieldmetadatainfo.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/fieldmetadatainfo
 ---
 
 # FieldMetadataInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/index.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/index.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: concept
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/index
 ---
 
 # Data carriers

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/isaleinfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/isaleinfo.md
@@ -5,6 +5,7 @@ description: ERP Quote Connector Interface data carrier - ISaleInfo
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/isaleinfo
 ---
 
 # ISaleInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/orderresponseinfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/orderresponseinfo.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/orderresponseinfo
 ---
 
 # OrderResponseInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/placeorderresponseinfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/placeorderresponseinfo.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/placeorderresponseinfo
 ---
 
 # PlaceOrderResponseInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/pluginresponseinfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/pluginresponseinfo.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/pluginresponseinfo
 ---
 
 # PluginResponseInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/pricelistinfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/pricelistinfo.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/pricelistinfo
 ---
 
 # PriceListInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/productextradatafieldinfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/productextradatafieldinfo.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/productextradatafieldinfo
 ---
 
 # ProductExtraDataFieldInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/productinfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/productinfo.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/productinfo
 ---
 
 # ProductInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/quotealternativecontextinfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/quotealternativecontextinfo.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/quotealternativecontextinfo
 ---
 
 # QuoteAlternativeContextInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/quotealternativeinfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/quotealternativeinfo.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/quotealternativeinfo
 ---
 
 # QuoteAlternativeInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/quotealternativewithlinesinfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/quotealternativewithlinesinfo.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/quotealternativewithlinesinfo
 ---
 
 # QuoteAlternativeWithLinesInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/quoteconnectioninfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/quoteconnectioninfo.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/quoteconnectioninfo
 ---
 
 # QuoteConnectionInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/quoteinfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/quoteinfo.md
@@ -5,6 +5,7 @@ description:  ERP Quote Connector Interface data carrier -  QuoteInfo
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/quoteinfo
 ---
 
 # QuoteInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/quotelineinfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/quotelineinfo.md
@@ -5,6 +5,7 @@ description:  ERP Quote Connector Interface data carrier - QuoteLineInfo
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/quotelineinfo
 ---
 
 # QuoteLineInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/quotelistiteminfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/quotelistiteminfo.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/quotelistiteminfo
 ---
 
 # QuoteListItemInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/quotesentresponseinfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/quotesentresponseinfo.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/quotesentresponseinfo
 ---
 
 # QuoteSentResponseInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/quoteversioncontextinfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/quoteversioncontextinfo.md
@@ -5,6 +5,7 @@ description:  ERP Quote Connector Interface data carrier - QuoteVersionContextIn
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/quoteversioncontextinfo
 ---
 
 # QuoteVersionContextInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/quoteversioninfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/quoteversioninfo.md
@@ -5,6 +5,7 @@ description:  ERP Quote Connector Interface data carrier - QuoteVersionInfo
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/quoteversioninfo
 ---
 
 # QuoteVersionInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/quoteversionresponseinfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/quoteversionresponseinfo.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/quoteversionresponseinfo
 ---
 
 # QuoteVersionResponseInfo

--- a/docs/en/api/plugins/quote-connectors/api/data-carriers/quoteversionstateinfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/data-carriers/quoteversionstateinfo.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/data-carriers/quoteversionstateinfo
 ---
 
 # QuoteVersionStateInfo

--- a/docs/en/api/plugins/quote-connectors/api/enums/configfieldtype.md
+++ b/docs/en/api/plugins/quote-connectors/api/enums/configfieldtype.md
@@ -6,7 +6,10 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
-redirect_from: /en/api/plugins/quote-connectors/api/enums/index
+redirect_from:
+  - /en/api/plugins/quote-connectors/api/enums/index
+  - /en/api/netserver/plugins/quote-connectors/api/enums/configfieldtype
+  - /en/api/netserver/plugins/quote-connectors/api/enums/index
 ---
 
 # Enum ConfigFieldType

--- a/docs/en/api/plugins/quote-connectors/api/enums/fieldaccessinfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/enums/fieldaccessinfo.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/enums/fieldaccessinfo
 ---
 
 # Enum FieldAccessInfo

--- a/docs/en/api/plugins/quote-connectors/api/enums/quoteaction.md
+++ b/docs/en/api/plugins/quote-connectors/api/enums/quoteaction.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/enums/quoteaction
 ---
 
 # QuoteAction

--- a/docs/en/api/plugins/quote-connectors/api/enums/quotestatus.md
+++ b/docs/en/api/plugins/quote-connectors/api/enums/quotestatus.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/enums/quotestatus
 ---
 
 # Enum QuoteStatus

--- a/docs/en/api/plugins/quote-connectors/api/enums/valueoverrideinfo.md
+++ b/docs/en/api/plugins/quote-connectors/api/enums/valueoverrideinfo.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/enums/valueoverrideinfo
 ---
 
 # Enum ValueOverrideInfo

--- a/docs/en/api/plugins/quote-connectors/api/iarchiveprovider.md
+++ b/docs/en/api/plugins/quote-connectors/api/iarchiveprovider.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: howto
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/iarchiveprovider
 ---
 
 # IArchiveProvider

--- a/docs/en/api/plugins/quote-connectors/api/index.md
+++ b/docs/en/api/plugins/quote-connectors/api/index.md
@@ -2,6 +2,7 @@
 title: Quote Connector API
 description: Quote Connector API
 date: 09.02.2022
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/index
 ---
 
 # .net APIs

--- a/docs/en/api/plugins/quote-connectors/api/iproductregistercache.md
+++ b/docs/en/api/plugins/quote-connectors/api/iproductregistercache.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: howto
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/iproductregistercache
 ---
 
 # IProductRegisterCache

--- a/docs/en/api/plugins/quote-connectors/api/iquoteconnector.md
+++ b/docs/en/api/plugins/quote-connectors/api/iquoteconnector.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: howto
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/iquoteconnector
 ---
 
 <!-- markdownlint-disable-file MD013 -->

--- a/docs/en/api/plugins/quote-connectors/api/iquoteconnector2.md
+++ b/docs/en/api/plugins/quote-connectors/api/iquoteconnector2.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: howto
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/iquoteconnector2
 ---
 
 # IQuoteConnector2

--- a/docs/en/api/plugins/quote-connectors/api/quoteconnectorbase.md
+++ b/docs/en/api/plugins/quote-connectors/api/quoteconnectorbase.md
@@ -1,3 +1,14 @@
+---
+uid: quote-connector-base
+title: QuoteConnectorBase
+description: QuoteConnectorBase implementation
+keywords: QuoteConnectorBase
+author: SuperOffice Product and Engineering
+date: 08.25.2025
+content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/quoteconnectorbase
+---
+
 # QuoteConnectorBase implementation
 
 The QuoteConnectorBase implements most of the IQuoteConnector API and adds some useful default behavior to the basic API contract. For example – recalculate alternative is handled for you.
@@ -12,6 +23,7 @@ Validates the version, looks for problems. Will typically change the Status and 
 
 Should for instance validate the alternatives and then concatenate the problems into the Status and reason fields.
 
+<!-- markdownlint-disable-next-line MD013 -->
 ## QuoteAlternativeWithLinesInfo ValidateAlternative(QuoteAlternativeWithLinesInfo quoteAlternativeWithLines, bool clearOldValues = false)
 
 Check rules for the quote alternative and fill out the status and reason fields if there are one or more problems.

--- a/docs/en/api/plugins/quote-connectors/api/quoteconnectorextender.md
+++ b/docs/en/api/plugins/quote-connectors/api/quoteconnectorextender.md
@@ -5,6 +5,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/quoteconnectorextender
 ---
 
 # QuoteConnectorExtender

--- a/docs/en/api/plugins/quote-connectors/api/reason-fields.md
+++ b/docs/en/api/plugins/quote-connectors/api/reason-fields.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 keywords: quote
 content_type: concept
 date:
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/reason-fields
 ---
 
 # Reason fields

--- a/docs/en/api/plugins/quote-connectors/api/rights-field.md
+++ b/docs/en/api/plugins/quote-connectors/api/rights-field.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 keywords: quote
 content_type: concept         
 date:
+redirect_from: /en/api/netserver/plugins/quote-connectors/api/rights-field
 ---
 
 # Rights field

--- a/docs/en/api/plugins/quote-connectors/approve-quote.md
+++ b/docs/en/api/plugins/quote-connectors/approve-quote.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: howto
+redirect_from: /en/api/netserver/plugins/quote-connectors/approve-quote
 ---
 
 # Approving the quote

--- a/docs/en/api/plugins/quote-connectors/calc-price.md
+++ b/docs/en/api/plugins/quote-connectors/calc-price.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: howto
+redirect_from: /en/api/netserver/plugins/quote-connectors/calc-price
 ---
 
 # Price calculations and field changes

--- a/docs/en/api/plugins/quote-connectors/capability-names.md
+++ b/docs/en/api/plugins/quote-connectors/capability-names.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: reference
+redirect_from: /en/api/netserver/plugins/quote-connectors/capability-names
 ---
 
 # Capability names

--- a/docs/en/api/plugins/quote-connectors/create-quote.md
+++ b/docs/en/api/plugins/quote-connectors/create-quote.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.08.2021
 keywords: quote, sale, product, price list, QuoteConnectorExtender
 content_type: howto
+redirect_from: /en/api/netserver/plugins/quote-connectors/create-quote
 ---
 
 # Creating a quote

--- a/docs/en/api/plugins/quote-connectors/discounts.md
+++ b/docs/en/api/plugins/quote-connectors/discounts.md
@@ -5,6 +5,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: concept
+redirect_from: /en/api/netserver/plugins/quote-connectors/discounts
 ---
 
 # Discounts

--- a/docs/en/api/plugins/quote-connectors/edit-connection.md
+++ b/docs/en/api/plugins/quote-connectors/edit-connection.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: howto
+redirect_from: /en/api/netserver/plugins/quote-connectors/edit-connection
 ---
 
 # Editing a connection

--- a/docs/en/api/plugins/quote-connectors/error-system.md
+++ b/docs/en/api/plugins/quote-connectors/error-system.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: concept
+redirect_from: /en/api/netserver/plugins/quote-connectors/error-system
 ---
 
 # Error system

--- a/docs/en/api/plugins/quote-connectors/find-product.md
+++ b/docs/en/api/plugins/quote-connectors/find-product.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote,search
 content_type: howto
+redirect_from: /en/api/netserver/plugins/quote-connectors/find-product
 ---
 
 # Product search provider

--- a/docs/en/api/plugins/quote-connectors/implementation-guide.md
+++ b/docs/en/api/plugins/quote-connectors/implementation-guide.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: howto
+redirect_from: /en/api/netserver/plugins/quote-connectors/implementation-guide
 ---
 # How to create a SuperOffice Quote Connector
 

--- a/docs/en/api/plugins/quote-connectors/index.md
+++ b/docs/en/api/plugins/quote-connectors/index.md
@@ -6,6 +6,7 @@ author: Eivind Fasting
 date: 01.31.2025
 keywords: quote, connector, setup
 content_type: concept
+redirect_from: /en/api/netserver/plugins/quote-connectors/index
 ---
 
 # ERP Quote Connector Interface

--- a/docs/en/api/plugins/quote-connectors/online-quote-connectors/index.md
+++ b/docs/en/api/plugins/quote-connectors/online-quote-connectors/index.md
@@ -4,6 +4,7 @@ uid: online_quote_connector
 description: Online quote connectors
 author: SuperOffice Product and Engineering
 keywords:
+redirect_from: /en/api/netserver/plugins/quote-connectors/online-quote-connectors/index
 ---
 
 # Online Quote Connectors

--- a/docs/en/api/plugins/quote-connectors/online-quote-connectors/rest-quote-connector-api.md
+++ b/docs/en/api/plugins/quote-connectors/online-quote-connectors/rest-quote-connector-api.md
@@ -4,6 +4,7 @@ uid: quote_connector_rest_api
 description: Online REST quote connectors
 author: xt1
 keywords: quote
+redirect_from: /en/api/netserver/plugins/quote-connectors/online-quote-connectors/rest-quote-connector-api
 ---
 
 # Online REST quote connector API

--- a/docs/en/api/plugins/quote-connectors/online-quote-connectors/soap-quote-connector-api.md
+++ b/docs/en/api/plugins/quote-connectors/online-quote-connectors/soap-quote-connector-api.md
@@ -4,6 +4,7 @@ uid: quote_connector_soap_api
 description: Online quote connectors SOAP API
 author: SuperOffice Product and Engineering
 keywords: quote
+redirect_from: /en/api/netserver/plugins/quote-connectors/online-quote-connectors/soap-quote-connector-api
 ---
 
 # Online SOAP quote connector API

--- a/docs/en/api/plugins/quote-connectors/place-order.md
+++ b/docs/en/api/plugins/quote-connectors/place-order.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: howto
+redirect_from: /en/api/netserver/plugins/quote-connectors/place-order
 ---
 
 # Placing orders into ERP

--- a/docs/en/api/plugins/quote-connectors/save-quote.md
+++ b/docs/en/api/plugins/quote-connectors/save-quote.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: howto
+redirect_from: /en/api/netserver/plugins/quote-connectors/save-quote
 ---
 
 # Saving the quote

--- a/docs/en/api/plugins/quote-connectors/scenarios/add-product.md
+++ b/docs/en/api/plugins/quote-connectors/scenarios/add-product.md
@@ -6,7 +6,10 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: tutorial
-redirect_from: /en/api/plugins/quote-connectors/scenarios/index
+redirect_from:
+  - /en/api/plugins/quote-connectors/scenarios/index
+  - /en/api/netserver/plugins/quote-connectors/scenarios/add-product
+  - /en/api/netserver/plugins/quote-connectors/scenarios/index
 ---
 
 # Scenario – adding a product

--- a/docs/en/api/plugins/quote-connectors/scenarios/customer-specific-product-codes.md
+++ b/docs/en/api/plugins/quote-connectors/scenarios/customer-specific-product-codes.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: tutorial
+redirect_from: /en/api/netserver/plugins/quote-connectors/scenarios/customer-specific-product-codes
 ---
 
 # Dealing with customer-specific product codes

--- a/docs/en/api/plugins/quote-connectors/send-quote.md
+++ b/docs/en/api/plugins/quote-connectors/send-quote.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.08.2021
 keywords: quote
 content_type: howto
+redirect_from: /en/api/netserver/plugins/quote-connectors/send-quote
 ---
 
 # Sending quotes

--- a/docs/en/api/plugins/quote-connectors/set-up.md
+++ b/docs/en/api/plugins/quote-connectors/set-up.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date:
 keywords: quote
 content_type: howto
+redirect_from: /en/api/netserver/plugins/quote-connectors/set-up
 ---
 
 # How to set up a quote connector

--- a/docs/en/api/plugins/quote-connectors/start-client.md
+++ b/docs/en/api/plugins/quote-connectors/start-client.md
@@ -6,6 +6,7 @@ keywords: quote connector client, InitializeConnection
 author: SuperOffice Product and Engineering
 date: 02.04.2022
 content_type: howto
+redirect_from: /en/api/netserver/plugins/quote-connectors/start-client
 ---
 
 # Start the client

--- a/docs/en/api/plugins/sentry/create-sentry-plugin.md
+++ b/docs/en/api/plugins/sentry/create-sentry-plugin.md
@@ -7,6 +7,7 @@ date: 11.05.2016
 keywords:
 content_type: howto
 deployment: onsite
+redirect_from: /en/api/netserver/plugins/sentry/create-sentry-plugin
 ---
 
 # Create your own Sentry plugin

--- a/docs/en/api/plugins/sentry/index.md
+++ b/docs/en/api/plugins/sentry/index.md
@@ -7,6 +7,7 @@ date: 11.05.2016
 keywords:
 content_type: concept
 deployment: onsite
+redirect_from: /en/api/netserver/plugins/sentry/index
 ---
 
 # Sentry plugins

--- a/docs/en/api/plugins/sentry/tutorial-sentry-plugin-with-ext-table.md
+++ b/docs/en/api/plugins/sentry/tutorial-sentry-plugin-with-ext-table.md
@@ -7,6 +7,7 @@ date: 05.16.2008
 keywords: sentry
 content_type: tutorial
 deployment: onsite
+redirect_from: /en/api/netserver/plugins/sentry/tutorial-sentry-plugin-with-ext-table
 ---
 
 # Sentry plugin with external table

--- a/docs/en/api/plugins/sentry/use-sentry-plugin.md
+++ b/docs/en/api/plugins/sentry/use-sentry-plugin.md
@@ -7,6 +7,7 @@ date: 11.05.2016
 keywords: Sentry, plug-in, plugin, security, TableRight, N
 content_type: howto
 deployment: onsite
+redirect_from: /en/api/netserver/plugins/sentry/use-sentry-plugin
 ---
 
 # Using the basic Sentry plugin

--- a/docs/en/api/rows/create-row-in-entity.md
+++ b/docs/en/api/rows/create-row-in-entity.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/rows/create-row-in-entity
 ---
 
 # Create a Row as a property of another entity

--- a/docs/en/api/rows/create-row.md
+++ b/docs/en/api/rows/create-row.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/rows/create-row
 ---
 
 # Create a Row with basic properties

--- a/docs/en/api/rows/customsearch.md
+++ b/docs/en/api/rows/customsearch.md
@@ -7,6 +7,7 @@ keywords: data access, rows, CustomSearch
 content_type: concept
 deployment: online, onsite
 platform: web, win
+redirect_from: /en/api/netserver/rows/customsearch
 ---
 
 # CustomSearch queries

--- a/docs/en/api/rows/delete-row-from-entity.md
+++ b/docs/en/api/rows/delete-row-from-entity.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/rows/delete-row-from-entity
 ---
 
 # Delete a Row through an Entity

--- a/docs/en/api/rows/delete-row.md
+++ b/docs/en/api/rows/delete-row.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/rows/delete-row
 ---
 
 # Delete a Row

--- a/docs/en/api/rows/events.md
+++ b/docs/en/api/rows/events.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords: hook
 content_type: concept
+redirect_from: /en/api/netserver/rows/events
 ---
 
 # Events in Row objects

--- a/docs/en/api/rows/get-row-from-entity.md
+++ b/docs/en/api/rows/get-row-from-entity.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/rows/get-row-from-entity
 ---
 
 # Retrieve a row through an entity

--- a/docs/en/api/rows/get-row.md
+++ b/docs/en/api/rows/get-row.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/rows/get-row
 ---
 
 # Retrieve a Row with basic properties

--- a/docs/en/api/rows/howto/address/index.md
+++ b/docs/en/api/rows/howto/address/index.md
@@ -7,7 +7,9 @@ author: Bergfrid Dias
 date: 02.16.2022
 version: 9
 content_type: howto
-redirect_from: /en/globalization-and-localization/address/howto/rows/index
+redirect_from:
+  - /en/globalization-and-localization/address/howto/rows/index
+  - /en/api/netserver/rows/howto/address/index
 ---
 
 # Address - rows

--- a/docs/en/api/rows/howto/address/update-address.md
+++ b/docs/en/api/rows/howto/address/update-address.md
@@ -7,7 +7,9 @@ author: Tony Yates
 date: 11.05.2016
 version: 8
 content_type: howto
-redirect_from: /en/globalization-and-localization/address/howto/rows/update-address
+redirect_from:
+  - /en/globalization-and-localization/address/howto/rows/update-address
+  - /en/api/netserver/rows/howto/address/update-address
 ---
 
 # ContactAddress

--- a/docs/en/api/rows/howto/company/add-new-contact-interest.md
+++ b/docs/en/api/rows/howto/company/add-new-contact-interest.md
@@ -6,7 +6,9 @@ keywords: company, contact, interest, API, row, ContIntRow, ContactInterestRow, 
 author: Tony Yates
 date: 05.11.2016
 content_type: howto
-redirect_from: /en/company/howto/row/add-new-contact-interest
+redirect_from:
+  - /en/company/howto/row/add-new-contact-interest
+  - /en/api/netserver/rows/howto/company/add-new-contact-interest
 ---
 
 # How to add a new contact interest

--- a/docs/en/api/rows/howto/company/create-contact-row.md
+++ b/docs/en/api/rows/howto/company/create-contact-row.md
@@ -6,7 +6,9 @@ keywords: company, contact, API, row, ContactRow
 author: Tony Yates
 date: 05.11.2016
 content_type: howto
-redirect_from: /en/company/howto/row/create-contact-row
+redirect_from:
+  - /en/company/howto/row/create-contact-row
+  - /en/api/netserver/rows/howto/company/create-contact-row
 ---
 
 # Create a contact row

--- a/docs/en/api/rows/howto/company/create-contact-rows.md
+++ b/docs/en/api/rows/howto/company/create-contact-rows.md
@@ -6,7 +6,9 @@ description: How to create a contact through row collection (ContactRows).
 author: Tony Yates
 date: 05.11.2016
 content_type: howto
-redirect_from: /en/company/howto/row/create-contact-rows
+redirect_from:
+  - /en/company/howto/row/create-contact-rows
+  - /en/api/netserver/rows/howto/company/create-contact-rows
 ---
 
 # Create a contact through row collection (Rows)

--- a/docs/en/api/rows/howto/company/get-catlist-categoryrows.md
+++ b/docs/en/api/rows/howto/company/get-catlist-categoryrows.md
@@ -6,7 +6,9 @@ keywords: category, rows
 author: Tony Yates
 date: 05.11.2016
 content_type: howto
-redirect_from: /en/company/howto/row/get-catlist-categoryrows
+redirect_from:
+  - /en/company/howto/row/get-catlist-categoryrows
+  - /en/api/netserver/rows/howto/company/get-catlist-categoryrows
 ---
 
 # Get the CategoryList via CategoryRows object

--- a/docs/en/api/rows/howto/company/index.md
+++ b/docs/en/api/rows/howto/company/index.md
@@ -6,7 +6,9 @@ keywords: contact, company, row, API
 author: Bergfrid Skaara Dias
 date: 02.22.2022
 content_type: concept
-redirect_from: /en/company/howto/row/index
+redirect_from:
+  - /en/company/howto/row/index
+  - /en/api/netserver/rows/howto/company/index
 ---
 
 # Contact - row

--- a/docs/en/api/rows/howto/contact/collection.md
+++ b/docs/en/api/rows/howto/contact/collection.md
@@ -6,7 +6,9 @@ keywords: PersonRow, person, contact, row, API
 author: Tony Yates
 date: 11.05.2016
 content_type: howto
-redirect_from: /en/contact/howto/row/collection
+redirect_from:
+  - /en/contact/howto/row/collection
+  - /en/api/netserver/rows/howto/contact/collection
 ---
 
 # Collection

--- a/docs/en/api/rows/howto/contact/get-persons-from-contact-rows.md
+++ b/docs/en/api/rows/howto/contact/get-persons-from-contact-rows.md
@@ -6,7 +6,9 @@ keywords: person, contact, API, rows, PersonRows
 author: Tony Yates
 date: 05.11.2016
 content_type: howto
-redirect_from: /en/contact/howto/row/get-persons-from-contact-rows
+redirect_from:
+  - /en/contact/howto/row/get-persons-from-contact-rows
+  - /en/api/netserver/rows/howto/contact/get-persons-from-contact-rows
 ---
 
 # Retrieve a list of people using rows

--- a/docs/en/api/rows/howto/contact/index.md
+++ b/docs/en/api/rows/howto/contact/index.md
@@ -6,7 +6,9 @@ keywords: person, contact, row, API
 author: Bergfrid Skaara Dias
 date: 02.16.2022
 content_type: howto
-redirect_from: /en/contact/howto/row/index
+redirect_from:
+  - /en/contact/howto/row/index
+  - /en/api/netserver/rows/howto/contact/index
 ---
 
 # Contact - row

--- a/docs/en/api/rows/howto/contact/update-person-rows.md
+++ b/docs/en/api/rows/howto/contact/update-person-rows.md
@@ -6,7 +6,9 @@ keywords: person, contact, API, rows, PersonRow, update, AddressRow
 author: Tony Yates
 date: 05.11.2016
 content_type: howto
-redirect_from: /en/contact/howto/row/update-person-rows
+redirect_from:
+  - /en/contact/howto/row/update-person-rows
+  - /en/api/netserver/rows/howto/contact/update-person-rows
 ---
 
 # Update a person with a new name, address, position using rows

--- a/docs/en/api/rows/howto/diary/create-apt-row.md
+++ b/docs/en/api/rows/howto/diary/create-apt-row.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, API, row, AppointmentRow
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/diary/howto/row/create-apt-row
+redirect_from:
+  - /en/diary/howto/row/create-apt-row
+  - /en/api/netserver/rows/howto/diary/create-apt-row
 ---
 
 # Create an appointment row

--- a/docs/en/api/rows/howto/diary/create-apt-rows.md
+++ b/docs/en/api/rows/howto/diary/create-apt-rows.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, API, rows, collection, AppointmentRows
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/diary/howto/row/create-apt-rows
+redirect_from:
+  - /en/diary/howto/row/create-apt-rows
+  - /en/api/netserver/rows/howto/diary/create-apt-rows
 ---
 
 # Create an appointment through row collection (Rows)

--- a/docs/en/api/rows/howto/diary/index.md
+++ b/docs/en/api/rows/howto/diary/index.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, API, row
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: reference
-redirect_from: /en/diary/howto/row/index
+redirect_from:
+  - /en/diary/howto/row/index
+  - /en/api/netserver/rows/howto/diary/index
 ---
 
 # Diary - rows

--- a/docs/en/api/rows/howto/saint/index.md
+++ b/docs/en/api/rows/howto/saint/index.md
@@ -7,7 +7,9 @@ author: Bergfrid Skaara Dias
 date: 06.09.2023
 version: 10
 content_type: howto
-redirect_from: /en/sale/saint/howto/row/index
+redirect_from:
+  - /en/sale/saint/howto/row/index
+  - /en/api/netserver/rows/howto/saint/index
 ---
 
 # SAINT - row

--- a/docs/en/api/rows/howto/saint/search-saint-contactrow-customsearch.md
+++ b/docs/en/api/rows/howto/saint/search-saint-contactrow-customsearch.md
@@ -7,7 +7,9 @@ author: Bergfrid Skaara Dias
 date: 11.05.2021
 version: 10
 content_type: howto
-redirect_from: /en/sale/saint/howto/row/search-saint-contactrow-customsearch
+redirect_from:
+  - /en/sale/saint/howto/row/search-saint-contactrow-customsearch
+  - /en/api/netserver/rows/howto/saint/search-saint-contactrow-customsearch
 ---
 
 # Search for contacts with a given SAINT counter using ContactRow.CustomSearch

--- a/docs/en/api/rows/index.md
+++ b/docs/en/api/rows/index.md
@@ -7,6 +7,7 @@ keywords: data access, row, rows, collection, HDB, DataTable, DataRow, SuperOffi
 content_type: concept
 deployment: online, onsite
 platform: web, win
+redirect_from: /en/api/netserver/rows/index
 ---
 
 # High-level database layer (Rows)

--- a/docs/en/api/rows/update-row-in-entity.md
+++ b/docs/en/api/rows/update-row-in-entity.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/rows/update-row-in-entity
 ---
 
 # Update a Row through an Entity

--- a/docs/en/api/rows/update-row.md
+++ b/docs/en/api/rows/update-row.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.05.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/rows/update-row
 ---
 
 # Update basic properties of a Row

--- a/docs/en/api/search/find-selection/convert-to-new-date-range-operators.md
+++ b/docs/en/api/search/find-selection/convert-to-new-date-range-operators.md
@@ -6,6 +6,7 @@ author: AnthonyYates
 keywords: NewSelection, Selection, Find, Date
 content_type: howto
 platform: web
+redirect_from: /en/api/netserver/search/find-selection/convert-to-new-date-range-operators
 ---
 
 # Converting to new dynamic date ranges

--- a/docs/en/api/search/find-selection/date-range-as-criteria.md
+++ b/docs/en/api/search/find-selection/date-range-as-criteria.md
@@ -6,6 +6,7 @@ author: AnthonyYates
 keywords: NewSelection, Selection, Find, Date
 content_type: article
 platform: web
+redirect_from: /en/api/netserver/search/find-selection/date-range-as-criteria
 ---
 
 # Dynamic date range as criteria

--- a/docs/en/api/search/find-selection/how-to-search.md
+++ b/docs/en/api/search/find-selection/how-to-search.md
@@ -7,6 +7,7 @@ keywords: Selection, Find, Search
 content_type: howto
 deployment: online, onsite
 version: 9.2
+redirect_from: /en/api/netserver/search/find-selection/how-to-search
 ---
 
 <!-- markdownlint-disable-file MD051 MD044 -->

--- a/docs/en/api/search/find-selection/import-export-typical-search.md
+++ b/docs/en/api/search/find-selection/import-export-typical-search.md
@@ -5,6 +5,7 @@ author: AnthonyYates
 keywords: Typical search, Selection, Find
 content_type: article
 platform: web
+redirect_from: /en/api/netserver/search/find-selection/import-export-typical-search
 ---
 
 # Export and import of typical search

--- a/docs/en/api/search/find-selection/index.md
+++ b/docs/en/api/search/find-selection/index.md
@@ -7,6 +7,7 @@ keywords: NewSelection, Selection, Find
 content_type: article
 platform: web
 version: 9.2
+redirect_from: /en/api/netserver/search/find-selection
 ---
 
 <!-- markdownlint-disable-file MD051 -->

--- a/docs/en/api/search/find-selection/operators.md
+++ b/docs/en/api/search/find-selection/operators.md
@@ -6,6 +6,7 @@ keywords: NewSelection, Selection, Find
 content_type: reference
 deployment: online, onsite
 platform: web
+redirect_from: /en/api/netserver/search/find-selection/operators
 ---
 
 # Operators and data types

--- a/docs/en/api/search/find-selection/populate-selectable-columns.md
+++ b/docs/en/api/search/find-selection/populate-selectable-columns.md
@@ -7,6 +7,7 @@ keywords: NewSelection, Selection, Find
 content_type: concept
 deployment: online, onsite
 platform: web
+redirect_from: /en/api/netserver/search/find-selection/populate-selectable-columns
 ---
 
 <!-- markdownlint-disable-file MD051 -->

--- a/docs/en/api/search/find-selection/terminology.md
+++ b/docs/en/api/search/find-selection/terminology.md
@@ -5,6 +5,7 @@ author: AnthonyYates
 keywords: NewSelection, Selection, Find
 content_type: reference
 platform: web
+redirect_from: /en/api/netserver/search/find-selection/terminology
 ---
 
 # Common terms and concepts

--- a/docs/en/api/search/find-selection/typical-search.md
+++ b/docs/en/api/search/find-selection/typical-search.md
@@ -5,6 +5,7 @@ author: AnthonyYates
 keywords: Typical search, Selection, Find
 content_type: article
 platform: web
+redirect_from: /en/api/netserver/search/find-selection/typical-search
 ---
 
 <!-- markdownlint-disable-file MD051 -->

--- a/docs/en/api/search/full-text-search.md
+++ b/docs/en/api/search/full-text-search.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 keywords: database
 content_type: reference
 deployment: onsite
+redirect_from: /en/api/netserver/search/full-text-search
 ---
 
 # Full-text search

--- a/docs/en/api/search/iarchiveagent/iarchiveagent.md
+++ b/docs/en/api/search/iarchiveagent/iarchiveagent.md
@@ -7,6 +7,7 @@ content_type: concept
 date:
 category:
 area: api-services
+redirect_from: /en/api/netserver/search/iarchiveagent/iarchiveagent
 ---
 
 # IArchiveAgent

--- a/docs/en/api/search/iarchiveagent/index.md
+++ b/docs/en/api/search/iarchiveagent/index.md
@@ -8,6 +8,7 @@ content_type: concept
 date:
 category: 
 area: api-services
+redirect_from: /en/api/netserver/search/iarchiveagent
 ---
 
 # Archive agents

--- a/docs/en/api/search/iarchiveagent/using-activityarchive-filters.md
+++ b/docs/en/api/search/iarchiveagent/using-activityarchive-filters.md
@@ -8,6 +8,7 @@ content_type: howto
 date:
 category: 
 area: api-services
+redirect_from: /en/api/netserver/search/iarchiveagent/using-activityarchive-filters
 ---
 
 # How to use ActivityArchive filters

--- a/docs/en/api/search/iarchiveagent/using-criteria.md
+++ b/docs/en/api/search/iarchiveagent/using-criteria.md
@@ -8,6 +8,7 @@ content_type: howto
 date:
 category: 
 area: api-services
+redirect_from: /en/api/netserver/search/iarchiveagent/using-criteria
 ---
 
 # How to use multiple criteria with the ArchiveAgent

--- a/docs/en/api/search/ifindagent/dump-result.md
+++ b/docs/en/api/search/ifindagent/dump-result.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 06.24.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/search/ifindagent/dump-result
 ---
 
 # DumpResult helper method

--- a/docs/en/api/search/ifindagent/find-project-by-name.md
+++ b/docs/en/api/search/ifindagent/find-project-by-name.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 06.24.2016
 keywords:
 content_type: howto
+redirect_from: /en/api/netserver/search/ifindagent/find-project-by-name
 ---
 
 # Find a project, returning the name

--- a/docs/en/api/search/ifindagent/index.md
+++ b/docs/en/api/search/ifindagent/index.md
@@ -7,6 +7,7 @@ content_type: howto
 date:
 category: search
 area: api-services
+redirect_from: /en/api/netserver/search/ifindagent
 ---
 
 # IFindAgent

--- a/docs/en/api/search/ifindagent/using-criteria.md
+++ b/docs/en/api/search/ifindagent/using-criteria.md
@@ -8,6 +8,7 @@ content_type: howto
 date:
 category: 
 area: api-services
+redirect_from: /en/api/netserver/search/ifindagent/using-criteria
 ---
 
 # How to use multiple criteria with the FindAgent

--- a/docs/en/api/search/index.md
+++ b/docs/en/api/search/index.md
@@ -7,6 +7,7 @@ date: 02.02.2022
 updated: 02.12.2024
 keywords: search
 content_type: concept
+redirect_from: /en/api/netserver/search
 ---
 
 # Search

--- a/docs/en/api/search/odata/associate.md
+++ b/docs/en/api/search/odata/associate.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 keywords: search,odata
 date:
 content_type: howto
+redirect_from: /en/api/netserver/search/odata/associate
 ---
 
 # Associate

--- a/docs/en/api/search/odata/boolean.md
+++ b/docs/en/api/search/odata/boolean.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 keywords: search,odata
 date:
 content_type: howto
+redirect_from: /en/api/netserver/search/odata/boolean
 ---
 
 # Boolean

--- a/docs/en/api/search/odata/date.md
+++ b/docs/en/api/search/odata/date.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 keywords: search
 date:
 content_type: howto
+redirect_from: /en/api/netserver/search/odata/date
 ---
 
 # Dates

--- a/docs/en/api/search/odata/datetime.md
+++ b/docs/en/api/search/odata/datetime.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 keywords: search
 date:
 content_type: howto
+redirect_from: /en/api/netserver/search/odata/datetime
 ---
 
 # DateTime

--- a/docs/en/api/search/odata/dynamic-provider.md
+++ b/docs/en/api/search/odata/dynamic-provider.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 keywords: search,odata
 date: 2023-04-26
 content_type: howto
+redirect_from: /en/api/netserver/search/odata/dynamic-provider
 ---
 
 # The Dynamic Provider - the dot syntax

--- a/docs/en/api/search/odata/index.md
+++ b/docs/en/api/search/odata/index.md
@@ -6,6 +6,7 @@ author: Bergfrid Dias
 date: 12.06.2021
 keywords: search, ODATA, REST, WebAPI, web services
 content_type: concept
+redirect_from: /en/api/netserver/search/odata
 ---
 
 # REST WebAPI search

--- a/docs/en/api/search/odata/lists.md
+++ b/docs/en/api/search/odata/lists.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 keywords: search, list, odata
 date:
 content_type: howto
+redirect_from: /en/api/netserver/search/odata/lists
 ---
 
 # ODATA lists

--- a/docs/en/api/search/odata/metadata.md
+++ b/docs/en/api/search/odata/metadata.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 keywords: search
 date: 2023-04-26
 content_type: howto
+redirect_from: /en/api/netserver/search/odata/metadata
 ---
 
 # Archive Metadata

--- a/docs/en/api/search/odata/numbers.md
+++ b/docs/en/api/search/odata/numbers.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 keywords: search,odata
 date:
 content_type: howto
+redirect_from: /en/api/netserver/search/odata/numbers
 ---
 
 # Numbers (integer, decimal, float)

--- a/docs/en/api/search/odata/strings.md
+++ b/docs/en/api/search/odata/strings.md
@@ -8,6 +8,7 @@ date: 06.18.2024
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
+redirect_from: /en/api/netserver/search/odata/strings
 ---
 
 # String

--- a/docs/en/api/search/odata/unary.md
+++ b/docs/en/api/search/odata/unary.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 keywords: search
 date:
 content_type: howto
+redirect_from: /en/api/netserver/search/odata/unary
 ---
 
 # Unary time-periods

--- a/docs/en/api/search/odata/using-filters.md
+++ b/docs/en/api/search/odata/using-filters.md
@@ -8,6 +8,7 @@ date: 06.18.2024
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
+redirect_from: /en/api/netserver/search/odata/using-filters
 ---
 
 # Using filters

--- a/docs/en/api/search/selection/archive/get-selection-members-provider.md
+++ b/docs/en/api/search/selection/archive/get-selection-members-provider.md
@@ -6,7 +6,11 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords: search,selectionprovider
 content_type: howto
-redirect_from: /en/api/search/selection/archive/index
+redirect_from:
+  - /en/api/search/selection/archive/index
+  - /en/api/netserver/search/selection/archive/index
+  - /en/api/netserver/search/selection/archive/get-selection-members-provider
+  - /en/api/netserver/search/selection/archive
 ---
 
 # How to retrieve members of a specific selection using archive provider

--- a/docs/en/api/search/selection/archive/get-selection-members-provider.md
+++ b/docs/en/api/search/selection/archive/get-selection-members-provider.md
@@ -4,11 +4,10 @@ uid: get_selection_members_provider
 description: How to retrieve members of a specific selection using archive provider
 author: SuperOffice Product and Engineering
 date: 05.11.2016
-keywords: search,selectionprovider
+keywords: search, selectionprovider
 content_type: howto
 redirect_from:
   - /en/api/search/selection/archive/index
-  - /en/api/netserver/search/selection/archive/index
   - /en/api/netserver/search/selection/archive/get-selection-members-provider
   - /en/api/netserver/search/selection/archive
 ---

--- a/docs/en/api/search/selection/dynamic-selections.md
+++ b/docs/en/api/search/selection/dynamic-selections.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 11.08.2021
 keywords: search, selection, searchCriteria
 content_type: concept
+redirect_from: /en/api/netserver/search/selection/dynamic-selections
 ---
 
 # Dynamic selections

--- a/docs/en/api/search/selection/entity/add-member-to-static-selection-entities.md
+++ b/docs/en/api/search/selection/entity/add-member-to-static-selection-entities.md
@@ -6,7 +6,11 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords: search,entities
 content_type: howto
-redirect_from: /en/api/search/selection/entity/index
+redirect_from:
+  - /en/api/search/selection/entity/index
+  - /en/api/netserver/search/selection/entity/index
+  - /en/api/netserver/search/selection/entity/add-member-to-static-selection-entities
+  - /en/api/netserver/search/selection/entity
 ---
 
 # How to add members to a static selection using entities layer

--- a/docs/en/api/search/selection/entity/add-member-to-static-selection-entities.md
+++ b/docs/en/api/search/selection/entity/add-member-to-static-selection-entities.md
@@ -4,11 +4,10 @@ uid: add_members_static_selection_entities
 description: How to add members to a static selection using entities
 author: SuperOffice Product and Engineering
 date: 05.11.2016
-keywords: search,entities
+keywords: search, entities
 content_type: howto
 redirect_from:
   - /en/api/search/selection/entity/index
-  - /en/api/netserver/search/selection/entity/index
   - /en/api/netserver/search/selection/entity/add-member-to-static-selection-entities
   - /en/api/netserver/search/selection/entity
 ---

--- a/docs/en/api/search/selection/entity/create-dynamic-entity.md
+++ b/docs/en/api/search/selection/entity/create-dynamic-entity.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords: search
 content_type: howto
+redirect_from: /en/api/netserver/search/selection/entity/create-dynamic-entity
 ---
 
 # Creating a dynamic selection using entities

--- a/docs/en/api/search/selection/entity/get-selection-members-entity.md
+++ b/docs/en/api/search/selection/entity/get-selection-members-entity.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords: search,selectionmembers
 content_type: howto
+redirect_from: /en/api/netserver/search/selection/entity/get-selection-members-entity
 ---
 
 # How to retrieve members of a specific selection using entities

--- a/docs/en/api/search/selection/index.md
+++ b/docs/en/api/search/selection/index.md
@@ -5,6 +5,7 @@ author: SuperOffice Product and Engineering
 date: 11.08.2021
 keywords: search, selection
 content_type: concept
+redirect_from: /en/api/netserver/search/selection
 ---
 
 # Selection

--- a/docs/en/api/search/selection/osql/add-member-to-static-selection-osql.md
+++ b/docs/en/api/search/selection/osql/add-member-to-static-selection-osql.md
@@ -6,7 +6,11 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords: search,osql,selectionmember
 content_type: howto
-redirect_from: /en/api/search/selection/osql/index
+redirect_from:
+  - /en/api/search/selection/osql/index
+  - /en/api/netserver/search/selection/osql/index
+  - /en/api/netserver/search/selection/osql/add-member-to-static-selection-osql
+  - /en/api/netserver/search/selection/osql
 ---
 
 # How to add members to a static selection using OSQL

--- a/docs/en/api/search/selection/osql/add-member-to-static-selection-osql.md
+++ b/docs/en/api/search/selection/osql/add-member-to-static-selection-osql.md
@@ -4,11 +4,10 @@ uid: add_members_static_selection_osql
 description: How to add members to a static selection using OSQL
 author: SuperOffice Product and Engineering
 date: 05.11.2016
-keywords: search,osql,selectionmember
+keywords: search, osql, selectionmember
 content_type: howto
 redirect_from:
   - /en/api/search/selection/osql/index
-  - /en/api/netserver/search/selection/osql/index
   - /en/api/netserver/search/selection/osql/add-member-to-static-selection-osql
   - /en/api/netserver/search/selection/osql
 ---

--- a/docs/en/api/search/selection/services/create-dynamic-services.md
+++ b/docs/en/api/search/selection/services/create-dynamic-services.md
@@ -8,7 +8,6 @@ keywords: search
 content_type: howto
 redirect_from:
   - /en/api/search/selection/services/index
-  - /en/api/netserver/search/selection/services/index
   - /en/api/netserver/search/selection/services/create-dynamic-services
   - /en/api/netserver/search/selection/services
 ---

--- a/docs/en/api/search/selection/services/create-dynamic-services.md
+++ b/docs/en/api/search/selection/services/create-dynamic-services.md
@@ -6,7 +6,11 @@ author: SuperOffice Product and Engineering
 date: 06.24.2016
 keywords: search
 content_type: howto
-redirect_from: /en/api/search/selection/services/index
+redirect_from:
+  - /en/api/search/selection/services/index
+  - /en/api/netserver/search/selection/services/index
+  - /en/api/netserver/search/selection/services/create-dynamic-services
+  - /en/api/netserver/search/selection/services
 ---
 
 # Creating a dynamic selection (services)

--- a/docs/en/api/search/selection/services/get-selection-members-services.md
+++ b/docs/en/api/search/selection/services/get-selection-members-services.md
@@ -6,6 +6,7 @@ author: SuperOffice Product and Engineering
 date: 05.11.2016
 keywords: search
 content_type: howto
+redirect_from: /en/api/netserver/search/selection/services/get-selection-members-services
 ---
 
 # How to retrieve members of a specific selection using services

--- a/docs/en/api/search/selection/sql/add-person-to-selection.md
+++ b/docs/en/api/search/selection/sql/add-person-to-selection.md
@@ -8,7 +8,6 @@ keywords: search, selection, static
 content_type: howto
 redirect_from:
   - /en/api/search/selection/sql/index
-  - /en/api/netserver/search/selection/sql/index
   - /en/api/netserver/search/selection/sql/add-person-to-selection
   - /en/api/netserver/search/selection/sql
 ---

--- a/docs/en/api/search/selection/sql/add-person-to-selection.md
+++ b/docs/en/api/search/selection/sql/add-person-to-selection.md
@@ -6,7 +6,11 @@ author: SuperOffice Product and Engineering
 date: 11.08.2021
 keywords: search, selection, static
 content_type: howto
-redirect_from: /en/api/search/selection/sql/index
+redirect_from:
+  - /en/api/search/selection/sql/index
+  - /en/api/netserver/search/selection/sql/index
+  - /en/api/netserver/search/selection/sql/add-person-to-selection
+  - /en/api/netserver/search/selection/sql
 ---
 
 <!-- markdownlint-disable-file MD013-->

--- a/docs/en/api/sql/howto/company/create-contact-sql.md
+++ b/docs/en/api/sql/howto/company/create-contact-sql.md
@@ -6,7 +6,9 @@ keywords: contact, company, SQL, API
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/company/howto/sql/create-contact-sql
+redirect_from:
+  - /en/company/howto/sql/create-contact-sql
+  - /en/api/netserver/sql/howto/company/create-contact-sql
 ---
 
 # Create a contact

--- a/docs/en/api/sql/howto/company/get-catlist-sql.md
+++ b/docs/en/api/sql/howto/company/get-catlist-sql.md
@@ -6,7 +6,9 @@ keywords: category, CategoryGroupLink, contact
 author: Bergfrid Dias
 date: 02.21.2022
 content_type: howto
-redirect_from: /en/company/howto/sql/get-catlist-sql
+redirect_from:
+  - /en/company/howto/sql/get-catlist-sql
+  - /en/api/netserver/sql/howto/company/get-catlist-sql
 ---
 
 # Get all categories

--- a/docs/en/api/sql/howto/company/get-contact-details-sql.md
+++ b/docs/en/api/sql/howto/company/get-contact-details-sql.md
@@ -6,7 +6,9 @@ keywords: contact, company, SQL, API, phone
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/company/howto/sql/get-contact-details-sql
+redirect_from:
+  - /en/company/howto/sql/get-contact-details-sql
+  - /en/api/netserver/sql/howto/company/get-contact-details-sql
 ---
 
 # Get contact details

--- a/docs/en/api/sql/howto/company/get-interests-sql.md
+++ b/docs/en/api/sql/howto/company/get-interests-sql.md
@@ -6,7 +6,9 @@ keywords: contact, company, interest, SQL, API
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/company/howto/sql/get-interests-sql
+redirect_from:
+  - /en/company/howto/sql/get-interests-sql
+  - /en/api/netserver/sql/howto/company/get-interests-sql
 ---
 
 # Get interests for contact

--- a/docs/en/api/sql/howto/company/index.md
+++ b/docs/en/api/sql/howto/company/index.md
@@ -6,7 +6,9 @@ keywords: contact, company, SQL, API
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/company/howto/sql/index
+redirect_from:
+  - /en/company/howto/sql/index
+  - /en/api/netserver/sql/howto/company/index
 ---
 
 # Contact - raw SQL

--- a/docs/en/api/sql/howto/contact/add-person-picture-blobs-sql.md
+++ b/docs/en/api/sql/howto/contact/add-person-picture-blobs-sql.md
@@ -6,7 +6,9 @@ keywords: blob, person, contact, image, picture, API, BinaryObject, BinaryObject
 author: Bergfrid Skaara Dias
 date: 11.02.2021
 content_type: howto
-redirect_from: /en/contact/howto/sql/add-person-picture-blobs-sql
+redirect_from:
+  - /en/contact/howto/sql/add-person-picture-blobs-sql
+  - /en/api/netserver/sql/howto/contact/add-person-picture-blobs-sql
 ---
 
 # How to add a person picture

--- a/docs/en/api/sql/howto/contact/get-persons-from-contact-sql.md
+++ b/docs/en/api/sql/howto/contact/get-persons-from-contact-sql.md
@@ -6,7 +6,9 @@ keywords: person, contact, company, API
 author: Bergfrid Skaara Dias
 date: 11.02.2021
 content_type: howto
-redirect_from: /en/contact/howto/sql/get-persons-from-contact-sql
+redirect_from:
+  - /en/contact/howto/sql/get-persons-from-contact-sql
+  - /en/api/netserver/sql/howto/contact/get-persons-from-contact-sql
 ---
 
 # List persons in a company

--- a/docs/en/api/sql/howto/contact/index.md
+++ b/docs/en/api/sql/howto/contact/index.md
@@ -6,7 +6,9 @@ keywords: person, contact, SQL, API
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/contact/howto/sql/index
+redirect_from:
+  - /en/contact/howto/sql/index
+  - /en/api/netserver/sql/howto/contact/index
 ---
 
 # Contact - SQL

--- a/docs/en/api/sql/howto/contact/update-person-sql.md
+++ b/docs/en/api/sql/howto/contact/update-person-sql.md
@@ -6,7 +6,9 @@ keywords: person, contact, update, API, SQL
 author: Bergfrid Skaara Dias
 date: 11.02.2021
 content_type: howto
-redirect_from: /en/contact/howto/sql/update-person-sql
+redirect_from:
+  - /en/contact/howto/sql/update-person-sql
+  - /en/api/netserver/sql/howto/contact/update-person-sql
 ---
 
 # Update a person

--- a/docs/en/api/sql/howto/custom-objects/index.md
+++ b/docs/en/api/sql/howto/custom-objects/index.md
@@ -8,7 +8,9 @@ keywords: udef, user-defined field, custom field, API
 content_type: concept
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/custom-objects/udef/howto/sql/index
+redirect_from:
+  - /en/custom-objects/udef/howto/sql/index
+  - /en/api/netserver/sql/howto/custom-objects/index
 ---
 
 # Udef - raw SQL

--- a/docs/en/api/sql/howto/custom-objects/set-udef.md
+++ b/docs/en/api/sql/howto/custom-objects/set-udef.md
@@ -8,7 +8,9 @@ keywords: udef, user-defined field, custom field, API
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/custom-objects/udef/howto/sql/set-udef
+redirect_from:
+  - /en/custom-objects/udef/howto/sql/set-udef
+  - /en/api/netserver/sql/howto/custom-objects/set-udef
 ---
 
 <!-- markdownlint-disable-file MD013 -->

--- a/docs/en/api/sql/howto/diary/accept-invitation-sql.md
+++ b/docs/en/api/sql/howto/diary/accept-invitation-sql.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, API, invitation
 author: Bergfrid Skaara Dias
 date: 03.02.2022
 content_type: howto
-redirect_from: /en/diary/howto/sql/accept-invitation-sql
+redirect_from:
+  - /en/diary/howto/sql/accept-invitation-sql
+  - /en/api/netserver/sql/howto/diary/accept-invitation-sql
 ---
 
 # Accept invitation

--- a/docs/en/api/sql/howto/diary/create-apt-sql.md
+++ b/docs/en/api/sql/howto/diary/create-apt-sql.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, API, VisibleFor, SAINT
 author: Bergfrid Skaara Dias
 date: 03.02.2022
 content_type: howto
-redirect_from: /en/diary/howto/sql/create-apt-sql
+redirect_from:
+  - /en/diary/howto/sql/create-apt-sql
+  - /en/api/netserver/sql/howto/diary/create-apt-sql
 ---
 
 # Create appointment

--- a/docs/en/api/sql/howto/diary/create-invitation-sql.md
+++ b/docs/en/api/sql/howto/diary/create-invitation-sql.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, API, invitation
 author: Bergfrid Skaara Dias
 date: 03.02.2022
 content_type: howto
-redirect_from: /en/diary/howto/sql/create-invitation-sql
+redirect_from:
+  - /en/diary/howto/sql/create-invitation-sql
+  - /en/api/netserver/sql/howto/diary/create-invitation-sql
 ---
 
 # Create invitation

--- a/docs/en/api/sql/howto/diary/index.md
+++ b/docs/en/api/sql/howto/diary/index.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, API
 author: Bergfrid Skaara Dias
 date: 03.02.2022
 content_type: reference
-redirect_from: /en/diary/howto/sql/index
+redirect_from:
+  - /en/diary/howto/sql/index
+  - /en/api/netserver/sql/howto/diary/index
 ---
 
 # Diary - raw SQL

--- a/docs/en/api/sql/howto/project/create.md
+++ b/docs/en/api/sql/howto/project/create.md
@@ -6,7 +6,9 @@ keywords: project, SQL, API, project_number
 author: Bergfrid Dias
 date: 05.31.2023
 content_type: howto
-redirect_from: /en/project/howto/sql/create
+redirect_from:
+  - /en/project/howto/sql/create
+  - /en/api/netserver/sql/howto/project/create
 ---
 
 # Adding a project

--- a/docs/en/api/sql/howto/project/index.md
+++ b/docs/en/api/sql/howto/project/index.md
@@ -6,7 +6,9 @@ keywords: project, project management, API, SQL, ProjType, type_idx, ProjStatus,
 author: Bergfrid Skaara Dias
 date: 05.31.2023
 content_type: howto
-redirect_from: /en/project/howto/sql/index
+redirect_from:
+  - /en/project/howto/sql/index
+  - /en/api/netserver/sql/howto/project/index
 ---
 
 # Howto

--- a/docs/en/api/sql/howto/project/project-guide.md
+++ b/docs/en/api/sql/howto/project/project-guide.md
@@ -6,7 +6,9 @@ keywords: project, project management, SQL, API, project guide, projtype, hasGui
 author: Bergfrid Dias
 date: 05.31.2023
 content_type: howto
-redirect_from: /en/project/howto/sql/project-guide
+redirect_from:
+  - /en/project/howto/sql/project-guide
+  - /en/api/netserver/sql/howto/project/project-guide
 ---
 
 # Project guides

--- a/docs/en/api/sql/howto/project/text-table.md
+++ b/docs/en/api/sql/howto/project/text-table.md
@@ -6,7 +6,9 @@ keywords: project, project management, SQL, API, text_id, owner_id
 author: Bergfrid Dias
 date: 11.05.2021
 content_type: concept
-redirect_from: /en/project/howto/sql/text-table
+redirect_from:
+  - /en/project/howto/sql/text-table
+  - /en/api/netserver/sql/howto/project/text-table
 ---
 
 # Text table

--- a/docs/en/api/sql/howto/saint/get-contact-by-saint-value.md
+++ b/docs/en/api/sql/howto/saint/get-contact-by-saint-value.md
@@ -7,7 +7,9 @@ author: Bergfrid Skaara Dias
 date: 06.09.2023
 version: 10
 content_type: howto
-redirect_from: /en/sale/saint/howto/sql/get-contact-by-saint-value
+redirect_from:
+  - /en/sale/saint/howto/sql/get-contact-by-saint-value
+  - /en/api/netserver/sql/howto/saint/get-contact-by-saint-value
 ---
 
 # Search for a contact with a given saint value

--- a/docs/en/api/sql/howto/saint/index.md
+++ b/docs/en/api/sql/howto/saint/index.md
@@ -7,7 +7,9 @@ author: Bergfrid Skaara Dias
 date: 06.09.2023
 version: 10
 content_type: concept
-redirect_from: /en/sale/saint/howto/sql/index
+redirect_from:
+  - /en/sale/saint/howto/sql/index
+  - /en/api/netserver/sql/howto/saint/index
 ---
 
 # SAINT - raw SQL

--- a/docs/en/api/sql/howto/saint/search-saint-values.md
+++ b/docs/en/api/sql/howto/saint/search-saint-values.md
@@ -7,7 +7,9 @@ author: Bergfrid Skaara Dias
 date: 06.09.2023
 version: 10
 content_type: howto
-redirect_from: /en/sale/saint/howto/sql/search-saint-values
+redirect_from:
+  - /en/sale/saint/howto/sql/search-saint-values
+  - /en/api/netserver/sql/howto/saint/search-saint-values
 ---
 
 # Searches on SAINT values

--- a/docs/en/api/sql/howto/sale/stakeholders.md
+++ b/docs/en/api/sql/howto/sale/stakeholders.md
@@ -7,7 +7,9 @@ author: Bergfrid Dias
 date: 11.05.2021
 version: 7.1
 content_type: concept
-redirect_from: /en/sale/howto/sql/stakeholders
+redirect_from:
+  - /en/sale/howto/sql/stakeholders
+  - /en/api/netserver/sql/howto/sale/stakeholders
 ---
 
 # Sale stakeholders

--- a/docs/en/api/web-services/endpoints/agents-webapi/index.md
+++ b/docs/en/api/web-services/endpoints/agents-webapi/index.md
@@ -9,6 +9,7 @@ version: 10
 content_type: concept
 audience: api
 audience_tooltip: SuperOffice APIs and database
+redirect_from: /en/api/netserver/web-services/endpoints/agents-webapi/index
 ---
 
 # Agents WebAPI

--- a/docs/en/api/web-services/endpoints/get-webapi-version.md
+++ b/docs/en/api/web-services/endpoints/get-webapi-version.md
@@ -6,6 +6,7 @@ author: Bergfrid Dias
 date: 11.19.2021
 keywords: API, web services, endpoints, WebAPI, REST, Agents, version
 content_type: howto
+redirect_from: /en/api/netserver/web-services/endpoints/get-webapi-version
 ---
 
 # How to get the API version

--- a/docs/en/api/web-services/endpoints/http-headers.md
+++ b/docs/en/api/web-services/endpoints/http-headers.md
@@ -6,6 +6,7 @@ author: Bergfrid Dias
 date: 12.02.2021
 keywords: API, WebAPI, headers, Accept-Language, Content-Type, If-Modified-Since, If-Unmodified-Since, internationalization, SO-Language, SO-Culture, Accept, If-Modified-Since, If-Unmodified-Since, SO-TimeZone, includeTZOffset
 content_type: concept 
+redirect_from: /en/api/netserver/web-services/endpoints/http-headers
 ---
 
 # Headers

--- a/docs/en/api/web-services/endpoints/index.md
+++ b/docs/en/api/web-services/endpoints/index.md
@@ -6,6 +6,7 @@ author: Bergfrid Dias
 date: 12.02.2021
 keywords: API, web services, endpoints, WebAPI, SOAP, REST
 content_type: concept
+redirect_from: /en/api/netserver/web-services/endpoints/index
 ---
 
 # Endpoints

--- a/docs/en/api/web-services/endpoints/rest-webapi/index.md
+++ b/docs/en/api/web-services/endpoints/rest-webapi/index.md
@@ -8,6 +8,7 @@ date: 05.23.2025
 content_type: concept
 audience: api
 audience_tooltip: SuperOffice APIs and database
+redirect_from: /en/api/netserver/web-services/endpoints/rest-webapi/index
 ---
 
 # REST WebAPI

--- a/docs/en/api/web-services/endpoints/soap/index.md
+++ b/docs/en/api/web-services/endpoints/soap/index.md
@@ -6,6 +6,7 @@ author: Bergfrid Dias
 date: 12.02.2021
 keywords: API, web services, endpoints, SOAP, Agents, Services88
 content_type: concept
+redirect_from: /en/api/netserver/web-services/endpoints/soap/index
 ---
 
 # SOAP API

--- a/docs/en/api/web-services/howto/address/get-localized-address.md
+++ b/docs/en/api/web-services/howto/address/get-localized-address.md
@@ -7,7 +7,9 @@ author: Tony Yates
 date: 05.15.2017
 version: 8
 content_type: howto
-redirect_from: /en/globalization-and-localization/address/howto/services/get-localized-address
+redirect_from:
+  - /en/globalization-and-localization/address/howto/services/get-localized-address
+  - /en/api/netserver/web-services/howto/address/get-localized-address
 ---
 
 # Read the LocalizedAddress

--- a/docs/en/api/web-services/howto/address/index.md
+++ b/docs/en/api/web-services/howto/address/index.md
@@ -7,7 +7,9 @@ author: Bergfrid Dias
 date: 02.16.2022
 version: 9
 content_type: howto
-redirect_from: /en/globalization-and-localization/address/howto/services/index
+redirect_from:
+  - /en/globalization-and-localization/address/howto/services/index
+  - /en/api/netserver/web-services/howto/address/index
 ---
 
 # Address - web services

--- a/docs/en/api/web-services/howto/address/set-localized-address.md
+++ b/docs/en/api/web-services/howto/address/set-localized-address.md
@@ -7,7 +7,9 @@ author: Tony Yates
 date: 05.15.2017
 version: 9
 content_type: howto
-redirect_from: /en/globalization-and-localization/address/howto/services/set-localized-address
+redirect_from:
+  - /en/globalization-and-localization/address/howto/services/set-localized-address
+  - /en/api/netserver/web-services/howto/address/set-localized-address
 ---
 
 # Set LocalizedAddress

--- a/docs/en/api/web-services/howto/company/add-catlist-item-rest.md
+++ b/docs/en/api/web-services/howto/company/add-catlist-item-rest.md
@@ -6,7 +6,9 @@ keywords: category, contact, rest
 author: Tony Yates
 content_type: howto
 date: 10.22.2024
-redirect_from: /en/company/howto/services/add-catlist-item-rest
+redirect_from:
+  - /en/company/howto/services/add-catlist-item-rest
+  - /en/api/netserver/web-services/howto/company/add-catlist-item-rest
 ---
 
 # Add a category list item using REST

--- a/docs/en/api/web-services/howto/company/add-catlist-item-webapi-agents.md
+++ b/docs/en/api/web-services/howto/company/add-catlist-item-webapi-agents.md
@@ -6,7 +6,9 @@ keywords: category, contact, WebAPI, agents
 author: Bergfrid Dias
 date: 11.18.2021
 content_type: howto
-redirect_from: /en/company/howto/services/add-catlist-item-webapi-agents
+redirect_from:
+  - /en/company/howto/services/add-catlist-item-webapi-agents
+  - /en/api/netserver/web-services/howto/company/add-catlist-item-webapi-agents
 ---
 
 # Add a category list item

--- a/docs/en/api/web-services/howto/company/create-contact.md
+++ b/docs/en/api/web-services/howto/company/create-contact.md
@@ -14,8 +14,13 @@ redirect_from:
   - /en/api/web-services/howto/company/create-contact-services
   - /en/api/web-services/howto/company/create-contact-webapi-agents
   - /en/company/howto/services/create-contact-rest
+  - /en/api/netserver/web-services/howto/company/create-contact
+  - /en/api/netserver/web-services/howto/company/create-contact-rest
+  - /en/api/netserver/web-services/howto/company/create-contact-services
+  - /en/api/netserver/web-services/howto/company/create-contact-webapi-agents
   - /en/company/howto/services/create-contact-services
   - /en/company/howto/services/create-contact-webapi-agents
+redirect_from: /en/api/netserver/web-services/howto/company/create-contact
 ---
 
 <!-- markdownlint-disable-file MD051 -->

--- a/docs/en/api/web-services/howto/company/get-all-contacts-rest.md
+++ b/docs/en/api/web-services/howto/company/get-all-contacts-rest.md
@@ -6,7 +6,9 @@ keywords: contact, company, services, API, search, rest
 author: Tony Yates
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/company/howto/services/get-all-contacts-rest
+redirect_from:
+  - /en/company/howto/services/get-all-contacts-rest
+  - /en/api/netserver/web-services/howto/company/get-all-contacts-rest
 ---
 
 # Select all companies

--- a/docs/en/api/web-services/howto/company/get-catlist-listagent.md
+++ b/docs/en/api/web-services/howto/company/get-catlist-listagent.md
@@ -6,7 +6,9 @@ keywords: category, list agent
 author: Tony Yates
 date: 02.21.2022
 content_type: howto
-redirect_from: /en/company/howto/services/get-catlist-listagent
+redirect_from:
+  - /en/company/howto/services/get-catlist-listagent
+  - /en/api/netserver/web-services/howto/company/get-catlist-listagent
 ---
 
 # Get a CategoryList using the ListAgent

--- a/docs/en/api/web-services/howto/company/get-catlist-mdoagent.md
+++ b/docs/en/api/web-services/howto/company/get-catlist-mdoagent.md
@@ -6,7 +6,9 @@ keywords: category, MDO agent
 author: Tony Yates
 date: 10.22.2024
 content_type: howto
-redirect_from: /en/company/howto/services/get-catlist-mdoagent
+redirect_from:
+  - /en/company/howto/services/get-catlist-mdoagent
+  - /en/api/netserver/web-services/howto/company/get-catlist-mdoagent
 ---
 
 # Get a CategoryList using the MDO Agent

--- a/docs/en/api/web-services/howto/company/get-contact-via-services-layer.md
+++ b/docs/en/api/web-services/howto/company/get-contact-via-services-layer.md
@@ -6,7 +6,9 @@ keywords: contact, company, services, API, api-services, ContactAgent
 author: Tony Yates
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/company/howto/services/get-contact-via-services-layer
+redirect_from:
+  - /en/company/howto/services/get-contact-via-services-layer
+  - /en/api/netserver/web-services/howto/company/get-contact-via-services-layer
 ---
 
 # Get a contact through the services layer

--- a/docs/en/api/web-services/howto/company/get-interests-for-contact-services.md
+++ b/docs/en/api/web-services/howto/company/get-interests-for-contact-services.md
@@ -6,7 +6,9 @@ keywords: contact, company, services, API, interest, ContactAgent, SelectableMDO
 author: Tony Yates
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/company/howto/services/get-interests-for-contact-services
+redirect_from:
+  - /en/company/howto/services/get-interests-for-contact-services
+  - /en/api/netserver/web-services/howto/company/get-interests-for-contact-services
 ---
 
 # How to list all selected interests for a contact (services)

--- a/docs/en/api/web-services/howto/company/get-set-category-mdoagent.md
+++ b/docs/en/api/web-services/howto/company/get-set-category-mdoagent.md
@@ -6,7 +6,9 @@ keywords: MDOAgent
 author: Bergfrid Dias
 date: 02.22.2022
 content_type: howto
-redirect_from: /en/company/howto/services/get-set-category-mdoagent
+redirect_from:
+  - /en/company/howto/services/get-set-category-mdoagent
+  - /en/api/netserver/web-services/howto/company/get-set-category-mdoagent
 ---
 
 # How to get the category list and set category on a contact

--- a/docs/en/api/web-services/howto/company/index.md
+++ b/docs/en/api/web-services/howto/company/index.md
@@ -9,7 +9,9 @@ version: 10
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/company/howto/services/index
+redirect_from:
+  - /en/company/howto/services/index
+  - /en/api/netserver/web-services/howto/company/index
 ---
 
 # Contact - services

--- a/docs/en/api/web-services/howto/company/set-interest-on-off-services.md
+++ b/docs/en/api/web-services/howto/company/set-interest-on-off-services.md
@@ -6,7 +6,9 @@ keywords: contact, company, services, API, interest, ContactAgent, electableMDOL
 author: Tony Yates
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/company/howto/services/set-interest-on-off-services
+redirect_from:
+  - /en/company/howto/services/set-interest-on-off-services
+  - /en/api/netserver/web-services/howto/company/set-interest-on-off-services
 ---
 
 # How to set an interest on or off for a contact (services)

--- a/docs/en/api/web-services/howto/contact/display-image-from-blob-table-services.md
+++ b/docs/en/api/web-services/howto/contact/display-image-from-blob-table-services.md
@@ -5,7 +5,9 @@ description: How to display an image from the Blob table using services
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/contact/howto/services/display-image-from-blob-table-services
+redirect_from:
+  - /en/contact/howto/services/display-image-from-blob-table-services
+  - /en/api/netserver/web-services/howto/contact/display-image-from-blob-table-services
 ---
 
 # How to display an image from the Blob table (services)

--- a/docs/en/api/web-services/howto/contact/display-person-image-ws.md
+++ b/docs/en/api/web-services/howto/contact/display-person-image-ws.md
@@ -6,7 +6,9 @@ keywords: person, contact, web services, API, ImageUtility
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/contact/howto/services/display-person-image-ws
+redirect_from:
+  - /en/contact/howto/services/display-person-image-ws
+  - /en/api/netserver/web-services/howto/contact/display-person-image-ws
 ---
 
 # Display person image

--- a/docs/en/api/web-services/howto/contact/get-person-image-rest.md
+++ b/docs/en/api/web-services/howto/contact/get-person-image-rest.md
@@ -6,7 +6,9 @@ keywords: person, contact, services, API, REST, image
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/contact/howto/services/get-person-image-rest
+redirect_from:
+  - /en/contact/howto/services/get-person-image-rest
+  - /en/api/netserver/web-services/howto/contact/get-person-image-rest
 ---
 
 # Display a person's picture

--- a/docs/en/api/web-services/howto/contact/get-persons-contactagent.md
+++ b/docs/en/api/web-services/howto/contact/get-persons-contactagent.md
@@ -6,7 +6,9 @@ keywords: person, contact, services, API, api-services, ContactAgent, PersonAgen
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/contact/howto/services/get-persons-contactagent
+redirect_from:
+  - /en/contact/howto/services/get-persons-contactagent
+  - /en/api/netserver/web-services/howto/contact/get-persons-contactagent
 ---
 
 # Retrieving list of persons with ContactAgent

--- a/docs/en/api/web-services/howto/contact/get-persons-personagent.md
+++ b/docs/en/api/web-services/howto/contact/get-persons-personagent.md
@@ -6,7 +6,9 @@ keywords: person, contact, services, API, api-services, PersonAgent, GetPersonLi
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/contact/howto/services/get-persons-personagent
+redirect_from:
+  - /en/contact/howto/services/get-persons-personagent
+  - /en/api/netserver/web-services/howto/contact/get-persons-personagent
 ---
 
 # Retrieving list of persons with PersonAgent

--- a/docs/en/api/web-services/howto/contact/index.md
+++ b/docs/en/api/web-services/howto/contact/index.md
@@ -6,7 +6,9 @@ keywords: person, contact, services, API
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: concept
-redirect_from: /en/contact/howto/services/index
+redirect_from:
+  - /en/contact/howto/services/index
+  - /en/api/netserver/web-services/howto/contact/index
 ---
 
 # Contact - services

--- a/docs/en/api/web-services/howto/contact/update-person-image-rest.md
+++ b/docs/en/api/web-services/howto/contact/update-person-image-rest.md
@@ -6,7 +6,9 @@ keywords: person, contact, services, API, REST
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/contact/howto/services/update-person-image-rest
+redirect_from:
+  - /en/contact/howto/services/update-person-image-rest
+  - /en/api/netserver/web-services/howto/contact/update-person-image-rest
 ---
 
 # Update the person's picture

--- a/docs/en/api/web-services/howto/contact/update-person-services.md
+++ b/docs/en/api/web-services/howto/contact/update-person-services.md
@@ -6,7 +6,9 @@ keywords: person, contact, services, API api-services, GetPersonEntity, PersonAg
 author: Bergfrid Skaara Dias
 date: 11.04.2021
 content_type: howto
-redirect_from: /en/contact/howto/services/update-person-services
+redirect_from:
+  - /en/contact/howto/services/update-person-services
+  - /en/api/netserver/web-services/howto/contact/update-person-services
 ---
 
 # Update a person with a new name, address, position using services

--- a/docs/en/api/web-services/howto/custom-objects/custom-objects-search.md
+++ b/docs/en/api/web-services/howto/custom-objects/custom-objects-search.md
@@ -9,7 +9,9 @@ keywords: custom object, search, DatabaseTable, TableRecord, extra table
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/api/custom-objects/howto/custom-objects-search
+redirect_from:
+  - /en/api/custom-objects/howto/custom-objects-search
+  - /en/api/netserver/web-services/howto/custom-objects/custom-objects-search
 ---
 
 <!-- markdownlint-disable-file MD013 -->

--- a/docs/en/api/web-services/howto/custom-objects/find-contact-by-udef.md
+++ b/docs/en/api/web-services/howto/custom-objects/find-contact-by-udef.md
@@ -8,7 +8,9 @@ keywords: udef, user-defined field, custom field, API, FindAgent, GetSpecifiedCr
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/custom-objects/udef/howto/services/find-contact-by-udef
+redirect_from:
+  - /en/custom-objects/udef/howto/services/find-contact-by-udef
+  - /en/api/netserver/web-services/howto/custom-objects/find-contact-by-udef
 ---
 
 # Find a contact using a udef field

--- a/docs/en/api/web-services/howto/custom-objects/get-udef-list-and-values.md
+++ b/docs/en/api/web-services/howto/custom-objects/get-udef-list-and-values.md
@@ -8,7 +8,9 @@ keywords: udef, user-defined field, custom field, API, api-services, GetUserDefi
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/custom-objects/udef/howto/services/get-udef-list-and-values
+redirect_from:
+  - /en/custom-objects/udef/howto/services/get-udef-list-and-values
+  - /en/api/netserver/web-services/howto/custom-objects/get-udef-list-and-values
 ---
 
 # How to display all user-defined fields

--- a/docs/en/api/web-services/howto/custom-objects/index.md
+++ b/docs/en/api/web-services/howto/custom-objects/index.md
@@ -12,6 +12,7 @@ audience_tooltip: SuperOffice APIs and database
 redirect_from:
   - /en/api/custom-objects/index
   - /en/custom-objects/udef/howto/services/index
+  - /en/api/netserver/web-services/howto/custom-objects/index
 ---
 
 # Introduction to custom objects and fields

--- a/docs/en/api/web-services/howto/custom-objects/rest-add-custom-object-row.md
+++ b/docs/en/api/web-services/howto/custom-objects/rest-add-custom-object-row.md
@@ -9,7 +9,9 @@ keywords: custom object, InsertRow, DatabaseTable, TableRecord, extra table
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/api/custom-objects/howto/custom-objects-insert-row
+redirect_from:
+  - /en/api/custom-objects/howto/custom-objects-insert-row
+  - /en/api/netserver/web-services/howto/custom-objects/rest-add-custom-object-row
 ---
 
 <!-- markdownlint-disable-file MD051 -->

--- a/docs/en/api/web-services/howto/custom-objects/rest-create-udef-field.md
+++ b/docs/en/api/web-services/howto/custom-objects/rest-create-udef-field.md
@@ -8,7 +8,9 @@ date: 03.11.2022
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/custom-objects/udef/howto/services/rest-create-udef-field
+redirect_from:
+  - /en/custom-objects/udef/howto/services/rest-create-udef-field
+  - /en/api/netserver/web-services/howto/custom-objects/rest-create-udef-field
 ---
 
 # How to create a user-defined field using the web services API

--- a/docs/en/api/web-services/howto/custom-objects/rest-delete-custom-object-row.md
+++ b/docs/en/api/web-services/howto/custom-objects/rest-delete-custom-object-row.md
@@ -9,7 +9,9 @@ version: 10
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/api/custom-objects/howto/custom-objects-delete-row
+redirect_from:
+  - /en/api/custom-objects/howto/custom-objects-delete-row
+  - /en/api/netserver/web-services/howto/custom-objects/rest-delete-custom-object-row
 ---
 
 <!-- markdownlint-disable-file MD051 -->

--- a/docs/en/api/web-services/howto/custom-objects/rest-delete-udef-field.md
+++ b/docs/en/api/web-services/howto/custom-objects/rest-delete-udef-field.md
@@ -8,7 +8,9 @@ date: 03.11.2022
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/custom-objects/udef/howto/services/rest-delete-udef-field
+redirect_from:
+  - /en/custom-objects/udef/howto/services/rest-delete-udef-field
+  - /en/api/netserver/web-services/howto/custom-objects/rest-delete-udef-field
 ---
 
 # How to delete a user-defined field using the web services API

--- a/docs/en/api/web-services/howto/custom-objects/rest-get-all-udef-fields.md
+++ b/docs/en/api/web-services/howto/custom-objects/rest-get-all-udef-fields.md
@@ -8,7 +8,9 @@ date: 03.11.2022
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/custom-objects/udef/howto/services/rest-get-all-udef-fields
+redirect_from:
+  - /en/custom-objects/udef/howto/services/rest-get-all-udef-fields
+  - /en/api/netserver/web-services/howto/custom-objects/rest-get-all-udef-fields
 ---
 
 # How to get all user-defined fields using the web services API

--- a/docs/en/api/web-services/howto/custom-objects/rest-get-custom-object-row.md
+++ b/docs/en/api/web-services/howto/custom-objects/rest-get-custom-object-row.md
@@ -9,7 +9,9 @@ keywords: custom object, ReadRow, DatabaseTable, TableRecord, extra table
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/api/custom-objects/howto/custom-objects-read-row
+redirect_from:
+  - /en/api/custom-objects/howto/custom-objects-read-row
+  - /en/api/netserver/web-services/howto/custom-objects/rest-get-custom-object-row
 ---
 
 <!-- markdownlint-disable-file MD051 -->

--- a/docs/en/api/web-services/howto/custom-objects/rest-update-custom-object-row.md
+++ b/docs/en/api/web-services/howto/custom-objects/rest-update-custom-object-row.md
@@ -9,7 +9,9 @@ keywords: custom object, UpdateRow, DatabaseTable, TableRecord, extra table
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/api/custom-objects/howto/custom-objects-update-row
+redirect_from:
+  - /en/api/custom-objects/howto/custom-objects-update-row
+  - /en/api/netserver/web-services/howto/custom-objects/rest-update-custom-object-row
 ---
 
 <!-- markdownlint-disable-file MD051 -->

--- a/docs/en/api/web-services/howto/custom-objects/rest-update-udef-field.md
+++ b/docs/en/api/web-services/howto/custom-objects/rest-update-udef-field.md
@@ -8,7 +8,9 @@ date: 03.11.2022
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/custom-objects/udef/howto/services/rest-update-udef-field
+redirect_from:
+  - /en/custom-objects/udef/howto/services/rest-update-udef-field
+  - /en/api/netserver/web-services/howto/custom-objects/rest-update-udef-field
 ---
 
 # How to update a user-defined field using the web services API

--- a/docs/en/api/web-services/howto/custom-objects/set-udef-listitem-value.md
+++ b/docs/en/api/web-services/howto/custom-objects/set-udef-listitem-value.md
@@ -8,7 +8,9 @@ date: 11.05.2021
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
-redirect_from: /en/custom-objects/udef/howto/services/set-udef-listitem-value
+redirect_from:
+  - /en/custom-objects/udef/howto/services/set-udef-listitem-value
+  - /en/api/netserver/web-services/howto/custom-objects/set-udef-listitem-value
 ---
 
 # How to set a user-defined list item on a Udef field (services)

--- a/docs/en/api/web-services/howto/diary/accept-invitation-services.md
+++ b/docs/en/api/web-services/howto/diary/accept-invitation-services.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, invitation, API, web services
 author: Bergfrid Skaara Dias
 date: 03.18.2022
 content_type: howto
-redirect_from: /en/diary/howto/services/accept-invitation-services
+redirect_from:
+  - /en/diary/howto/services/accept-invitation-services
+  - /en/api/netserver/web-services/howto/diary/accept-invitation-services
 ---
 
 # How to accept an invitation (services)

--- a/docs/en/api/web-services/howto/diary/create-apt-services.md
+++ b/docs/en/api/web-services/howto/diary/create-apt-services.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, API, web services
 author: Bergfrid Skaara Dias
 date: 03.18.2022
 content_type: howto
-redirect_from: /en/diary/howto/services/create-apt-services
+redirect_from:
+  - /en/diary/howto/services/create-apt-services
+  - /en/api/netserver/web-services/howto/diary/create-apt-services
 ---
 
 # Create an appointment using services

--- a/docs/en/api/web-services/howto/diary/create-invitation-services.md
+++ b/docs/en/api/web-services/howto/diary/create-invitation-services.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, API, web services
 author: Bergfrid Skaara Dias
 date: 03.18.2022
 content_type: howto
-redirect_from: /en/diary/howto/services/create-invitation-services
+redirect_from:
+  - /en/diary/howto/services/create-invitation-services
+  - /en/api/netserver/web-services/howto/diary/create-invitation-services
 ---
 
 # How to create an invitation (services)

--- a/docs/en/api/web-services/howto/diary/create-recurring-appointment-services.md
+++ b/docs/en/api/web-services/howto/diary/create-recurring-appointment-services.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, API, web services, recurrence
 author: Bergfrid Skaara Dias
 date: 03.18.2022
 content_type: howto
-redirect_from: /en/diary/howto/services/create-recurring-appointment-services
+redirect_from:
+  - /en/diary/howto/services/create-recurring-appointment-services
+  - /en/api/netserver/web-services/howto/diary/create-recurring-appointment-services
 ---
 
 # How to create a recurring appointment (services)

--- a/docs/en/api/web-services/howto/diary/get-invitations-services.md
+++ b/docs/en/api/web-services/howto/diary/get-invitations-services.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, API, web services, archiveprovider
 author: Bergfrid Skaara Dias
 date: 03.18.2022
 content_type: howto
-redirect_from: /en/diary/howto/services/get-invitations-services
+redirect_from:
+  - /en/diary/howto/services/get-invitations-services
+  - /en/api/netserver/web-services/howto/diary/get-invitations-services
 ---
 
 # How to get a list of invitations (services)

--- a/docs/en/api/web-services/howto/diary/index.md
+++ b/docs/en/api/web-services/howto/diary/index.md
@@ -6,7 +6,9 @@ keywords: diary, calendar, appointment, invitation, API, web services
 author: Bergfrid Skaara Dias
 date: 03.18.2022
 content_type: concept
-redirect_from: /en/diary/howto/services/index
+redirect_from:
+  - /en/diary/howto/services/index
+  - /en/api/netserver/web-services/howto/diary/index
 ---
 
 # Diary - services

--- a/docs/en/api/web-services/howto/diary/rest-create-videomeeting.md
+++ b/docs/en/api/web-services/howto/diary/rest-create-videomeeting.md
@@ -9,6 +9,7 @@ version: 10.5.5
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
+redirect_from: /en/api/netserver/web-services/howto/diary/rest-create-videomeeting
 ---
 
 # Create a video meeting

--- a/docs/en/api/web-services/howto/diary/rest-delete-videomeeting.md
+++ b/docs/en/api/web-services/howto/diary/rest-delete-videomeeting.md
@@ -9,6 +9,7 @@ version: 10.5.5
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
+redirect_from: /en/api/netserver/web-services/howto/diary/rest-delete-videomeeting
 ---
 
 # Delete a video meeting

--- a/docs/en/api/web-services/howto/document/index.md
+++ b/docs/en/api/web-services/howto/document/index.md
@@ -14,6 +14,7 @@ redirect_from:
   - /en/document/howto/agents-web-api/index
   - /en/document/howto/rest/index
   - /en/document/howto/services/index
+redirect_from: /en/api/netserver/web-services/howto/document/index
 ---
 
 # Document API options

--- a/docs/en/api/web-services/howto/document/rest-add-document-template.md
+++ b/docs/en/api/web-services/howto/document/rest-add-document-template.md
@@ -12,6 +12,7 @@ audience_tooltip: SuperOffice APIs and database
 redirect_from:
   - /en/document/howto/agents-web-api/add-document-template
   - /en/document/howto/rest/add-document-template
+  - /en/api/netserver/web-services/howto/document/rest-add-document-template
 ---
 
 # Add a document template

--- a/docs/en/api/web-services/howto/document/rest-generate-document.md
+++ b/docs/en/api/web-services/howto/document/rest-generate-document.md
@@ -12,6 +12,7 @@ audience_tooltip: SuperOffice APIs and database
 redirect_from:
   - /en/document/howto/agents-web-api/generate-document
   - /en/document/howto/rest/generate-document
+  - /en/api/netserver/web-services/howto/document/rest-generate-document
 ---
 
 # Generate a document

--- a/docs/en/api/web-services/howto/document/services-configure-access.md
+++ b/docs/en/api/web-services/howto/document/services-configure-access.md
@@ -11,7 +11,9 @@ audience: api
 audience_tooltip: SuperOffice APIs and database
 category: document
 area: api-services
-redirect_from: /en/document/howto/services/configure-access
+redirect_from:
+  - /en/document/howto/services/configure-access
+  - /en/api/netserver/web-services/howto/document/services-configure-access
 ---
 
 # Configuring document access

--- a/docs/en/api/web-services/howto/document/services-create.md
+++ b/docs/en/api/web-services/howto/document/services-create.md
@@ -11,7 +11,9 @@ audience: api
 audience_tooltip: SuperOffice APIs and database
 category: document
 area: api-services
-redirect_from: /en/document/howto/services/create
+redirect_from:
+  - /en/document/howto/services/create
+  - /en/api/netserver/web-services/howto/document/services-create
 ---
 
 # How to create a new document in SO_ARC

--- a/docs/en/api/web-services/howto/document/services-download.md
+++ b/docs/en/api/web-services/howto/document/services-download.md
@@ -11,7 +11,9 @@ audience: api
 audience_tooltip: SuperOffice APIs and database
 category: document
 area: api-services
-redirect_from: /en/document/howto/services/download
+redirect_from:
+  - /en/document/howto/services/download
+  - /en/api/netserver/web-services/howto/document/services-download
 ---
 
 # How to download a new document

--- a/docs/en/api/web-services/howto/document/services-update.md
+++ b/docs/en/api/web-services/howto/document/services-update.md
@@ -11,7 +11,9 @@ audience: api
 audience_tooltip: SuperOffice APIs and database
 category: document
 area: api-services
-redirect_from: /en/document/howto/services/update
+redirect_from:
+  - /en/document/howto/services/update
+  - /en/api/netserver/web-services/howto/document/services-update
 ---
 
 # How to update a document in SO_ARC

--- a/docs/en/api/web-services/howto/flows/index.md
+++ b/docs/en/api/web-services/howto/flows/index.md
@@ -9,6 +9,7 @@ version: 10.3.5
 content_type: concept
 audience: api
 audience_tooltip: SuperOffice APIs and database
+redirect_from: /en/api/netserver/web-services/howto/flows/index
 ---
 
 # Introduction to working with flows through the APIs

--- a/docs/en/api/web-services/howto/flows/rest-create-default-email-flow.md
+++ b/docs/en/api/web-services/howto/flows/rest-create-default-email-flow.md
@@ -9,6 +9,7 @@ version: 10.3.5
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
+redirect_from: /en/api/netserver/web-services/howto/flows/rest-create-default-email-flow
 ---
 
 # Create an EmailFlow object

--- a/docs/en/api/web-services/howto/flows/rest-create-flow-step.md
+++ b/docs/en/api/web-services/howto/flows/rest-create-flow-step.md
@@ -9,6 +9,7 @@ version: 10.3.5
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
+redirect_from: /en/api/netserver/web-services/howto/flows/rest-create-flow-step
 ---
 
 # Create a Step object

--- a/docs/en/api/web-services/howto/flows/rest-create-flow-trigger.md
+++ b/docs/en/api/web-services/howto/flows/rest-create-flow-trigger.md
@@ -9,6 +9,7 @@ version: 10.3.5
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
+redirect_from: /en/api/netserver/web-services/howto/flows/rest-create-flow-trigger
 ---
 
 # Create a Trigger object

--- a/docs/en/api/web-services/howto/flows/rest-save-flow.md
+++ b/docs/en/api/web-services/howto/flows/rest-save-flow.md
@@ -9,6 +9,7 @@ version: 10.3.5
 content_type: concept
 audience: api
 audience_tooltip: SuperOffice APIs and database
+redirect_from: /en/api/netserver/web-services/howto/flows/rest-save-flow
 ---
 
 # Save email flow

--- a/docs/en/api/web-services/howto/index.md
+++ b/docs/en/api/web-services/howto/index.md
@@ -9,6 +9,7 @@ version: 10.3
 content_type: howto
 audience: api
 audience_tooltip: SuperOffice APIs and database
+redirect_from: /en/api/netserver/web-services/howto/index
 ---
 
 # Working web services and REST

--- a/docs/en/api/web-services/howto/sale/index.md
+++ b/docs/en/api/web-services/howto/sale/index.md
@@ -7,7 +7,9 @@ author: Bergfrid Skaara Dias
 date: 11.05.2021
 version: 10
 content_type: concept
-redirect_from: /en/sale/howto/services/index
+redirect_from:
+  - /en/sale/howto/services/index
+  - /en/api/netserver/web-services/howto/sale/index
 ---
 
 # Sale - web services

--- a/docs/en/api/web-services/howto/sale/link-sale-to-appointment.md
+++ b/docs/en/api/web-services/howto/sale/link-sale-to-appointment.md
@@ -7,7 +7,9 @@ author: Bergfrid Skaara Dias
 date: 11.05.2021
 version: 10
 content_type: howto
-redirect_from: /en/sale/howto/services/link-sale-to-appointment
+redirect_from:
+  - /en/sale/howto/services/link-sale-to-appointment
+  - /en/api/netserver/web-services/howto/sale/link-sale-to-appointment
 ---
 
 # How to link a sale to a follow-up (services)

--- a/docs/en/api/web-services/index.md
+++ b/docs/en/api/web-services/index.md
@@ -8,6 +8,7 @@ keywords: API, web services, endpoints, proxy, NetServer, SOAP, REST, Agent, Sup
 content_type: concept
 deployment: online, onsite
 platform: web, win
+redirect_from: /en/api/netserver/web-services/index
 ---
 
 # Web services

--- a/docs/en/api/web-services/proxies/built-in.md
+++ b/docs/en/api/web-services/proxies/built-in.md
@@ -6,6 +6,7 @@ author: Bergfrid Dias
 date: 12.03.2021
 keywords: API, web services, proxy, WebAPI, SOAP, SuperOffice.Service.dll, modes, DefaultMode
 content_type: howto
+redirect_from: /en/api/netserver/web-services/proxies/built-in
 ---
 
 # Calling SOAP using the NetServer proxy

--- a/docs/en/api/web-services/proxies/custom.md
+++ b/docs/en/api/web-services/proxies/custom.md
@@ -6,6 +6,7 @@ author: Bergfrid Dias
 date: 11.19.2021
 keywords: API, web services, proxy, SOAP, NetServer, WSDL
 content_type: howto
+redirect_from: /en/api/netserver/web-services/proxies/custom
 ---
 
 # Calling SOAP through a custom proxy

--- a/docs/en/api/web-services/proxies/index.md
+++ b/docs/en/api/web-services/proxies/index.md
@@ -6,6 +6,7 @@ author: Bergfrid Dias
 date: 12.02.2021
 keywords: API, web services, proxy, WebAPI, SOAP, WebApiOptions
 content_type: concept
+redirect_from: /en/api/netserver/web-services/proxies/index
 ---
 
 # NetServer web service proxies

--- a/docs/en/api/web-services/proxies/superoffice-webapi/iauthorization.md
+++ b/docs/en/api/web-services/proxies/superoffice-webapi/iauthorization.md
@@ -6,6 +6,7 @@ author: Anthony Yates
 date: 11.24.2021
 keywords: API, web services, proxy, WebAPI, REST, IAuthorization, credentials, AuthorizationSystemUserTicket, AuthorizationAccessToken, AuthorizationUserToken, jwks_uri
 content_type: concept
+redirect_from: /en/api/netserver/web-services/proxies/superoffice-webapi/iauthorization
 ---
 
 # About IAuthorization

--- a/docs/en/api/web-services/proxies/superoffice-webapi/index.md
+++ b/docs/en/api/web-services/proxies/superoffice-webapi/index.md
@@ -6,6 +6,7 @@ author: Bergfrid Dias
 date: 11.24.2021
 keywords: API, web services, proxy, WebAPI, SuperOffice.WebApi, WebApiOptions, RequestOptions, IAuthorization, async await
 content_type: howto
+redirect_from: /en/api/netserver/web-services/proxies/superoffice-webapi/index
 ---
 
 # How to use SuperOffice.WebApi

--- a/docs/en/api/web-services/proxies/superoffice-webapi/systemuserclient.md
+++ b/docs/en/api/web-services/proxies/superoffice-webapi/systemuserclient.md
@@ -6,6 +6,7 @@ author: Anthony Yates
 date: 11.24.2021
 keywords: API, web services, proxy, WebAPI, REST, system user, authentication, PartnerSystemUserService, Ticket, SystemUserClient, SuperOffice.WebApi.IdentityModel
 content_type: concept
+redirect_from: /en/api/netserver/web-services/proxies/superoffice-webapi/systemuserclient
 ---
 
 # How to use System User Client

--- a/docs/en/api/web-services/so-timezone.md
+++ b/docs/en/api/web-services/so-timezone.md
@@ -6,6 +6,7 @@ author: Bergfrid Dias
 date: 11.19.2021
 keywords: timezone, date, timeanddate
 content_type: concept 
+redirect_from: /en/api/netserver/web-services/so-timezone
 ---
 
 # SOTimezone

--- a/docs/en/api/web-services/webapi/index.md
+++ b/docs/en/api/web-services/webapi/index.md
@@ -8,6 +8,7 @@ keywords: security, authentication, WebAPI, SOTICKET, BEARER
 content_type: concept
 deployment: onsite
 platform: web
+redirect_from: /en/api/netserver/web-services/webapi/index
 ---
 
 # SuperOffice WebApi


### PR DESCRIPTION
## Folders to update

- archive-providers
- bulk-operations
- caching
- config
- custom-objects
- entities
- foreign-keys
- lists
- logging
- mdo-providers
- osql
- plugins
- rows
- search
- sql
- web-service

(excluding generated references)

## Path prefix

/en/api/netserver/[PATH-WITHOUT-EXTENTION]

## Pattern

* If no redirect_from property, add it as 1 line with path prefix
* If redirect_from on string format, convert to array format and add line(s)
* If redirect_from on array format, add line(s)

## Special cases

* If the file is a docfx redirect (has redirect_url), don't add redirect_from to the stub but instead add it to the content file the URL points to. This is why some files are updated with more than one redirect_from value.
* docs/en/api/plugins/quote-connectors/api/quoteconnectorbase.md had no metadata, so I added the entire block