### PR TITLE
#2164 Fix soprotocol sample links in category pages

### DIFF
--- a/docs/en/company/index.yml
+++ b/docs/en/company/index.yml
@@ -99,15 +99,11 @@ conceptualContent:
       - text: SoProtocol - create company
         itemType: list
         typeDesc: how-to-guide
-        url: ../ui/soprotocol/create-contact.md
+        url: ../ui/soprotocol/howto/create-contact.md
       - text: SoProtocol - get company
         itemType: list
         typeDesc: how-to-guide
-        url: ../ui/soprotocol/get-contact.md
-      - text: SoProtocol - edit company
-        itemType: list
-        typeDesc: how-to-guide
-        url: ../ui/soprotocol/edit-contact.md
+        url: ../ui/soprotocol/howto/open-contact.md
 
     # Card
     - title: Data options

--- a/docs/en/contact/index.yml
+++ b/docs/en/contact/index.yml
@@ -111,7 +111,7 @@ conceptualContent:
       - text: SoProtocol - list of contacts from a company
         itemType: list
         typeDesc: how-to-guide
-        url: ../ui/soprotocol/show-persons-for-contact.md
+        url: ../ui/soprotocol/howto/open-contact.md
 
     # Card
     - title: Data options

--- a/docs/en/diary/index.yml
+++ b/docs/en/diary/index.yml
@@ -245,10 +245,10 @@ additionalContent:
         links:
         - text: Web panels
           url: ../ui/web-panels/index.md
-        - text: SoProtocol - create appointment
-          url: ../ui/soprotocol/create-appointment.md
-        - text: SoProtocol - open appointment dialog
-          url: ../ui/soprotocol/open-appointment-dialog.md
+        - text: SoProtocol - create follow-up
+          url: ../ui/soprotocol/howto/create-follow-up.md
+        - text: SoProtocol - open Follow-up dialog
+          url: ../ui/soprotocol/howto/open-follow-up.md
       # Card
       - title: Related content
         links:


### PR DESCRIPTION
## Changes

The *howto* sub-folder was missing from these URLs, and we've renamed and/or merged the target files.

Since the content merged into the open-contact sample, which we already link to, I removed the **edit company** entry. Also, we should not advertise edit because it is a deprecated capability.

## Where to test

Go to the company, contact, and diary category pages from the Areas drop-down menu on the navbar.