### PR TITLE
#2164 Change wording button > link in Gmail Link settings

### DIFF
--- a/docs/da/email/gmail-link/learn/settings.md
+++ b/docs/da/email/gmail-link/learn/settings.md
@@ -2,11 +2,16 @@
 uid: help-da-gmail-link-settings
 title: Redigering af Gmail Link-indstillinger
 description: Redigering af Gmail Link-indstillinger
-author: SuperOffice RnD
-date: 06.29.2022
-keywords: Gmail Link
+keywords: Gmail Link-indstillinger, Arkiver e-mail i SuperOffice
+author: SuperOffice Product and Engineering
+date: 08.25.2025
 content_type: reference
+category: email
+topic: Gmail Link
+audience: person
+audience_tooltip: SuperOffice CRM
 language: da
+index: true
 ---
 
 # Redigering af Gmail Link-indstillinger
@@ -56,7 +61,7 @@ Nederst i dialogboksen **SuperOffice Gmail Link - Indstillinger** finder du føl
 
 ## Rediger SuperOffice-bruger
 
-Klik på denne knap for at linke til en anden SuperOffice-installation. Følg vejledningen på skærmen.
+Klik på dette link for at linke til en anden SuperOffice-installation. Følg vejledningen på skærmen.
 
 <!-- Referenced links -->
 [3]: email-archive-incoming.md

--- a/docs/de/email/gmail-link/learn/settings.md
+++ b/docs/de/email/gmail-link/learn/settings.md
@@ -2,11 +2,16 @@
 uid: help-de-gmail-link-settings
 title: Einstellungen für Gmail Link bearbeiten
 description: Einstellungen für Gmail Link bearbeiten
-author: SuperOffice RnD
-date: 06.29.2022
-keywords: Gmail Link
+keywords: Gmail Link Einstellungen, E-Mail in SuperOffice archivieren
+author: SuperOffice Product and Engineering
+date: 08.25.2025
 content_type: reference
+category: email
+topic: Gmail Link
+audience: person
+audience_tooltip: SuperOffice CRM
 language: de
+index: true
 ---
 
 # Einstellungen für Gmail Link bearbeiten
@@ -56,7 +61,7 @@ Unten im Dialogfeld **SuperOffice Gmail Link - Einstellungen** werden folgende I
 
 ## SuperOffice Benutzer ändern
 
-Klicken Sie auf diese Schaltfläche, um die Verbindung zu einer anderen SuperOffice-Installation herzustellen. Befolgen Sie die Anweisungen auf dem Bildschirm.
+Klicken Sie auf diesen Link, um die Verbindung zu einer anderen SuperOffice-Installation herzustellen. Befolgen Sie die Anweisungen auf dem Bildschirm.
 
 <!-- Referenced links -->
 [3]: email-archive-incoming.md

--- a/docs/en/email/gmail-link/learn/settings.md
+++ b/docs/en/email/gmail-link/learn/settings.md
@@ -2,11 +2,16 @@
 uid: help-en-gmail-link-settings
 title: Edit Gmail Link settings
 description: Edit Gmail Link settings
-author: SuperOffice RnD
-date: 06.29.2022
-keywords: Gmail Link
+keywords: Gmail Link settings, archive email in SuperOffice
+author: SuperOffice Product and Engineering
+date: 08.25.2025
 content_type: reference
+category: email
+topic: Gmail Link
+audience: person
+audience_tooltip: SuperOffice CRM
 language: en
+index: true
 ---
 
 # Edit Gmail Link settings
@@ -56,7 +61,7 @@ At the bottom of the dialog **SuperOffice Gmail Link - Settings** you can find t
 
 ## Change SuperOffice user
 
-Click this button to connect to another SuperOffice installation. Follow the onscreen instructions.
+Click this link to connect to another SuperOffice installation. Follow the onscreen instructions.
 
 <!-- Referenced links -->
 [3]: email-archive-incoming.md

--- a/docs/nl/email/gmail-link/learn/settings.md
+++ b/docs/nl/email/gmail-link/learn/settings.md
@@ -2,11 +2,16 @@
 uid: help-nl-gmail-link-settings
 title: Instellingen Gmail Link bewerken
 description: Instellingen Gmail Link bewerken
-author: SuperOffice RnD
-date: 06.29.2022
-keywords: Gmail Link
+keywords: Gmail Link instellingen, E-mail archiveren in SuperOffice
+author: SuperOffice Product and Engineering
+date: 08.25.2025
 content_type: reference
+category: email
+topic: Gmail Link
+audience: person
+audience_tooltip: SuperOffice CRM
 language: nl
+index: true
 ---
 
 # Instellingen Gmail Link bewerken
@@ -56,7 +61,7 @@ Onder aan het dialoogvenster **SuperOffice Gmail Link - Instellingen** kunt u de
 
 ## SuperOffice-gebruiker wijzigen
 
-Klik op deze knop om een verbinding te maken met een andere installatie van SuperOffice. Volg de instructies op uw scherm.
+Klik op deze koppeling om een verbinding te maken met een andere installatie van SuperOffice. Volg de instructies op uw scherm.
 
 <!-- Referenced links -->
 [3]: email-archive-incoming.md

--- a/docs/no/email/gmail-link/learn/settings.md
+++ b/docs/no/email/gmail-link/learn/settings.md
@@ -2,11 +2,16 @@
 uid: help-no-gmail-link-settings
 title: Redigere Gmail Link-innstillinger
 description: Redigere Gmail Link-innstillinger
-author: SuperOffice RnD
-date: 06.29.2022
-keywords: Gmail Link
+keywords: Gmail Link-innstillinger, Arkiver e-post i SuperOffice
+author: SuperOffice Product and Engineering
+date: 08.25.2025
 content_type: reference
+category: email
+topic: Gmail Link
+audience: person
+audience_tooltip: SuperOffice CRM
 language: no
+index: true
 ---
 
 # Redigere Gmail Link-innstillinger
@@ -56,7 +61,7 @@ Nederst i dialogboksen **SuperOffice Gmail Link - Innstillinger** finner du føl
 
 ## Endre SuperOffice-bruker
 
-Klikk på denne knappen for å koble til en annen SuperOffice-installasjon. Følg instruksjonene på skjermen.
+Klikk på denne linken for å koble til en annen SuperOffice-installasjon. Følg instruksjonene på skjermen.
 
 <!-- Referenced links -->
 [3]: email-archive-incoming.md

--- a/docs/sv/email/gmail-link/learn/settings.md
+++ b/docs/sv/email/gmail-link/learn/settings.md
@@ -2,11 +2,16 @@
 uid: help-sv-gmail-link-settings
 title: Redigera Gmail Link-inställningar
 description: Redigera Gmail Link-inställningar
-author: SuperOffice RnD
-date: 06.29.2022
-keywords: Gmail-länk
+keywords: Gmail Link-inställningar, Arkivera e-postmeddelande i SuperOffice
+author: SuperOffice Product and Engineering
+date: 08.25.2025
 content_type: reference
+category: email
+topic: Gmail Link
+audience: person
+audience_tooltip: SuperOffice CRM
 language: sv
+index: true
 ---
 
 # Redigera Gmail Link-inställningar


### PR DESCRIPTION
## Changes

* Edited last para
  * Except Swedish, which uses the phrase "Klicka här för att..." and can remain as-is.
* Updated and enhanced metadata