### PR TITLE
#2242 Add area subcategory pages as 'explore this topic'

### DIFF
--- a/docs/en/company/learn/toc.yml
+++ b/docs/en/company/learn/toc.yml
@@ -13,3 +13,5 @@ items:
   href: delete.md
 - name: Address formats for countries
   href: address-formats.md
+- name: Explore this topic
+  href: ../index.yml

--- a/docs/en/company/toc.yml
+++ b/docs/en/company/toc.yml
@@ -2,14 +2,5 @@ items:
 - name: Company (contact)
   href: index.yml
   items:
-  - name: User guide
-    topicHref: learn/index.md
   - name: Technical reference
     href: reference/index.md
-  - name: API options
-    topicHref: reference/index.md
-    items:
-    - name: CRMScript
-      topicHref: ../automation/crmscript/howto/company/index.md
-    - name: Web services
-      topicHref: ../api/web-services/howto/company/index.md

--- a/docs/en/contact/learn/toc.yml
+++ b/docs/en/contact/learn/toc.yml
@@ -15,3 +15,5 @@ items:
   href: send-email.md
 - name: Dial contact
   href: dial.md
+- name: Explore this topic
+  href: ../index.yml

--- a/docs/en/contact/toc.yml
+++ b/docs/en/contact/toc.yml
@@ -2,13 +2,5 @@ items:
 - name: Contact (person)
   href: index.yml
   items:
-  - name: User guide
-    topicHref: learn/index.md
   - name: Technical reference
     href: reference/index.md
-  - name: API options
-    items:
-    - name: CRMScript
-      topicHref: ../automation/crmscript/howto/contact/index.md
-    - name: Web-services
-      topicHref: ../api/web-services/howto/contact/index.md

--- a/docs/en/diary/learn/toc.yml
+++ b/docs/en/diary/learn/toc.yml
@@ -29,3 +29,5 @@ items:
 - name: Invitations
   href: invitation/toc.yml
   topicHref: invitation/index.md
+- name: Explore this topic
+  href: ../index.yml

--- a/docs/en/diary/toc.yml
+++ b/docs/en/diary/toc.yml
@@ -2,17 +2,11 @@ items:
 - name: Diary
   href: index.yml
   items:
-  - name: User guide
-    topicHref: learn/index.md
   - name: Technical reference
     href: reference/index.md
   - name: API options
     topicHref: reference/index.md
     items:
-    - name: CRMScript
-      topicHref: ../automation/crmscript/howto/diary/index.md
-    - name: Web services
-      topicHref: ../api/web-services/howto/diary/index.md
     - name: Tutorials
       href: ../api/tutorials/index.md
       items:

--- a/docs/en/document/learn/toc.yml
+++ b/docs/en/document/learn/toc.yml
@@ -46,3 +46,5 @@ items:
     href: ../templates/admin/update-template.md
   - name: Document templates in multiple languages
     href: ../../onsite/win-client/learn/using-document-templates-for-multiple-languages.md
+- name: Explore this topic
+  href: ../index.yml

--- a/docs/en/document/toc.yml
+++ b/docs/en/document/toc.yml
@@ -4,8 +4,6 @@ items:
   items:
   - name: Cloud document integrations
     href: library/it/index.md
-  - name: WebTools
-    topicHref: ../../../integrations/webtools/index.md
   - name: Ribbons
     href: ribbons/index.md
     items:
@@ -13,13 +11,5 @@ items:
       href: ribbons/enable-debug.md
     - name: Troubleshooting
       href: ribbons/troubleshooting.md
-  - name: User guide
-    topicHref: learn/index.md
-  - name: Template variable reference
-    topicHref: templates/variables/index.md
-  - name: Merge field reference
-    topicHref: templates/merge-fields/index.md
   - name: Open Document Format
     href: odf.md
-  - name: API options
-    topicHref: ../api/web-services/howto/document/index.md

--- a/docs/en/email/learn/toc.yml
+++ b/docs/en/email/learn/toc.yml
@@ -6,9 +6,5 @@ items:
 - name: Inbox
   href: ../inbox/learn/toc.yml
   topicHref: ../inbox/learn/index.md
-- name: SuperOffice for Outlook
-  topicHref: ../../../../integrations/superoffice-for-outlook/index.md
-- name: Gmail Link
-  topicHref: ../../../../integrations/gmail-link/index.md
-- name: Mail Link
-  topicHref: ../../../../integrations/mail-link/index.md
+- name: Explore this topic
+  href: ../index.yml

--- a/docs/en/email/toc.yml
+++ b/docs/en/email/toc.yml
@@ -7,8 +7,6 @@ items:
     topicHref: mailgun/index.md
   - name: SuperOffice Inbox
     items:
-    - name: User guide
-      topicHref: inbox/learn/index.md
     - name: MailKit
       href: inbox/it/index.md
   - name: Service and Marketing

--- a/docs/en/project/learn/toc.yml
+++ b/docs/en/project/learn/toc.yml
@@ -21,3 +21,5 @@ items:
 - name: For administrators
   href: ../admin/toc.yml
   topicHref: ../admin/index.md
+- name: Explore this topic
+  href: ../index.yml

--- a/docs/en/project/toc.yml
+++ b/docs/en/project/toc.yml
@@ -1,14 +1,5 @@
 items:
 - name: Project
   href: index.yml
-- name: User guide
-  topicHref: learn/index.md
-- name: For administrators
-  topicHref: admin/index.md
 - name: Technical reference
   href: reference/index.md
-- name: API options
-  topicHref: reference/index.md
-  items:
-  - name: CRMScript
-    topicHref: ../automation/crmscript/howto/project/index.md

--- a/docs/en/request/learn/toc.yml
+++ b/docs/en/request/learn/toc.yml
@@ -36,3 +36,5 @@ items:
 - name: For administrators
   href: ../admin/toc.yml
   topicHref: ../admin/index.md
+- name: Explore this topic
+  href: ../index.yml

--- a/docs/en/request/toc.yml
+++ b/docs/en/request/toc.yml
@@ -1,11 +1,5 @@
 items:
 - name: Requests
   href: index.yml
-- name: User guide
-  topicHref: learn/index.md
-- name: For administrators
-  topicHref: admin/index.md
 - name: Technical reference
   href: overview.md
-- name: CRMScript options
-  topicHref: ../automation/crmscript/howto/request/index.md

--- a/docs/en/sale/learn/toc.yml
+++ b/docs/en/sale/learn/toc.yml
@@ -27,3 +27,5 @@ items:
 - name: For administrators
   href: ../admin/toc.yml
   topicHref: ../admin/index.md
+- name: Explore this topic
+  href: ../index.yml

--- a/docs/en/sale/toc.yml
+++ b/docs/en/sale/toc.yml
@@ -1,23 +1,5 @@
 items:
 - name: Sale
   href: index.yml
-- name: User guide - sales
-  topicHref: learn/index.md
-- name: For administrators
-  topicHref: admin/index.md
-- name: Quote management
-  topicHref: learn/quote/index.md
-- name: Sales intelligence (SAINT)
-  topicHref: ../saint/learn/index.md
 - name: Technical reference
   href: dev/index.md
-- name: API options - sale
-  items:
-  - name: CRMScript
-    topicHref: ../automation/crmscript/howto/sale/index.md
-  - name: Web services
-    topicHref: ../api/web-services/howto/sale/index.md
-- name: API options - quote
-  items:
-  - name: CRMScript
-    topicHref: ../automation/crmscript/howto/quote/index.md


### PR DESCRIPTION
## Changes

The primary change is the new entry in the 8 en/topic/learn/toc.yml files

## FYI

Cleaned up the corresponding en/topic/toc.yml files, removing topicHref-only entries. To prevent the landing page from being shown in the toc area, the href needs to stay in these files (to be remedied in #2244 )