### PR TITLE
SPF - changed from blacklist to blocklist

### DIFF
--- a/docs/en/email/mailgun/spf/index.md
+++ b/docs/en/email/mailgun/spf/index.md
@@ -10,7 +10,7 @@ index: true
 
 ## What is SPF?
 
-An SPF record is a type of [Domain Name Service][1] (DNS) record that identifies which mail servers are permitted to send an email on behalf of your domain and/or can't send on behalf of your domain (whitelist and/or blocklist of IP / domains). Apply these restrictions by adding an [MX record][2] in your DNS zone.
+An SPF record is a type of [Domain Name Service][1] (DNS) record that identifies which mail servers are permitted to send an email on behalf of your domain and/or can't send on behalf of your domain (allowed list and/or blocklist of IP / domains). Apply these restrictions by adding an [MX record][2] in your DNS zone.
 
 ## Why is it Important?
 


### PR DESCRIPTION
Both terms refer to a list of denied items, but "blocklist" is the modern and preferred term for inclusivity. While "blacklist" is still widely understood and used, "blocklist" is being adopted by many organizations to replace the exclusionary term.

We try to use blocklist in both UI and our documentation.