### PR TITLE
Add form field restrictions admin page and update learn files (#2430)

### DIFF
--- a/docs/da/marketing/forms/admin/form-field-restrictions.md
+++ b/docs/da/marketing/forms/admin/form-field-restrictions.md
@@ -1,0 +1,72 @@
+---
+uid: help-da-marketing-forms-field-restrictions
+title: Begrænsninger for formularfelter
+description: Lær, hvordan du styrer, hvilke felter der er tilgængelige i formularer, og om formularindsendelser kan overskrive eksisterende data i disse felter.
+keywords: begrænsninger for formularfelter, formular, felt, tillad ikke overskrivning, overskrivning, vis ikke i formularer
+author: digitaldiina
+date: 05.04.2026
+version: 11.13
+content_type: howto
+category: marketing
+topic: forms
+license: marketingessentials
+audience: settings
+audience_tooltip: Settings and maintenance
+index: true
+language: da
+---
+
+# Begrænsninger for formularfelter
+
+Begrænsninger for formularfelter giver dig mulighed for at styre, hvilke felter der er tilgængelige i formularer, og om en formularindsendelse kan overskrive eksisterende data i disse felter.
+
+Som standard overskriver formularindsendelser ikke eksisterende data. Den person, der bygger formularen, kan vælge at aktivere overskrivning for de enkelte felter. Brug feltbegrænsninger til at fjerne denne mulighed fra følsomme felter eller forhindre, at et felt vises i formulargeneratoren overhovedet.
+
+> [!CAUTION]
+> Formularer på et websted kan udfyldes af alle. Tilladelse til overskrivning medfører risici, herunder utilsigtet datatab, uautoriserede ændringer af følsomme felter og kompromitteret dataintegritet som følge af forkerte indtastninger. Håndter følsomme felter med omhu.
+
+## Sådan administrerer du feltbegrænsninger
+
+Feltbegrænsninger konfigureres i **Indstillinger og vedligeholdelse** og kræver administratorrettigheder.
+
+1. Gå til **Indstillinger og vedligeholdelse**.
+1. Vælg <i class="ph ph-bullseye" aria-hidden="true"></i> **Marketing** i navigatoren.
+1. Vælg fanen **Begrænsninger for formularfelter**.
+
+![Admin Marketing - Indstil begrænsninger for formularfelter, der er synlige i Marketing-formularer -screenshot][img1]
+
+## Tilføj en feltbegrænsning
+
+1. Vælg et felt på rullelisten i sektionen **Felter med begrænsninger**.
+1. Vælg begrænsningstypen for feltet.
+1. Vælg **Gem**.
+
+Gentag for at tilføje begrænsninger for flere felter.
+
+## Begrænsningsindstillinger
+
+* **Tillad ikke overskrivning:** Overskrivningsindstillingen fjernes fra dette felt i alle formularer, herunder formularer, der allerede er udgivet. Feltet er fortsat tilgængeligt i formulargeneratoren og kan stadig føjes til formularer, men indsendte data overskriver aldrig eksisterende værdier.
+
+* **Vis ikke i formularer:** Feltet fjernes helt fra formulargeneratoren og kan ikke føjes til nye formularer. Eksisterende udgivne formularer, der allerede indeholder feltet, påvirkes ikke.
+
+## Fjern en feltbegrænsning
+
+1. Find feltet på listen **Felter med begrænsninger**.
+1. Vælg fjern-ikonet (<i class="ph ph-x-circle" aria-hidden="true"></i>) ud for feltet.
+1. Vælg **Gem**.
+
+Fjernelse af en begrænsning gendanner standardfunktionaliteten. Feltet bliver igen tilgængeligt i formulargeneratoren, og formularejeren kan vælge, om der skal tillades overskrivning.
+
+## Relateret indhold
+
+* [Feltindstillinger][1]
+* [Opret en ny formular][2]
+* [Administrere skrifttyper til formularer][3]
+
+<!-- Referenced links -->
+[1]: ../learn/field-options.md
+[2]: ../learn/create.md
+[3]: manage-fonts.md
+
+<!-- Referenced images -->
+[img1]: ../../../../media/loc/en/admin/admin-marketing-form-field-restrictions.png

--- a/docs/da/marketing/forms/learn/create.md
+++ b/docs/da/marketing/forms/learn/create.md
@@ -4,8 +4,8 @@ title: Opret en ny formular
 description: Få mere at vide om, hvordan du kan oprette en webformular, i denne vejledning.
 keywords: formular, webformular
 author: digitaldiina
-date: 03.17.2026
-version: 11.11
+date: 05.04.2026
+version: 11.13
 content_type: howto
 category: marketing
 topic: forms
@@ -85,13 +85,13 @@ I kategorien **Felter** kan du tilføje de felter, der skal medtages i formulare
 
 3. Vælg en af de følgende feltkategorier i vinduet **Tilføj element**:
 
-    * **SuperOffice-elementer**: Felter, der er knyttet til SuperOffice data, som f.eks. personnavn, land, e-mailadresse osv. Afhængig af felttypen kan værdier fra indsendte formularer enten erstatte eksisterende værdier (f. eks. land eller titel) eller føjes til det relevante SuperOffice-felt (f.eks. mobiltelefon).
+    * **SuperOffice-elementer**: Felter, der er knyttet til SuperOffice-data, som f.eks. personnavn, land, e-mailadresse osv. Standard- og brugerdefinerede felter er tilgængelige. Afhængig af felttypen kan værdier fra indsendte formularer enten overskrive eksisterende værdier eller føjes til det relevante SuperOffice-felt. Når du aktiverer overskrivning for et felt, vises en advarsel. Hvis et felt mangler, eller overskrivningsindstillingen ikke er tilgængelig, kan en administrator have anvendt en [feltbegrænsning][10].
 
     * **Formularelementer**: Felter til indtastning af tekst eller dato, felter til valg af værdier (lister, afkrydsningsfelter og alternativknapper) og filupload-felter.
 
     * **Visningselementer**: Sektioner, tekster og billeder. Brug sektioner til at [oprette formularer](#multi-page) med flere sider.
 
-4. Vælg et felt på listen.
+4. Vælg et felt på listen. Hvis listen er lang, kan du bruge søgefeltet til at finde et felt ved navn.
 
 5. Klik på **Tilføj**. Vinduet lukkes, og feltet føjes til formularen og dens forhåndsvisning.
 
@@ -207,6 +207,7 @@ Her kan du [definere, hvad der sker, når nogen sender et svar på formularen][3
 [4]: field-options.md
 [8]: ../../learn/create-folder.md
 [9]: ../admin/manage-fonts.md
+[10]: ../admin/form-field-restrictions.md
 
 <!-- Referenced images -->
 [img15]: ../../../../media/loc/en/marketing/contact-me-form-properties.png

--- a/docs/da/marketing/forms/learn/field-options.md
+++ b/docs/da/marketing/forms/learn/field-options.md
@@ -4,8 +4,8 @@ title: Feltindstillinger
 description: Feltindstillinger
 keywords: formular, felt, formularelementer, reCAPTCHA
 author: SuperOffice Product and Engineering
-date: 09.26.2025
-version: 10.5
+date: 05.04.2026
+version: 11.13
 content_type: reference
 category: marketing
 topic: forms
@@ -21,7 +21,7 @@ Dette er en oversigt over særlige indstillinger i nogle af de tilgængelige fel
 
 ## SuperOffice-elementer
 
-* **Erstat:** Vælg denne indstilling for at erstatte en eksisterende værdi i SuperOffice med værdien i formularen. Dette er relevant for land, titel og Hr./Fr.
+* **Tillad overskrivning af eksisterende data:** Vælg denne indstilling for at erstatte en eksisterende værdi i SuperOffice med den indsendte formularværdi. Der vises en advarsel, når du aktiverer denne indstilling. Hvis denne indstilling ikke er tilgængelig for et felt, kan en administrator have begrænset det. Se [begrænsninger for formularfelter][5].
 
 * **Person - samtykke**
 
@@ -95,3 +95,4 @@ Dette er en oversigt over særlige indstillinger i nogle af de tilgængelige fel
 [2]: create.md#multi-page
 [3]: ../../recipients/learn/manage-email-subscriptions.md
 [4]: ../../../security/privacy/admin/add-purpose.md
+[5]: ../admin/form-field-restrictions.md

--- a/docs/da/marketing/forms/learn/toc.yml
+++ b/docs/da/marketing/forms/learn/toc.yml
@@ -21,3 +21,5 @@ items:
   href: tutorial-sign-up.md
 - name: Administrere skrifttyper til formularer
   href: ../admin/manage-fonts.md
+- name: Begrænsninger for formularfelter
+  href: ../admin/form-field-restrictions.md

--- a/docs/de/marketing/forms/admin/form-field-restrictions.md
+++ b/docs/de/marketing/forms/admin/form-field-restrictions.md
@@ -1,0 +1,72 @@
+---
+uid: help-de-marketing-forms-field-restrictions
+title: Einschränkungen für Formularfelder
+description: Erfahren Sie, wie Sie steuern können, welche Felder in Formularen verfügbar sind und ob Formularübermittlungen vorhandene Daten in diesen Feldern überschreiben können.
+keywords: Einschränkungen für Formularfelder, Formular, Feld, nicht überschreiben, überschreiben, nicht in Formularen anzeigen
+author: digitaldiina
+date: 05.04.2026
+version: 11.13
+content_type: howto
+category: marketing
+topic: forms
+license: marketingessentials
+audience: settings
+audience_tooltip: Settings and maintenance
+index: true
+language: de
+---
+
+# Einschränkungen für Formularfelder
+
+Mit Einschränkungen für Formularfelder können Sie steuern, welche Felder in Formularen verfügbar sind und ob eine Formularübermittlung vorhandene Daten in diesen Feldern überschreiben kann.
+
+Standardmäßig überschreiben Formularübermittlungen keine vorhandenen Daten. Die Person, die das Formular erstellt, kann das Überschreiben für einzelne Felder aktivieren. Mit Feldeinschränkungen können Sie diese Option für sensible Felder entfernen oder verhindern, dass ein Feld im Formulareditor angezeigt wird.
+
+> [!CAUTION]
+> Formulare auf einer Website können von jedem ausgefüllt werden. Das Zulassen von Überschreibungen birgt Risiken, darunter unbeabsichtigter Datenverlust, unbefugte Änderungen an sensiblen Feldern und eine Beeinträchtigung der Datenintegrität durch falsche Eingaben. Behandeln Sie sensible Felder sorgfältig.
+
+## Einschränkungen für Felder verwalten
+
+Feldeinschränkungen werden in **Einstellungen und Verwaltung** konfiguriert und erfordern Administratorrechte.
+
+1. Gehen Sie zu **Einstellungen und Verwaltung**.
+1. Wählen Sie <i class="ph ph-bullseye" aria-hidden="true"></i> **Marketing** im Navigator aus.
+1. Wählen Sie die Registerkarte **Einschränkungen für Formularfelder** aus.
+
+![Admin Marketing - Einschränkungen für in Marketing-Formularen sichtbare Felder festlegen -screenshot][img1]
+
+## Feldeinschränkung hinzufügen
+
+1. Wählen Sie im Bereich **Felder mit Einschränkungen** ein Feld aus der Dropdown-Liste aus.
+1. Wählen Sie den Einschränkungstyp für das Feld aus.
+1. Wählen Sie **Speichern** aus.
+
+Wiederholen Sie diese Schritte, um Einschränkungen für weitere Felder hinzuzufügen.
+
+## Einschränkungsoptionen
+
+* **Nicht überschreiben:** Die Option zum Überschreiben wird für dieses Feld in allen Formularen entfernt, einschließlich bereits veröffentlichter Formulare. Das Feld bleibt im Formulareditor verfügbar und kann weiterhin zu Formularen hinzugefügt werden, aber übermittelte Daten überschreiben niemals vorhandene Werte.
+
+* **Nicht in Formularen anzeigen:** Das Feld wird vollständig aus dem Formulareditor entfernt und kann neuen Formularen nicht hinzugefügt werden. Bereits veröffentlichte Formulare, die das Feld bereits enthalten, sind davon nicht betroffen.
+
+## Feldeinschränkung entfernen
+
+1. Suchen Sie das Feld in der Liste **Felder mit Einschränkungen**.
+1. Wählen Sie das Entfernen-Symbol (<i class="ph ph-x-circle" aria-hidden="true"></i>) neben dem Feld aus.
+1. Wählen Sie **Speichern** aus.
+
+Das Entfernen einer Einschränkung stellt das Standardverhalten wieder her. Das Feld steht im Formulareditor wieder zur Verfügung, und der Formulareigentümer kann entscheiden, ob das Überschreiben erlaubt werden soll.
+
+## Verwandte Inhalte
+
+* [Feldoptionen][1]
+* [Ein neues Formular erstellen][2]
+* [Schriftarten für Formulare verwalten][3]
+
+<!-- Referenced links -->
+[1]: ../learn/field-options.md
+[2]: ../learn/create.md
+[3]: manage-fonts.md
+
+<!-- Referenced images -->
+[img1]: ../../../../media/loc/en/admin/admin-marketing-form-field-restrictions.png

--- a/docs/de/marketing/forms/learn/create.md
+++ b/docs/de/marketing/forms/learn/create.md
@@ -4,8 +4,8 @@ title: Ein neues Formular erstellen
 description: In dieser Anleitung lernen Sie, wie Sie ein Web-Formular erstellen können.
 keywords: Formular, Web-Formular, Opt-in
 author: digitaldiina
-date: 03.17.2026
-version: 11.11
+date: 05.04.2026
+version: 11.13
 content_type: howto
 category: marketing
 topic: forms
@@ -85,13 +85,13 @@ In der Kategorie **Felder** können Sie die Felder hinzufügen, die im Formular 
 
 3. Wählen Sie im Fenster **Element hinzufügen** eine der folgenden Feldkategorien aus:
 
-    * **SuperOffice-Elemente**: Diese Felder sind mit SuperOffice-Daten wie dem Namen, dem Land, der E-Mail-Adresse der Person usw. verknüpft. Je nach Feldtyp können Werte aus übermittelten Formularen vorhandene Werte (wie Land oder Titel) ersetzen oder zum betreffenden SuperOffice-Feld hinzugefügt werden (wie die Mobilfunknummer).
+    * **SuperOffice-Elemente**: Diese Felder sind mit SuperOffice-Daten wie dem Namen, dem Land, der E-Mail-Adresse der Person usw. verknüpft. Standard- und benutzerdefinierte Felder sind verfügbar. Je nach Feldtyp können Werte aus übermittelten Formularen vorhandene Werte überschreiben oder zum betreffenden SuperOffice-Feld hinzugefügt werden. Wenn Sie das Überschreiben für ein Feld aktivieren, wird eine Warnung angezeigt. Wenn ein Feld fehlt oder die Option zum Überschreiben nicht verfügbar ist, wurde es möglicherweise von einem Administrator mit einer [Feldeinschränkung][10] belegt.
 
     * **Formularelemente**: Diese Felder dienen zur Eingabe von Text oder Datum, zum Auswählen von Werten (Listen, Kontrollkästchen und Optionsfelder) und zum Hochladen von Dateien.
 
     * **Ansichtselemente**: Bereiche, Texte und Bilder. Mit Bereichen können Sie [mehrseitige Formulare erstellen](#multi-page).
 
-4. Wählen Sie ein Feld aus der Liste aus.
+4. Wählen Sie ein Feld aus der Liste aus. Wenn die Liste lang ist, können Sie das Suchfeld verwenden, um ein Feld nach Name zu suchen.
 
 5. Klicken Sie auf **Hinzufügen**. Das Fenster wird geschlossen und das Feld wird zum Formular und zur Formularvorschau hinzugefügt.
 
@@ -207,6 +207,7 @@ Hier können Sie [festlegen, was passiert, wenn jemand ein Formularantwort sende
 [4]: field-options.md
 [8]: ../../learn/create-folder.md
 [9]: ../admin/manage-fonts.md
+[10]: ../admin/form-field-restrictions.md
 
 <!-- Referenced images -->
 [img15]: ../../../../media/loc/en/marketing/contact-me-form-properties.png

--- a/docs/de/marketing/forms/learn/field-options.md
+++ b/docs/de/marketing/forms/learn/field-options.md
@@ -4,8 +4,8 @@ title: Feldoptionen
 description: Feldoptionen
 keywords: Formular, Feld, Feldoption, Formularelement, Ansichtselement
 author: SuperOffice Product and Engineering
-date: 09.26.2025
-version: 10.5
+date: 05.04.2026
+version: 11.13
 content_type: reference
 category: marketing
 topic: forms
@@ -21,7 +21,7 @@ Im Folgenden finden Sie eine Übersicht über spezielle Optionen in einigen verf
 
 ## SuperOffice-Elemente
 
-* **Ersetzen:** Wählen Sie diese Option, um einen in SuperOffice vorhandenen Wert durch den Wert im Formular zu ersetzen. Dies ist für Angaben wie Land, Titel und Anrede (Herr/Frau) relevant.
+* **Überschreiben von vorhandenen Daten erlauben:** Wählen Sie diese Option, um einen vorhandenen SuperOffice-Wert durch den im Formular übermittelten Wert zu ersetzen. Wenn Sie diese Option aktivieren, wird eine Warnung angezeigt. Wenn diese Option für ein Feld nicht verfügbar ist, wurde es möglicherweise von einem Administrator eingeschränkt. Weitere Informationen finden Sie unter [Einschränkungen für Formularfelder][5].
 
 * **Person - Einwilligung**
 
@@ -95,3 +95,4 @@ Im Folgenden finden Sie eine Übersicht über spezielle Optionen in einigen verf
 [2]: create.md#multi-page
 [3]: ../../recipients/learn/manage-email-subscriptions.md
 [4]: ../../../security/privacy/admin/add-purpose.md
+[5]: ../admin/form-field-restrictions.md

--- a/docs/de/marketing/forms/learn/toc.yml
+++ b/docs/de/marketing/forms/learn/toc.yml
@@ -21,3 +21,5 @@ items:
   href: tutorial-sign-up.md
 - name: Schriftarten für Formulare verwalten
   href: ../admin/manage-fonts.md
+- name: Einschränkungen für Formularfelder
+  href: ../admin/form-field-restrictions.md

--- a/docs/en/marketing/forms/admin/form-field-restrictions.md
+++ b/docs/en/marketing/forms/admin/form-field-restrictions.md
@@ -1,0 +1,72 @@
+---
+uid: help-en-marketing-forms-field-restrictions
+title: Form field restrictions
+description: Learn how to control which fields are available in forms and whether form submissions can overwrite existing data in those fields.
+keywords: form field restrictions, form, field, do not allow overwrite, overwrite, do not show in forms
+author: digitaldiina
+date: 05.04.2026
+version: 11.13
+content_type: howto
+category: marketing
+topic: forms
+license: marketingessentials
+audience: settings
+audience_tooltip: Settings and maintenance
+index: true
+language: en
+---
+
+# Form field restrictions
+
+Form field restrictions let you control which fields are available in forms, and whether a form submission can overwrite existing data in those fields.
+
+By default, form submissions do not overwrite existing data. The person building the form can choose to enable overwrite for individual fields. Use field restrictions to remove that option from sensitive fields, or to prevent a field from appearing in the form builder at all.
+
+> [!CAUTION]
+> Forms on a website can be filled out by anyone. Allowing overwrites carries risks including unintentional data loss, unauthorized modifications to sensitive fields, and compromised data integrity through incorrect entries. Handle sensitive fields with care.
+
+## Where to manage field restrictions
+
+Field restrictions are configured in **Settings and maintenance** and require administrator rights.
+
+1. Go to **Settings and maintenance**.
+1. Select <i class="ph ph-bullseye" aria-hidden="true"></i> **Marketing** from the navigator.
+1. Select the **Form field restrictions** tab.
+
+![Admin Marketing - Set restrictions on form fields visible in Marketing forms -screenshot][img1]
+
+## Add a field restriction
+
+1. In the **Fields with restrictions** section, select a field from the dropdown list.
+1. Select the restriction type for that field.
+1. Select **Save**.
+
+Repeat to add restrictions for more fields.
+
+## Restriction options
+
+* **Do not allow overwrite:** The overwrite option is removed from this field in all forms, including forms that are already published. The field remains available in the form builder and can still be added to forms, but submitted data will never overwrite existing values.
+
+* **Do not show in forms:** The field is removed from the form builder entirely and cannot be added to new forms. Existing published forms that already include the field are not affected.
+
+## Remove a field restriction
+
+1. Locate the field in the **Fields with restrictions** list.
+1. Select the remove icon (<i class="ph ph-x-circle" aria-hidden="true"></i>) next to the field.
+1. Select **Save**.
+
+Removing a restriction restores default behavior. The field becomes available in the form builder again, and the form owner can choose whether to allow overwrite.
+
+## Related content
+
+* [Field options][1]
+* [Create a form][2]
+* [Manage fonts for forms][3]
+
+<!-- Referenced links -->
+[1]: ../learn/field-options.md
+[2]: ../learn/create.md
+[3]: manage-fonts.md
+
+<!-- Referenced images -->
+[img1]: ../../../../media/loc/en/admin/admin-marketing-form-field-restrictions.png

--- a/docs/en/marketing/forms/learn/create.md
+++ b/docs/en/marketing/forms/learn/create.md
@@ -4,8 +4,8 @@ title: Create a new form
 description: Learn how you can create a web form in this how-to guide.
 keywords: form, form template, multi-page, custom styling, css
 author: digitaldiina
-date: 03.17.2026
-version: 11.11
+date: 05.04.2026
+version: 11.13
 content_type: howto
 category: marketing
 topic: forms
@@ -85,13 +85,13 @@ In the **Fields** category you add the fields that should be included in the for
 
 3. In the **Add element** window, select one of the following field categories:
 
-    * **SuperOffice elements**: Fields that are linked to SuperOffice data, such as contact name, country, email address, and so on. Depending on the type of field, values from submitted forms can either replace existing values (such as country or title) or be added to the relevant SuperOffice field (such as mobile phone).
+    * **SuperOffice elements**: Fields that are linked to SuperOffice data, such as contact name, country, email address, and so on. Standard and custom fields are available. Depending on the type of field, values from submitted forms can either overwrite existing values or be added to the relevant SuperOffice field. When you enable overwrite for a field, a warning is displayed. If a field is missing or the overwrite option is unavailable, an administrator may have applied a [field restriction][10].
 
     * **Form elements**: Fields for entering text or date, fields for selecting values (lists, checkboxes and radio buttons) and file upload fields.
 
     * **View elements**: Sections, texts and images. Use sections to [create multi-page forms](#multi-page).
 
-4. Select a field in the list.
+4. Select a field in the list. If the list is long, use the search box to find a field by name.
 
 5. Click **Add**. The window closes and the field is added to the form and the form preview.
 
@@ -239,6 +239,7 @@ Here you can [define what happens when someone submits a form response][3].
 [4]: field-options.md
 [8]: ../../learn/create-folder.md
 [9]: ../admin/manage-fonts.md
+[10]: ../admin/form-field-restrictions.md
 
 <!-- Referenced images -->
 [img15]: ../../../../media/loc/en/marketing/contact-me-form-properties.png

--- a/docs/en/marketing/forms/learn/field-options.md
+++ b/docs/en/marketing/forms/learn/field-options.md
@@ -4,8 +4,8 @@ title: Field options
 description: List of fields (and their options) you can add to a SuperOffice Marketing form.
 keywords: form, field, form element, view element, reCAPTCHA
 author: SuperOffice Product and Engineering
-date: 09.26.2025
-version: 10.5
+date: 05.04.2026
+version: 11.13
 content_type: reference
 category: marketing
 topic: forms
@@ -21,7 +21,7 @@ This is an overview of special options in some of the available fields.
 
 ## SuperOffice elements
 
-* **Replace:** Select this option to replace an existing value in SuperOffice with the value in the form. This is relevant for country, title and mr/mrs.
+* **Allow overwrite of existing data:** Select this option to replace an existing value in SuperOffice with the value submitted in the form. A warning is displayed when you enable this option. If this option is not available for a field, an administrator may have restricted it. See [form field restrictions][5].
 
 * **Contact - consent**
 
@@ -95,5 +95,6 @@ This is an overview of special options in some of the available fields.
 [2]: create.md#multi-page
 [3]: ../../recipients/learn/manage-email-subscriptions.md
 [4]: ../../../security/privacy/admin/add-purpose.md
+[5]: ../admin/form-field-restrictions.md
 
 <!-- Referenced images -->

--- a/docs/en/marketing/forms/learn/toc.yml
+++ b/docs/en/marketing/forms/learn/toc.yml
@@ -23,3 +23,5 @@ items:
   href: tutorial-sign-up.md
 - name: Manage fonts for forms
   href: ../admin/manage-fonts.md
+- name: Form field restrictions
+  href: ../admin/form-field-restrictions.md

--- a/docs/nl/marketing/forms/admin/form-field-restrictions.md
+++ b/docs/nl/marketing/forms/admin/form-field-restrictions.md
@@ -1,0 +1,72 @@
+---
+uid: help-nl-marketing-forms-field-restrictions
+title: Restricties voor formuliervelden
+description: Leer hoe u kunt bepalen welke velden beschikbaar zijn in formulieren en of formulierverzendingen bestaande gegevens in die velden kunnen overschrijven.
+keywords: restricties voor formuliervelden, formulier, veld, overschrijven niet toestaan, overschrijven, niet weergeven in formulieren
+author: digitaldiina
+date: 05.04.2026
+version: 11.13
+content_type: howto
+category: marketing
+topic: forms
+license: marketingessentials
+audience: settings
+audience_tooltip: Settings and maintenance
+index: true
+language: nl
+---
+
+# Restricties voor formuliervelden
+
+Met restricties voor formuliervelden kunt u bepalen welke velden beschikbaar zijn in formulieren en of een formulierverzending bestaande gegevens in die velden kan overschrijven.
+
+Standaard overschrijven formulierverzendingen geen bestaande gegevens. De persoon die het formulier maakt, kan kiezen om overschrijven voor afzonderlijke velden in te schakelen. Gebruik veldrestricties om die optie van gevoelige velden te verwijderen of om te voorkomen dat een veld helemaal in de formulierbuilder verschijnt.
+
+> [!CAUTION]
+> Formulieren op een website kunnen door iedereen worden ingevuld. Het toestaan van overschrijvingen brengt risico's met zich mee, waaronder onbedoeld gegevensverlies, ongeautoriseerde wijzigingen van gevoelige velden en aangetaste gegevensintegriteit door onjuiste invoer. Ga zorgvuldig om met gevoelige velden.
+
+## Restricties voor velden beheren
+
+Veldrestricties worden geconfigureerd in **Instellingen en onderhoud** en vereisen beheerdersrechten.
+
+1. Ga naar **Instellingen en onderhoud**.
+1. Selecteer <i class="ph ph-bullseye" aria-hidden="true"></i> **Marketing** in de navigator.
+1. Selecteer het tabblad **Restricties voor formuliervelden**.
+
+![Admin Marketing - Restricties instellen voor in Marketing-formulieren zichtbare velden -screenshot][img1]
+
+## Veldrestrictie toevoegen
+
+1. Selecteer een veld in de vervolgkeuzelijst in de sectie **Velden met restricties**.
+1. Selecteer het restrictietype voor dat veld.
+1. Selecteer **Opslaan**.
+
+Herhaal dit om restricties toe te voegen voor meer velden.
+
+## Restrictieopties
+
+* **Overschrijven niet toestaan:** De overschrijfoptie wordt verwijderd uit dit veld in alle formulieren, inclusief formulieren die al zijn gepubliceerd. Het veld blijft beschikbaar in de formulierbuilder en kan nog steeds worden toegevoegd aan formulieren, maar ingediende gegevens zullen bestaande waarden nooit overschrijven.
+
+* **Niet weergeven in formulieren:** Het veld wordt volledig verwijderd uit de formulierbuilder en kan niet worden toegevoegd aan nieuwe formulieren. Bestaande gepubliceerde formulieren die het veld al bevatten, worden niet beïnvloed.
+
+## Veldrestrictie verwijderen
+
+1. Zoek het veld in de lijst **Velden met restricties**.
+1. Selecteer het pictogram Verwijderen (<i class="ph ph-x-circle" aria-hidden="true"></i>) naast het veld.
+1. Selecteer **Opslaan**.
+
+Als u een restrictie verwijdert, wordt het standaardgedrag hersteld. Het veld is weer beschikbaar in de formulierbuilder en de formuliereigenaar kan kiezen of overschrijven is toegestaan.
+
+## Gerelateerde inhoud
+
+* [Veldopties][1]
+* [Een nieuw formulier maken][2]
+* [Lettertypen voor formulieren beheren][3]
+
+<!-- Referenced links -->
+[1]: ../learn/field-options.md
+[2]: ../learn/create.md
+[3]: manage-fonts.md
+
+<!-- Referenced images -->
+[img1]: ../../../../media/loc/en/admin/admin-marketing-form-field-restrictions.png

--- a/docs/nl/marketing/forms/learn/create.md
+++ b/docs/nl/marketing/forms/learn/create.md
@@ -4,8 +4,8 @@ title: Een nieuw formulier maken
 description: Leer hoe u een webformulier kunt maken in deze handleiding.
 keywords: formulier, opt-in
 author: digitaldiina
-date: 03.17.2026
-version: 11.11
+date: 05.04.2026
+version: 11.13
 content_type: howto
 category: marketing
 topic: forms
@@ -85,13 +85,13 @@ In de categorie **Velden** voegt u de velden toe die moeten worden opgenomen in 
 
 3. Selecteer in het venster **Element toevoegen** een van de volgende veldcategorieën:
 
-    * **SuperOffice-elementen**: Velden die zijn gekoppeld aan SuperOffice-gegevens, zoals naam van persoon, land, e-mailadres enzovoort. Afhankelijk van het type veld, kunnen waarden van ingediende formulieren zowel bestaande waarden vervangen (zoals land of functie) of worden toegevoegd aan het relevante SuperOffice-veld (zoals mobiel nummer).
+    * **SuperOffice-elementen**: Velden die zijn gekoppeld aan SuperOffice-gegevens, zoals naam van persoon, land, e-mailadres enzovoort. Standaard- en aangepaste velden zijn beschikbaar. Afhankelijk van het type veld, kunnen waarden van ingediende formulieren bestaande waarden overschrijven of worden toegevoegd aan het relevante SuperOffice-veld. Wanneer u overschrijven voor een veld inschakelt, wordt een waarschuwing weergegeven. Als een veld ontbreekt of de overschrijfoptie niet beschikbaar is, heeft een beheerder mogelijk een [veldrestrictie][10] toegepast.
 
     * **Formulierelementen**: Velden om tekst of datum in te voeren, velden om waarden te selecteren (lijsten, selectievakjes en keuzerondjes) en velden om bestanden te uploaden.
 
     * **Elementen weergeven**: Paragrafen, teksten en afbeeldingen. Gebruik secties om [formulieren met meerdere pagina's te maken](#multi-page).
 
-4. Selecteer een veld uit de lijst.
+4. Selecteer een veld uit de lijst. Als de lijst lang is, gebruikt u het zoekvak om een veld op naam te vinden.
 
 5. Klik op **Toevoegen**. Het venster wordt gesloten en het veld wordt toegevoegd aan het formulier en het formuliervoorbeeld.
 
@@ -207,6 +207,7 @@ Hier kunt u [definiëren wat er gebeurt wanneer iemand een reactie op een formul
 [4]: field-options.md
 [8]: ../../learn/create-folder.md
 [9]: ../admin/manage-fonts.md
+[10]: ../admin/form-field-restrictions.md
 
 <!-- Referenced images -->
 [img15]: ../../../../media/loc/en/marketing/contact-me-form-properties.png

--- a/docs/nl/marketing/forms/learn/field-options.md
+++ b/docs/nl/marketing/forms/learn/field-options.md
@@ -4,8 +4,8 @@ title: Veldopties
 description: Veldopties
 keywords: formulier, veld, veldoptie, formulierelement
 author: SuperOffice Product and Engineering
-date: 09.26.2025
-version: 10.5
+date: 05.04.2026
+version: 11.13
 content_type: reference
 category: marketing
 topic: forms
@@ -21,7 +21,7 @@ Dit is een overzicht van speciale opties in sommige beschikbare velden.
 
 ## SuperOffice-elementen
 
-* **Vervangen:** Selecteer deze optie om een bestaande waarde in SuperOffice te vervangen door de waarde in het formulier. Dit is relevant voor land, functie en Dhr./Mw.
+* **Overschrijven van bestaande gegevens toestaan:** Selecteer deze optie om een bestaande waarde in SuperOffice te vervangen door de waarde die is ingediend via het formulier. Er wordt een waarschuwing weergegeven wanneer u deze optie inschakelt. Als deze optie niet beschikbaar is voor een veld, heeft een beheerder dit mogelijk beperkt. Zie [restricties voor formuliervelden][5].
 
 * **Persoon - toestemming**
 
@@ -95,3 +95,4 @@ Dit is een overzicht van speciale opties in sommige beschikbare velden.
 [2]: create.md#multi-page
 [3]: ../../recipients/learn/manage-email-subscriptions.md
 [4]: ../../../security/privacy/admin/add-purpose.md
+[5]: ../admin/form-field-restrictions.md

--- a/docs/nl/marketing/forms/learn/toc.yml
+++ b/docs/nl/marketing/forms/learn/toc.yml
@@ -21,3 +21,5 @@ items:
   href: tutorial-sign-up.md
 - name: Lettertypen voor formulieren beheren
   href: ../admin/manage-fonts.md
+- name: Restricties voor formuliervelden
+  href: ../admin/form-field-restrictions.md

--- a/docs/no/marketing/forms/admin/form-field-restrictions.md
+++ b/docs/no/marketing/forms/admin/form-field-restrictions.md
@@ -1,0 +1,72 @@
+---
+uid: help-no-marketing-forms-field-restrictions
+title: Begrensninger for skjemafelt
+description: Lær hvordan du styrer hvilke felt som er tilgjengelige i skjemaer, og om skjemainnsendinger kan overskrive eksisterende data i disse feltene.
+keywords: begrensninger for skjemafelt, skjema, felt, ikke tillat overskriving, overskriving, ikke vis i skjemaer
+author: digitaldiina
+date: 05.04.2026
+version: 11.13
+content_type: howto
+category: marketing
+topic: forms
+license: marketingessentials
+audience: settings
+audience_tooltip: Settings and maintenance
+index: true
+language: no
+---
+
+# Begrensninger for skjemafelt
+
+Begrensninger for skjemafelt lar deg styre hvilke felt som er tilgjengelige i skjemaer, og om en skjemainnsending kan overskrive eksisterende data i disse feltene.
+
+Som standard overskriver ikke skjemainnsendinger eksisterende data. Personen som bygger skjemaet, kan velge å aktivere overskriving for individuelle felt. Bruk feltbegrensninger til å fjerne dette alternativet fra sensitive felt, eller for å forhindre at et felt vises i skjemabyggeren i det hele tatt.
+
+> [!CAUTION]
+> Skjemaer på et nettsted kan fylles ut av alle. Å tillate overskriving innebærer risiko, inkludert utilsiktet datatap, uautoriserte endringer i sensitive felt og kompromittert dataintegritet gjennom feilaktige oppføringer. Håndter sensitive felt med forsiktighet.
+
+## Slik administrerer du feltbegrensninger
+
+Feltbegrensninger konfigureres i **Innstillinger og vedlikehold** og krever administratorrettigheter.
+
+1. Gå til **Innstillinger og vedlikehold**.
+1. Velg <i class="ph ph-bullseye" aria-hidden="true"></i> **Marketing** fra navigatoren.
+1. Velg fanen **Begrensninger for skjemafelt**.
+
+![Admin Marketing - Angi begrensninger for skjemafelt som er synlige i Marketing-skjemaer -screenshot][img1]
+
+## Legg til en feltbegrensning
+
+1. Velg et felt fra nedtrekkslisten i delen **Felt med begrensninger**.
+1. Velg begrensningstypen for det feltet.
+1. Velg **Lagre**.
+
+Gjenta for å legge til begrensninger for flere felt.
+
+## Begrensningsalternativer
+
+* **Ikke tillat overskriving:** Overskrivingsalternativet fjernes fra dette feltet i alle skjemaer, inkludert skjemaer som allerede er publisert. Feltet er fortsatt tilgjengelig i skjemabyggeren og kan fortsatt legges til skjemaer, men innsendte data vil aldri overskrive eksisterende verdier.
+
+* **Ikke vis i skjemaer:** Feltet fjernes helt fra skjemabyggeren og kan ikke legges til nye skjemaer. Eksisterende publiserte skjemaer som allerede inkluderer feltet, påvirkes ikke.
+
+## Fjern en feltbegrensning
+
+1. Finn feltet i listen **Felt med begrensninger**.
+1. Velg fjern-ikonet (<i class="ph ph-x-circle" aria-hidden="true"></i>) ved siden av feltet.
+1. Velg **Lagre**.
+
+Fjerning av en begrensning gjenoppretter standard virkemåte. Feltet blir tilgjengelig i skjemabyggeren igjen, og skjemaeieren kan velge om overskriving skal tillates.
+
+## Relatert innhold
+
+* [Feltalternativer][1]
+* [Opprette et nytt skjema][2]
+* [Administrere skrifttyper for skjemaer][3]
+
+<!-- Referenced links -->
+[1]: ../learn/field-options.md
+[2]: ../learn/create.md
+[3]: manage-fonts.md
+
+<!-- Referenced images -->
+[img1]: ../../../../media/loc/en/admin/admin-marketing-form-field-restrictions.png

--- a/docs/no/marketing/forms/learn/create.md
+++ b/docs/no/marketing/forms/learn/create.md
@@ -4,8 +4,8 @@ title: Opprette et nytt skjema
 description: Lær hvordan du kan opprette et nettskjema i denne veiledningen.
 keywords: skjema, webskjema, nettskjema, påmelding
 author: digitaldiina
-date: 03.17.2026
-version: 11.11
+date: 05.04.2026
+version: 11.13
 content_type: howto
 category: marketing
 topic: forms
@@ -85,13 +85,13 @@ I kategorien **Felt** legger du til feltene som skal brukes i skjemaet. Når du 
 
 3. I vinduet **Legg til element** velger du en av følgende feltkategorier:
 
-    * **SuperOffice-elementer**: Felt som er koblet til SuperOffice-data, for eksempel personnavn, land, e-postadresse og så videre. Avhengig av felttypen kan verdier fra innsendte skjemaer enten erstatte eksisterende verdier (for eksempel land eller tittel) eller legges til det relevante SuperOffice-feltet (for eksempel mobiltelefon).
+    * **SuperOffice-elementer**: Felt som er koblet til SuperOffice-data, for eksempel personnavn, land, e-postadresse og så videre. Standard- og egendefinerte felt er tilgjengelige. Avhengig av felttypen kan verdier fra innsendte skjemaer enten overskrive eksisterende verdier eller legges til det relevante SuperOffice-feltet. Når du aktiverer overskriving for et felt, vises det en advarsel. Hvis et felt mangler eller overskrivingsalternativet ikke er tilgjengelig, kan en administrator ha brukt en [feltbegrensning][10].
 
     * **Skjemaelementer**: Felt for å angi tekst eller dato, felt for å velge verdier (lister, avmerkingsbokser og alternativknapper) og felt for opplasting av filer.
 
     * **Visningselementer**: Seksjoner, tekster og bilder. Bruk seksjoner til å opprette [skjemaer med flere sider](#multi-page).
 
-4. Velg et felt fra listen.
+4. Velg et felt fra listen. Hvis listen er lang, kan du bruke søkeboksen til å finne et felt ved navn.
 
 5. Klikk på **Legg til**. Vinduet lukkes, og feltet legges til skjemaet og forhåndsvisningen av skjemaet.
 
@@ -207,6 +207,7 @@ Her kan du [definere hva som skjer når noen sender inn et skjemasvar][3].
 [4]: field-options.md
 [8]: ../../learn/create-folder.md
 [9]: ../admin/manage-fonts.md
+[10]: ../admin/form-field-restrictions.md
 
 <!-- Referenced images -->
 [img15]: ../../../../media/loc/en/marketing/contact-me-form-properties.png

--- a/docs/no/marketing/forms/learn/field-options.md
+++ b/docs/no/marketing/forms/learn/field-options.md
@@ -4,8 +4,8 @@ title: Feltalternativer
 description: Feltalternativer
 keywords: skjema, felt, skjemaelement, reCAPTCHA
 author: SuperOffice Product and Engineering
-date: 09.26.2025
-version: 10.5
+date: 05.04.2026
+version: 11.13
 content_type: reference
 category: marketing
 topic: forms
@@ -21,7 +21,7 @@ Dette er en oversikt over spesialalternativer i noen av de tilgjengelige feltene
 
 ## SuperOffice-elementer
 
-* **Overskriv:** Velg dette alternativet for å erstatte en eksisterende verdi i SuperOffice med verdien i skjemaet. Dette er aktuelt for land, tittel og hr/fr.
+* **Tillat overskriving av eksisterende data:** Velg dette alternativet for å erstatte en eksisterende verdi i SuperOffice med verdien som er sendt inn i skjemaet. Det vises en advarsel når du aktiverer dette alternativet. Hvis dette alternativet ikke er tilgjengelig for et felt, kan en administrator ha begrenset det. Se [begrensninger for skjemafelt][5].
 
 * **Person – samtykke**
 
@@ -95,3 +95,4 @@ Dette er en oversikt over spesialalternativer i noen av de tilgjengelige feltene
 [2]: create.md#multi-page
 [3]: ../../recipients/learn/manage-email-subscriptions.md
 [4]: ../../../security/privacy/admin/add-purpose.md
+[5]: ../admin/form-field-restrictions.md

--- a/docs/no/marketing/forms/learn/toc.yml
+++ b/docs/no/marketing/forms/learn/toc.yml
@@ -21,3 +21,5 @@ items:
   href: tutorial-sign-up.md
 - name: Administrere skrifttyper for skjemaer
   href: ../admin/manage-fonts.md
+- name: Begrensninger for skjemafelt
+  href: ../admin/form-field-restrictions.md

--- a/docs/sv/marketing/forms/admin/form-field-restrictions.md
+++ b/docs/sv/marketing/forms/admin/form-field-restrictions.md
@@ -1,0 +1,72 @@
+---
+uid: help-sv-marketing-forms-field-restrictions
+title: Begränsningar för formulärfält
+description: Lär dig hur du kontrollerar vilka fält som är tillgängliga i formulär och om formulärinskick kan skriva över befintliga data i dessa fält.
+keywords: begränsningar för formulärfält, formulär, fält, tillåt inte överskrivning, överskrivning, visa inte i formulär
+author: digitaldiina
+date: 05.04.2026
+version: 11.13
+content_type: howto
+category: marketing
+topic: forms
+license: marketingessentials
+audience: settings
+audience_tooltip: Settings and maintenance
+index: true
+language: sv
+---
+
+# Begränsningar för formulärfält
+
+Fältbegränsningar för formulär låter dig styra vilka fält som är tillgängliga i formulär och om ett formulärinskick kan skriva över befintliga data i dessa fält.
+
+Som standard skriver inte formulärinskick över befintliga data. Personen som bygger formuläret kan välja att aktivera överskrivning för enskilda fält. Använd fältbegränsningar för att ta bort det alternativet från känsliga fält eller för att förhindra att ett fält visas i formulärverktyget alls.
+
+> [!CAUTION]
+> Formulär på en webbplats kan fyllas i av vem som helst. Att tillåta överskrivningar innebär risker, bland annat oavsiktlig dataförlust, obehöriga ändringar av känsliga fält och äventyrad dataintegritet genom felaktiga uppgifter. Hantera känsliga fält med försiktighet.
+
+## Hantera fältbegränsningar
+
+Fältbegränsningar konfigureras i **Inställningar och underhåll** och kräver administratörsbehörighet.
+
+1. Gå till **Inställningar och underhåll**.
+1. Välj <i class="ph ph-bullseye" aria-hidden="true"></i> **Marketing** från navigatorn.
+1. Välj fliken **Begränsningar för formulärfält**.
+
+![Admin Marketing - Ange begränsningar för formulärfält som visas i Marketing-formulär -screenshot][img1]
+
+## Lägg till en fältbegränsning
+
+1. Välj ett fält i listrutan i avsnittet **Fält med begränsningar**.
+1. Välj begränsningstypen för det fältet.
+1. Välj **Spara**.
+
+Upprepa för att lägga till begränsningar för fler fält.
+
+## Begränsningsalternativ
+
+* **Tillåt inte överskrivning:** Överskrivningsalternativet tas bort från det här fältet i alla formulär, inklusive formulär som redan har publicerats. Fältet är fortfarande tillgängligt i formulärverktyget och kan fortfarande läggas till formulär, men inskickade data skriver aldrig över befintliga värden.
+
+* **Visa inte i formulär:** Fältet tas bort helt från formulärverktyget och kan inte läggas till nya formulär. Befintliga publicerade formulär som redan innehåller fältet påverkas inte.
+
+## Ta bort en fältbegränsning
+
+1. Leta upp fältet i listan **Fält med begränsningar**.
+1. Välj ta bort-ikonen (<i class="ph ph-x-circle" aria-hidden="true"></i>) bredvid fältet.
+1. Välj **Spara**.
+
+Om du tar bort en begränsning återställs standardbeteendet. Fältet blir tillgängligt i formulärverktyget igen och formulärägaren kan välja om överskrivning ska tillåtas.
+
+## Relaterat innehåll
+
+* [Fältalternativ][1]
+* [Skapa nytt formulär][2]
+* [Hantera typsnitt för formulär][3]
+
+<!-- Referenced links -->
+[1]: ../learn/field-options.md
+[2]: ../learn/create.md
+[3]: manage-fonts.md
+
+<!-- Referenced images -->
+[img1]: ../../../../media/loc/en/admin/admin-marketing-form-field-restrictions.png

--- a/docs/sv/marketing/forms/learn/create.md
+++ b/docs/sv/marketing/forms/learn/create.md
@@ -4,8 +4,8 @@ title: Skapa nytt formulär
 description: Lär dig hur du kan skapa ett webbformulär i den här instruktionsguiden.
 keywords: formulär, webbformulär, anmäl dig
 author: digitaldiina
-date: 03.17.2026
-version: 11.11
+date: 05.04.2026
+version: 11.13
 content_type: howto
 category: marketing
 topic: forms
@@ -85,13 +85,13 @@ I kategorin **Fält** lägger du till fälten som ska finnas med i formuläret. 
 
 3. Välj en av följande fältkategorier i fönstret **Lägg till post**:
 
-    * **SuperOffice-poster**: Fält som är länkade till SuperOffice-data, till exempel kontaktnamn, land, e-postadress och så vidare. Beroende på typ av fält kan värden från inlämnade formulär antingen ersätta befintliga värden (t.ex. land eller titel) eller läggas till i relevant SuperOffice-fält (t.ex. mobiltelefon).
+    * **SuperOffice-poster**: Fält som är länkade till SuperOffice-data, till exempel kontaktnamn, land, e-postadress och så vidare. Standard- och anpassade fält är tillgängliga. Beroende på typ av fält kan värden från inlämnade formulär antingen skriva över befintliga värden eller läggas till i relevant SuperOffice-fält. En varning visas när du aktiverar överskrivning för ett fält. Om ett fält saknas eller överskrivningsalternativet inte är tillgängligt kan en administratör ha tillämpat en [fältbegränsning][10].
 
     * **Formulärposter**: Fält där text eller datum, fält för att välja värden (listor, kryssrutor och alternativknappar) och filöverföringsfält anges.
 
     * **Visa poster**: Avsnitt, texter och bilder. Använd avsnitt för att [skapa flersidiga formulär](#multi-page).
 
-4. Välj ett fält i listan.
+4. Välj ett fält i listan. Om listan är lång kan du använda sökrutan för att hitta ett fält med namn.
 
 5. Klicka på **Lägg till**. Fönstret stängs och fältet läggs till i formuläret och i formulärförhandsvisningen.
 
@@ -207,6 +207,7 @@ Här kan du [definiera vad som händer när någon skickar in ett svarsformulär
 [4]: field-options.md
 [8]: ../../learn/create-folder.md
 [9]: ../admin/manage-fonts.md
+[10]: ../admin/form-field-restrictions.md
 
 <!-- Referenced images -->
 [img15]: ../../../../media/loc/en/marketing/contact-me-form-properties.png

--- a/docs/sv/marketing/forms/learn/field-options.md
+++ b/docs/sv/marketing/forms/learn/field-options.md
@@ -4,8 +4,8 @@ title: Fältalternativ
 description: Fältalternativ
 keywords: formulär fält, formulärpost, fältalternativ, reCAPTCHA
 author: SuperOffice Product and Engineering
-date: 09.26.2025
-version: 10.5
+date: 05.04.2026
+version: 11.13
 content_type: reference
 category: marketing
 topic: forms
@@ -21,7 +21,7 @@ Detta är en översikt över specialalternativ i några av de tillgängliga fäl
 
 ## SuperOffice-poster
 
-* **Ersätt:** Välj det här alternativet om du vill ersätta ett befintligt värde i SuperOffice med ett värde i formuläret. Detta gäller för land, rubrik och herr/fru.
+* **Tillåt överskrivning av befintliga data:** Välj det här alternativet om du vill ersätta ett befintligt värde i SuperOffice med värdet som skickades i formuläret. En varning visas när du aktiverar det här alternativet. Om det här alternativet inte är tillgängligt för ett fält kan en administratör ha begränsat det. Se [begränsningar för formulärfält][5].
 
 * **Kontakt – medgivande**
 
@@ -95,3 +95,4 @@ Detta är en översikt över specialalternativ i några av de tillgängliga fäl
 [2]: create.md#multi-page
 [3]: ../../recipients/learn/manage-email-subscriptions.md
 [4]: ../../../security/privacy/admin/add-purpose.md
+[5]: ../admin/form-field-restrictions.md

--- a/docs/sv/marketing/forms/learn/toc.yml
+++ b/docs/sv/marketing/forms/learn/toc.yml
@@ -21,3 +21,5 @@ items:
   href: tutorial-sign-up.md
 - name: Hantera typsnitt för formulär
   href: ../admin/manage-fonts.md
+- name: Begränsningar för formulärfält
+  href: ../admin/form-field-restrictions.md


### PR DESCRIPTION
For 11.13. 

* Adds new admin how-to for configuring per-field overwrite and visibility restrictions.
* Updates field-options and create pages to reference restrictions and rename 'Replace' to 'Allow overwrite of existing data'.
* All changes propagated to da, de, nl, no, sv.