### PR TITLE
Update email connectivity rollout messaging for 11.13 (#2905)

### DIFF
--- a/docs/da/learn/getting-started/connect-email-doc/includes/legacy-version-note.md
+++ b/docs/da/learn/getting-started/connect-email-doc/includes/legacy-version-note.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable-file MD041 -->
 > [!NOTE]
-> Denne side gælder for version 11.10 og tidligere. Hvis du bruger **SuperOffice Online 11.11 eller nyere**, skal du bruge guiden [Brugeropsætning][1] under **Personlige indstillinger** til at tilslutte dine konti.
+> Denne side gælder for version 11.10 og tidligere og for onsite-installationer. Hvis du er **SuperOffice Online**-kunde, skal du bruge guiden [Brugeropsætning][1] under **Personlige indstillinger** i stedet — tilgængelig for nye kunder fra 11.11, rulles gradvist ud til alle online-kunder fra 11.13.
 
 <!-- Referenced links -->
 [1]: ../../connect-your-accounts.md

--- a/docs/da/learn/getting-started/connect-your-accounts.md
+++ b/docs/da/learn/getting-started/connect-your-accounts.md
@@ -4,8 +4,8 @@ title: Tilslut dine konti
 description: Sådan bruger du guiden Brugeropsætning til at tilslutte din e-mailkonto og dokumenthåndtering til SuperOffice CRM.
 keywords: brugeropsætning, e-mailforbindelse, dokumenthåndtering, WebTools, tilslut e-mail, e-mailkonto, guide, personlige indstillinger
 author: digitaldiina
-date: 03.17.2026
-version: 11.11
+date: 05.04.2026
+version: 11.13
 content_type: howto
 audience: person
 audience_tooltip: SuperOffice CRM
@@ -14,7 +14,7 @@ language: da
 
 # Tilslut dine konti
 
-*Tilgængelig for nye kunder fra 11.11, tilgængelig for alle kunder fra 11.13.*
+*Tilgængelig for nye SuperOffice Online-kunder fra 11.11. Rulles gradvist ud til alle SuperOffice Online-kunder fra 11.13. Ikke tilgængelig for onsite-installationer.*
 
 Som ny bruger, eller når du opsætter en ny computer, bør du tilslutte din e-mailkonto og dokumenthåndtering til SuperOffice. Det giver dig mulighed for at:
 

--- a/docs/de/learn/getting-started/connect-email-doc/includes/legacy-version-note.md
+++ b/docs/de/learn/getting-started/connect-email-doc/includes/legacy-version-note.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable-file MD041 -->
 > [!NOTE]
-> Diese Seite gilt für Version 11.10 und früher. Wenn Sie **SuperOffice Online 11.11 oder höher** verwenden, nutzen Sie den Assistenten [Benutzereinrichtung][1] unter **Persönliche Einstellungen**, um Ihre Konten zu verbinden.
+> Diese Seite gilt für Version 11.10 und früher sowie für Onsite-Installationen. Wenn Sie **SuperOffice Online**-Kunde sind, nutzen Sie stattdessen den Assistenten [Benutzereinrichtung][1] unter **Persönliche Einstellungen** — verfügbar für neue Kunden ab 11.11, ab 11.13 schrittweise für alle Online-Kunden.
 
 <!-- Referenced links -->
 [1]: ../../connect-your-accounts.md

--- a/docs/de/learn/getting-started/connect-your-accounts.md
+++ b/docs/de/learn/getting-started/connect-your-accounts.md
@@ -4,8 +4,8 @@ title: Konten verbinden
 description: So verwenden Sie den Assistenten Benutzereinrichtung, um Ihr E-Mail-Konto und Ihre Dokumentenverwaltung mit SuperOffice CRM zu verbinden.
 keywords: Benutzereinrichtung, E-Mail-Verbindung, Dokumentenverwaltung, WebTools, E-Mail verbinden, E-Mail-Konto, Assistent, persönliche Einstellungen
 author: digitaldiina
-date: 03.17.2026
-version: 11.11
+date: 05.04.2026
+version: 11.13
 content_type: howto
 audience: person
 audience_tooltip: SuperOffice CRM
@@ -14,7 +14,7 @@ language: de
 
 # Konten verbinden
 
-*Verfügbar für neue Kunden ab 11.11, für alle Kunden ab 11.13.*
+*Verfügbar für neue SuperOffice Online-Kunden ab 11.11. Wird ab 11.13 schrittweise für alle SuperOffice Online-Kunden eingeführt. Nicht verfügbar für Onsite-Installationen.*
 
 Als neuer Benutzer oder beim Einrichten eines neuen Computers sollten Sie Ihr E-Mail-Konto und Ihre Dokumentenverwaltung mit SuperOffice verbinden. Dies ermöglicht Ihnen:
 

--- a/docs/en/learn/getting-started/connect-email-doc/includes/legacy-version-note.md
+++ b/docs/en/learn/getting-started/connect-email-doc/includes/legacy-version-note.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable-file MD041 -->
 > [!NOTE]
-> This page applies to version 11.10 and earlier. If you are on **SuperOffice Online 11.11 or later**, use the [User setup][1] wizard in **Personal settings** to connect your accounts.
+> This page applies to version 11.10 and earlier, and to onsite installations. If you are a **SuperOffice Online** customer, use the [User setup][1] wizard in **Personal settings** instead — available for new customers from 11.11, rolling out gradually to all online customers from 11.13.
 
 <!-- Referenced links -->
 [1]: ../../connect-your-accounts.md

--- a/docs/en/learn/getting-started/connect-your-accounts.md
+++ b/docs/en/learn/getting-started/connect-your-accounts.md
@@ -4,8 +4,8 @@ title: Connect your accounts
 description: How to use the User setup wizard to connect your email account and document handler to SuperOffice CRM.
 keywords: user setup, email connectivity, document handler, WebTools, connect email, email account, wizard, personal settings
 author: digitaldiina
-date: 03.17.2026
-version: 11.11
+date: 05.04.2026
+version: 11.13
 content_type: howto
 audience: person
 audience_tooltip: SuperOffice CRM
@@ -14,7 +14,7 @@ language: en
 
 # Connect your accounts
 
-*Available for new customers from 11.11, available for all customers from 11.13.*
+*Available for new SuperOffice Online customers from 11.11. Rolling out gradually to all SuperOffice Online customers from 11.13. Not available for onsite installations.*
 
 As a new user, or when setting up a new computer, you should connect your email account and document handler to SuperOffice. This lets you:
 

--- a/docs/nl/learn/getting-started/connect-email-doc/includes/legacy-version-note.md
+++ b/docs/nl/learn/getting-started/connect-email-doc/includes/legacy-version-note.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable-file MD041 -->
 > [!NOTE]
-> Deze pagina is van toepassing op versie 11.10 en eerder. Als je **SuperOffice Online 11.11 of hoger** gebruikt, gebruik dan de wizard [Gebruikersinstellingen][1] in **Persoonlijke instellingen** om je accounts te koppelen.
+> Deze pagina is van toepassing op versie 11.10 en eerder, en op onsite-installaties. Als je een **SuperOffice Online**-klant bent, gebruik dan de wizard [Gebruikersinstellingen][1] in **Persoonlijke instellingen** in plaats daarvan — beschikbaar voor nieuwe klanten vanaf 11.11, geleidelijk uitgerold naar alle online klanten vanaf 11.13.
 
 <!-- Referenced links -->
 [1]: ../../connect-your-accounts.md

--- a/docs/nl/learn/getting-started/connect-your-accounts.md
+++ b/docs/nl/learn/getting-started/connect-your-accounts.md
@@ -4,8 +4,8 @@ title: Accounts koppelen
 description: Hoe je de wizard Gebruikersinstellingen gebruikt om je e-mailaccount en documentbeheer te koppelen aan SuperOffice CRM.
 keywords: gebruikersinstellingen, e-mailverbinding, documentbeheer, WebTools, e-mail koppelen, e-mailaccount, wizard, persoonlijke instellingen
 author: digitaldiina
-date: 03.17.2026
-version: 11.11
+date: 05.04.2026
+version: 11.13
 content_type: howto
 audience: person
 audience_tooltip: SuperOffice CRM
@@ -14,7 +14,7 @@ language: nl
 
 # Accounts koppelen
 
-*Beschikbaar voor nieuwe klanten vanaf 11.11, beschikbaar voor alle klanten vanaf 11.13.*
+*Beschikbaar voor nieuwe SuperOffice Online-klanten vanaf 11.11. Wordt geleidelijk uitgerold naar alle SuperOffice Online-klanten vanaf 11.13. Niet beschikbaar voor onsite-installaties.*
 
 Als nieuwe gebruiker, of bij het instellen van een nieuwe computer, moet je je e-mailaccount en documentbeheer koppelen aan SuperOffice. Hiermee kun je:
 

--- a/docs/no/learn/getting-started/connect-email-doc/includes/legacy-version-note.md
+++ b/docs/no/learn/getting-started/connect-email-doc/includes/legacy-version-note.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable-file MD041 -->
 > [!NOTE]
-> Denne siden gjelder for versjon 11.10 og tidligere. Hvis du bruker **SuperOffice Online 11.11 eller nyere**, bruker du veiviseren [Brukeroppsett][1] i **Personlige innstillinger** for å koble til kontoene dine.
+> Denne siden gjelder for versjon 11.10 og tidligere, og for onsite-installasjoner. Hvis du er **SuperOffice Online**-kunde, bruker du veiviseren [Brukeroppsett][1] i **Personlige innstillinger** i stedet — tilgjengelig for nye kunder fra 11.11, rulles gradvis ut til alle online-kunder fra 11.13.
 
 <!-- Referenced links -->
 [1]: ../../connect-your-accounts.md

--- a/docs/no/learn/getting-started/connect-your-accounts.md
+++ b/docs/no/learn/getting-started/connect-your-accounts.md
@@ -4,8 +4,8 @@ title: Koble til kontoene dine
 description: Slik bruker du veiviseren Brukeroppsett til å koble e-postkontoen og dokumenthåndteringen din til SuperOffice CRM.
 keywords: brukeroppsett, e-posttilkobling, dokumenthåndtering, WebTools, koble til e-post, e-postkonto, veiviser, personlige innstillinger
 author: digitaldiina
-date: 03.17.2026
-version: 11.11
+date: 05.04.2026
+version: 11.13
 content_type: howto
 audience: person
 audience_tooltip: SuperOffice CRM
@@ -14,7 +14,7 @@ language: no
 
 # Koble til kontoene dine
 
-*Tilgjengelig for nye kunder fra 11.11, tilgjengelig for alle kunder fra 11.13.*
+*Tilgjengelig for nye SuperOffice Online-kunder fra 11.11. Rulles gradvis ut til alle SuperOffice Online-kunder fra 11.13. Ikke tilgjengelig for onsite-installasjoner.*
 
 Som ny bruker, eller når du setter opp en ny datamaskin, bør du koble e-postkontoen og dokumenthåndteringen din til SuperOffice. Dette lar deg:
 

--- a/docs/sv/learn/getting-started/connect-email-doc/includes/legacy-version-note.md
+++ b/docs/sv/learn/getting-started/connect-email-doc/includes/legacy-version-note.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable-file MD041 -->
 > [!NOTE]
-> Den här sidan gäller för version 11.10 och tidigare. Om du använder **SuperOffice Online 11.11 eller senare** använder du guiden [Användarinställningar][1] i **Personliga inställningar** för att ansluta dina konton.
+> Den här sidan gäller för version 11.10 och tidigare samt för onsite-installationer. Om du är **SuperOffice Online**-kund använder du guiden [Användarinställningar][1] i **Personliga inställningar** i stället — tillgänglig för nya kunder från 11.11, rullas ut gradvis till alla onlinekunder från 11.13.
 
 <!-- Referenced links -->
 [1]: ../../connect-your-accounts.md

--- a/docs/sv/learn/getting-started/connect-your-accounts.md
+++ b/docs/sv/learn/getting-started/connect-your-accounts.md
@@ -4,8 +4,8 @@ title: Anslut dina konton
 description: Hur du använder guiden Användarinställningar för att ansluta ditt e-postkonto och dokumenthantering till SuperOffice CRM.
 keywords: användarinställningar, e-postanslutning, dokumenthantering, WebTools, anslut e-post, e-postkonto, guide, personliga inställningar
 author: digitaldiina
-date: 03.17.2026
-version: 11.11
+date: 05.04.2026
+version: 11.13
 content_type: howto
 audience: person
 audience_tooltip: SuperOffice CRM
@@ -14,7 +14,7 @@ language: sv
 
 # Anslut dina konton
 
-*Tillgänglig för nya kunder från 11.11, tillgänglig för alla kunder från 11.13.*
+*Tillgänglig för nya SuperOffice Online-kunder från 11.11. Rullas ut gradvis till alla SuperOffice Online-kunder från 11.13. Inte tillgänglig för onsite-installationer.*
 
 Som ny användare, eller när du konfigurerar en ny dator, bör du ansluta ditt e-postkonto och din dokumenthantering till SuperOffice. Det gör att du kan:
 

--- a/integrations/mail-link/install.md
+++ b/integrations/mail-link/install.md
@@ -4,7 +4,7 @@ title: Install Mail Link
 description: Learn how to download, install, and configure SuperOffice Mail Link with Microsoft Outlook.
 keywords: install Mail Link, connect Outlook to SuperOffice, configure Mail Link
 author: digitaldiina
-date: 03.17.2026
+date: 05.04.2026
 content_type: howto
 category: integration
 topic: Mail Link
@@ -26,7 +26,7 @@ index: true
 Mail Link connects Microsoft Outlook to SuperOffice CRM. It is a stand-alone installer and is not part of SuperOffice WebTools.
 
 > [!NOTE]
-> From **SuperOffice Online 11.11** with the *NewEmailConnectivity* feature toggle active in your tenant, SuperOffice CRM will not use Mail Link to send emails or invitations — even if Mail Link is installed. Email is handled directly in SuperOffice.
+> From **SuperOffice Online 11.13**, SuperOffice CRM does not use Mail Link to send emails or invitations when the new email connectivity has been enabled in your tenant — even if Mail Link is installed. This rollout started for new online customers in 11.11 and continues gradually for all online customers from 11.13. Onsite installations are not affected.
 
 ## Download and install
 

--- a/release-notes/11/core-crm/11.11-update.md
+++ b/release-notes/11/core-crm/11.11-update.md
@@ -18,7 +18,7 @@ language: en
 
 ## User setup to configure email and document management
 
-*Available for new customers from 11.11, available for all customers from 11.13.*
+*Available for new SuperOffice Online customers from 11.11. Rolling out gradually to all SuperOffice Online customers from 11.13. Not available for onsite installations.*
 
 As a new user (or a user with a new computer), there are a few things you should set up to ensure a smooth interaction between SuperOffice CRM, your email account, and your document handler.
 


### PR DESCRIPTION
Clarify that the new email connectivity rolls out gradually to SuperOffice Online customers only from 11.13 (started for new customers in 11.11), and is not available for onsite installations. 

Updated connect-your-accounts.md (all 6 langs), legacy-version-note.md (all 6 langs), 11.11 release note, and mail-link install note.