### PR TITLE
#2691 Expand Email tag entry with matching logic and registry settings

### DIFF
--- a/docs/da/admin/preferences/service-settings.md
+++ b/docs/da/admin/preferences/service-settings.md
@@ -4,7 +4,7 @@ title: SuperOffice Service-systemindstillinger
 description: Globale præferencer for SuperOffice Service-systemindstillinger
 keywords: Service indstillinger, globale præferencer
 author: digitaldiina
-date: 10.17.2025
+date: 04.28.2026
 version: 11.5
 content_type: reference
 category: Settings and maintenance
@@ -40,7 +40,15 @@ Gå til <i class="ph ph-gear" aria-hidden="true"></i> **Præferencer** i navigat
 
 * **Standardafsender**: Systemets standardafsenderadresse til e-mails. Denne adresse tilsidesættes normalt af adresserne angivet i e-mailkonti. Der skal være tale om en e-mailadresse, som er importeret til SuperOffice Service. For eksempel, `<support@company.com>`.
 
-* **E-mailkode**: Den e-mailkode, der sammen med sagsnummeret danner en unik nøgle for emnet i e-mails, der udsendes fra SuperOffice Service. Du må ikke ændre denne værdi, medmindre du ved, hvad du gør! Hvis denne værdi ændres, vil modtagne e-mails ikke blive linket korrekt til eksisterende sager.
+* **E-mailkode**: Det navn, der bruges som kodenøgle i emnelinjen for udgående e-mails. Standardværdien er `ejTag`. Kombineret med sagsnummeret danner det en unik identifikator — for eksempel `ejTag: 12345` — som Service bruger til at matche indgående svar med den rigtige sag.
+
+    Når en e-mail modtages, kontrollerer Service først standardheaderen `In-Reply-To` for at matche den med en eksisterende sag. E-mailkoden i emnelinjen bruges som reserve. Undlad at ændre denne værdi, medmindre du forstår konsekvenserne — hvis du ændrer navnet, brydes matchingen for e-mails, der stadig refererer til den gamle kode.
+
+    > [!NOTE]
+    > To registerindstillinger ændrer denne adfærd:
+    >
+    > * **reg_id=72** (værdi `1`): Service søger kun i e-mailheaderen (emnelinjen) efter koden, ikke i brødteksten.
+    > * **reg_id=175** (værdi `1`): Service kontrollerer emnelinjen for e-mailkoden *før* den kontrollerer `In-Reply-To`-headeren, hvilket vender standardprioriteten om.
 
 * **Format for klokkeslæt i systemet**: Vælg, om du vil bruge et 24-timers eller 12-timers (AM/PM) ur i systemet. Brugerspecifikke ure (f.eks. visning af sager) styres af den enkelte brugers indstillinger og ikke af denne værdi.
 

--- a/docs/de/admin/preferences/service-settings.md
+++ b/docs/de/admin/preferences/service-settings.md
@@ -4,7 +4,7 @@ title: Benutzereinstellungen für SuperOffice Service
 description: Globale Einstellungen für Benutzereinstellungen für SuperOffice Service
 keywords: Service Einstellungen
 author: digitaldiina
-date: 10.17.2025
+date: 04.28.2026
 version: 11.5
 content_type: reference
 category: Settings and maintenance
@@ -40,7 +40,15 @@ Gehen Sie im Navigator zum <i class="ph ph-gear" aria-hidden="true"></i> **Einst
 
 * **Standardabsender**: Die Absenderadresse der Standard-E-Mail des Systems. Diese Adresse wird normalerweise durch die Adressen ersetzt, die für die Postfächer eingegeben wurden. Hierbei muss es sich um eine E-Mail-Adresse handeln, die in SuperOffice Service importiert wurde. Zum Beispiel, `<support@company.com>`.
 
-* **E-Mail-Tag**: Aus diesem E-Mail-Tag und der Anfragenummer wird eine eindeutige Kennung in der Betreffzeile von E-Mails erzeugt, die mit SuperOffice Service gesendet werden. Ändern Sie diesen Wert nur, wenn Sie mit den Auswirkungen vertraut sind. Eine Änderung kann zur Folge haben, dass erhaltene E-Mails vorhandenen Anfragen nicht richtig verknüpft werden.
+* **E-Mail-Tag**: Der Name, der als Tag-Schlüssel in der Betreffzeile ausgehender E-Mails verwendet wird. Der Standardwert ist `ejTag`. In Kombination mit der Anfragenummer wird eine eindeutige Kennung erstellt — zum Beispiel `ejTag: 12345` —, die Service verwendet, um eingehende Antworten der richtigen Anfrage zuzuordnen.
+
+    Wenn eine E-Mail eingeht, prüft Service zuerst den Standard-E-Mail-Header `In-Reply-To`, um sie einer vorhandenen Anfrage zuzuordnen. Der E-Mail-Tag in der Betreffzeile wird als Fallback verwendet. Ändern Sie diesen Wert nur, wenn Sie die Konsequenzen verstehen — eine Änderung des Namens unterbricht die Zuordnung für E-Mails, die noch den alten Tag referenzieren.
+
+    > [!NOTE]
+    > Zwei Registrierungseinstellungen ändern dieses Verhalten:
+    >
+    > * **reg_id=72** (Wert `1`): Service durchsucht nur den E-Mail-Header (Betreffzeile) nach dem Tag, nicht den Nachrichtentext.
+    > * **reg_id=175** (Wert `1`): Service prüft die Betreffzeile auf den E-Mail-Tag *bevor* der `In-Reply-To`-Header geprüft wird, was die Standardpriorität umkehrt.
 
 * **Systemzeit**: Wählen Sie, ob ein 24-Stunden-Format und ein 12-Stunden-Format (am/pm) verwendet werden soll. Benutzerspezifische Zeitangaben (zum Beispiel die Anzeige von Anfragen) werden durch die Einstellungen des jeweiligen Benutzers und nicht durch diesen Wert gesteuert.
 

--- a/docs/en/admin/preferences/service-settings.md
+++ b/docs/en/admin/preferences/service-settings.md
@@ -4,7 +4,7 @@ title: SuperOffice Service system settings
 description: Global preferences for SuperOffice Service system settings
 keywords: Service settings
 author: digitaldiina
-date: 10.17.2025
+date: 04.28.2026
 version: 11.5
 content_type: reference
 category: Settings and maintenance
@@ -40,7 +40,15 @@ Go to <i class="ph ph-gear" aria-hidden="true"></i> **Preferences** in the navig
 
 * **Default From address**: The system's default email sender address. This address will normally be overridden by the addresses entered into mailboxes. This must be an email address that is imported into SuperOffice Service. For example, `support@company.com`.
 
-* **Email tag**: The email tag which, in conjunction with the request number, creates a unique key for the subject in emails that are sent out from SuperOffice Service. You must not change this value unless you know what you are doing! If this value is changed, received emails will not be correctly linked to existing requests.
+* **Email tag**: The name used as the tag key in outbound email subjects. The default value is `ejTag`. Combined with the request number, it creates a unique identifier — for example, `ejTag: 12345` — that Service uses to match incoming replies to the correct request.
+
+    When an email arrives, Service first checks the standard `In-Reply-To` email header to match it to an existing request. The email tag in the subject line is used as a fallback. Do not change this value unless you understand the consequences — changing the name breaks the match for any emails that still reference the old tag.
+
+    > [!NOTE]
+    > Two registry settings modify this behavior:
+    >
+    > * **reg_id=72** (value `1`): Service searches only the email header (subject) for the tag, not the message body.
+    > * **reg_id=175** (value `1`): Service checks the subject for the email tag *before* checking the `In-Reply-To` header, reversing the default priority.
 
 * **System clock**: Select if to use a 24-hour or 12-hour (am/pm) clock in the system. User-specific clocks (for example, display of requests) are controlled by each individual user's settings, and not by this value.
 

--- a/docs/nl/admin/preferences/service-settings.md
+++ b/docs/nl/admin/preferences/service-settings.md
@@ -4,7 +4,7 @@ title: SuperOffice Service-systeeminstellingen
 description: Algemene voorkeuren voor SuperOffice Service-systeeminstellingen
 keywords: Service instellingen, systeeminstellingen, Algemene voorkeuren
 author: digitaldiina
-date: 10.17.2025
+date: 04.28.2026
 version: 11.5
 content_type: reference
 category: Settings and maintenance
@@ -40,7 +40,15 @@ Ga naar <i class="ph ph-gear" aria-hidden="true"></i> **Voorkeuren** in de navig
 
 * **Standaard Van-adres**: Het standaard afzenderadres van de e-mail van het systeem. Dit adres wordt meestal vervangen door de adressen die in de postbussen zijn ingevoerd. Dit moet een e-mailadres zijn dat in SuperOffice Service is geïmporteerd. Bijvoorbeeld, `<support@company.com>`.
 
-* **E-mailcode**: De e-mailcode die, samen met de verzoek-ID, wordt gebruikt om een unieke sleutel te maken voor de onderwerpregel van e-mailberichten die vanuit SuperOffice Service worden verstuurd. Deze waarde mag alleen worden gewijzigd wanneer u exact weet wat voor gevolgen dit kan hebben! Wanneer deze waarde wordt gewijzigd, worden ontvangen e-mailberichten niet meer goed gelinkt aan bestaande verzoeken.
+* **E-mailcode**: De naam die wordt gebruikt als codesleutel in de onderwerpregel van uitgaande e-mails. De standaardwaarde is `ejTag`. Gecombineerd met het verzoeknummer wordt een unieke identificatie aangemaakt — bijvoorbeeld `ejTag: 12345` — die Service gebruikt om binnenkomende antwoorden aan het juiste verzoek te koppelen.
+
+    Wanneer een e-mail binnenkomt, controleert Service eerst de standaard `In-Reply-To`-header om deze aan een bestaand verzoek te koppelen. De e-mailcode in de onderwerpregel wordt gebruikt als terugvaloptie. Wijzig deze waarde alleen als u de gevolgen begrijpt — het wijzigen van de naam verbreekt de koppeling voor e-mails die nog naar de oude code verwijzen.
+
+    > [!NOTE]
+    > Twee registerinstellingen wijzigen dit gedrag:
+    >
+    > * **reg_id=72** (waarde `1`): Service doorzoekt alleen de e-mailheader (onderwerpregel) op de code, niet de berichttekst.
+    > * **reg_id=175** (waarde `1`): Service controleert de onderwerpregel op de e-mailcode *vóór* de `In-Reply-To`-header, wat de standaardprioriteit omkeert.
 
 * **Systeemklok**: Kies de tijdnotatie 24 of 12 uur (am/pm) voor het systeem. Gebruikersspecifieke klokken (bijvoorbeeld weergave van verzoeken) worden bepaald door de instellingen van de betreffende gebruiker, niet door deze waarde.
 

--- a/docs/no/admin/preferences/service-settings.md
+++ b/docs/no/admin/preferences/service-settings.md
@@ -4,7 +4,7 @@ title: Systeminnstillinger for SuperOffice Service
 description: Globale preferanser for systeminnstillinger for SuperOffice Service
 keywords: Service preferanser
 author: digitaldiina
-date: 10.17.2025
+date: 04.28.2026
 version: 11.5
 content_type: reference
 category: Settings and maintenance
@@ -40,7 +40,15 @@ Gå til <i class="ph ph-gear" aria-hidden="true"></i> **Preferanser** i navigato
 
 * **Standardavsender**: Systemets standard avsenderadresse for e-post. Denne adressen vil normalt overstyres av adressene som legges inn i e-postkasser. Dette må være en e-postadresse som importeres i SuperOffice Service. For eksempel `<support@company.com>`.
 
-* **E-postkode**: E-postkoden som sammen med saksnummeret danner en unik nøkkel for emnet i e-postmeldinger som sendes ut fra SuperOffice Service. Du må ikke endre denne verdien med mindre du vet hva du gjør! Hvis denne verdien endres, vil ikke e-postmeldinger som mottas, kobles riktig til eksisterende saker.
+* **E-postkode**: Det navnet som brukes som kodenøkkel i emnefeltet for utgående e-postmeldinger. Standardverdien er `ejTag`. Kombinert med saksnummeret danner det en unik identifikator — for eksempel `ejTag: 12345` — som Service bruker til å matche innkommende svar med riktig sak.
+
+    Når en e-postmelding kommer inn, kontrollerer Service først standard-headeren `In-Reply-To` for å matche den med en eksisterende sak. E-postkoden i emnefeltet brukes som reserve. Ikke endre denne verdien med mindre du forstår konsekvensene — endring av navnet bryter matchingen for e-postmeldinger som fortsatt refererer til den gamle koden.
+
+    > [!NOTE]
+    > To registerinnstillinger endrer denne oppførselen:
+    >
+    > * **reg_id=72** (verdi `1`): Service søker bare i e-postheaderen (emnefeltet) etter koden, ikke i brødteksten.
+    > * **reg_id=175** (verdi `1`): Service kontrollerer emnefeltet for e-postkoden *før* den kontrollerer `In-Reply-To`-headeren, noe som reverserer standardprioriteten.
 
 * **Systemklokke**: Velg om du ønsker 24 timers klokke eller 12 timers klokke (am/pm) for systemet. Brukerspesifikke klokkeslett (for eksempel visning av saker) styres av hver enkelt brukers innstillinger, og ikke av denne verdien.
 

--- a/docs/sv/admin/preferences/service-settings.md
+++ b/docs/sv/admin/preferences/service-settings.md
@@ -4,7 +4,7 @@ title: Systeminställningar för SuperOffice Service
 description: Globala inställningar för Systeminställningar för SuperOffice Service
 keywords: systeminställningar
 author: digitaldiina
-date: 10.17.2025
+date: 04.28.2026
 version: 11.5
 content_type: reference
 category: Settings and maintenance
@@ -40,7 +40,15 @@ Gå till <i class="ph ph-gear" aria-hidden="true"></i> **Inställningar** i navi
 
 * **Standardavsändare**: Systemet standardavsändare för e-post. Denna adress åsidosätts normalt av adresser som läggs till i e-postlådor. Detta måste vara en e-postadress som har importerats i SuperOffice Service. Till exempel `<support@company.com>`.
 
-* **E-posttagg**: E-posttaggen som tillsammans med ärendenumret bildar en unik nyckel på ämnesraden i de e-postmeddelanden som skickas ut från SuperOffice Service. Du får inte ändra detta värde om du inte är helt säker på vad du gör! Om det här värdet ändras kommer inte mottagna e-postmeddelanden att kopplas rätt till befintliga ärenden.
+* **E-posttagg**: Det namn som används som tagg-nyckel på ämnesraden i utgående e-postmeddelanden. Standardvärdet är `ejTag`. Kombinerat med ärendenumret skapas en unik identifierare — till exempel `ejTag: 12345` — som Service använder för att matcha inkommande svar med rätt ärende.
+
+    När ett e-postmeddelande kommer in kontrollerar Service först standard-headern `In-Reply-To` för att matcha det med ett befintligt ärende. E-posttaggen på ämnesraden används som reservalternativ. Ändra inte det här värdet om du inte förstår konsekvenserna — om du ändrar namnet bryts matchningen för e-postmeddelanden som fortfarande refererar till den gamla taggen.
+
+    > [!NOTE]
+    > Två registerinställningar ändrar det här beteendet:
+    >
+    > * **reg_id=72** (värde `1`): Service söker bara i e-posthuvudet (ämnesraden) efter taggen, inte i meddelandetexten.
+    > * **reg_id=175** (värde `1`): Service kontrollerar ämnesraden efter e-posttaggen *innan* `In-Reply-To`-headern kontrolleras, vilket vänder standardprioriteringen.
 
 * **Format för klockslag i systemet**: Välj om du vill använda 24-timmarsklocka eller 12-timmarsklocka (am/pm) i systemet. Användarspecifika klockslag (till exempel visning av ärenden) styrs av varje enskild användares inställningar och påverkas inte av detta värde.
 


### PR DESCRIPTION
Explains that the preference controls the tag name (default: ejTag), how In-Reply-To takes priority over the tag for matching, and documents reg_id=72 and reg_id=175 registry settings. Updated in all six languages.