### PR TITLE
Fix link format for initial security evaluation

### DIFF
--- a/docs/en/developer-portal/standard-app/certification/index.md
+++ b/docs/en/developer-portal/standard-app/certification/index.md
@@ -44,5 +44,5 @@ Follow our [step-by-step guide][6], started by sending a request to publish in t
 [3]: ../index.md
 [5]: ../requirements/index.md
 [6]: certify-app.md
-[7]: initial-security-eval#does-it-cost-anything
+[7]: initial-security-eval.md#does-it-cost-anything
 [8]: initial-security-eval


### PR DESCRIPTION
Broken link to https://docs.superoffice.com/en/developer-portal/standard-app/certification/initial-security-eval.html#does-it-cost-anything