### PR TITLE
docs(sofo): add shared mailbox support and compose-pinning documentation

### DIFF
--- a/integrations/superoffice-for-outlook/deploy.md
+++ b/integrations/superoffice-for-outlook/deploy.md
@@ -4,8 +4,8 @@ title: Centralized deployment
 description: How to deploy SuperOffice for Outlook through the Microsoft 365 Admin Center or PowerShell.
 keywords: SuperOffice for Outlook, Outlook, email, deploy, add-in, PowerShell, Microsoft 365 Admin Center, SOFO
 author: Frode B, Martin Pavlas
-date: 03.14.2025
-version_sofo: 2024.8.12
+date: 05.05.2026
+version_sofo: 6.2.0
 content_type: howto
 category: integration
 topic: SuperOffice for Outlook
@@ -31,6 +31,24 @@ You can perform centralized deployment through the Microsoft 365 Admin Center.
 
 To deploy SuperOffice for Outlook using the Microsoft 365 admin center, see [Microsoft's documentation][3].
 
+## Approve shared mailbox permissions for users
+
+Shared mailbox support requires additional Microsoft 365 permissions. A Microsoft 365 Global Administrator must grant consent for the add-in before users can access shared mailbox features.
+
+Consent can be granted in three ways:
+
+* Using a generic authorisation URL (recommended - can be done before users encounter any prompts)
+* Using a URL that a user copies from the permission dialog they encounter
+* Directly from the add-in in Outlook, using a Global Administrator account
+
+If a user does not have admin rights, they can select "Return to the application without granting consent" in the dialog, then copy a link to share with their Microsoft 365 Global Administrator.
+
+> [!NOTE]
+> When an update to an add-in increases the scope of data access, Microsoft may require the update to be re-approved before it is deployed.
+
+For full step-by-step instructions, see [SuperOffice for Outlook: Authorisation guide][6].
+
 <!-- Referenced links -->
 [3]: https://learn.microsoft.com/en-us/microsoft-365/admin/manage/manage-deployment-of-add-ins?view=o365-worldwide
 [5]: get.md
+[6]: https://community.superoffice.com/en/support-faqs/faq/superoffice-for-outlook-authorisation-guide/

--- a/integrations/superoffice-for-outlook/deploy.md
+++ b/integrations/superoffice-for-outlook/deploy.md
@@ -43,10 +43,10 @@ Consent can be granted in three ways:
 
 If a user does not have admin rights, they can select "Return to the application without granting consent" in the dialog, then copy a link to share with their Microsoft 365 Global Administrator.
 
+For full step-by-step instructions, see [SuperOffice for Outlook: Authorisation guide][6].
+
 > [!NOTE]
 > When an update to an add-in increases the scope of data access, Microsoft may require the update to be re-approved before it is deployed.
-
-For full step-by-step instructions, see [SuperOffice for Outlook: Authorisation guide][6].
 
 <!-- Referenced links -->
 [3]: https://learn.microsoft.com/en-us/microsoft-365/admin/manage/manage-deployment-of-add-ins?view=o365-worldwide

--- a/integrations/superoffice-for-outlook/deploy.md
+++ b/integrations/superoffice-for-outlook/deploy.md
@@ -5,7 +5,7 @@ description: How to deploy SuperOffice for Outlook through the Microsoft 365 Adm
 keywords: SuperOffice for Outlook, Outlook, email, deploy, add-in, PowerShell, Microsoft 365 Admin Center, SOFO
 author: Frode B, Martin Pavlas
 date: 05.05.2026
-version_sofo: 6.2.0
+version_sofo: 6.3.0
 content_type: howto
 category: integration
 topic: SuperOffice for Outlook

--- a/integrations/superoffice-for-outlook/get.md
+++ b/integrations/superoffice-for-outlook/get.md
@@ -4,8 +4,8 @@ title: Get the add-in
 description: How to install SuperOffice for Outlook for your account (1 user).
 keywords: SuperOffice for Outlook, Outlook, email, get add-in, SOFO
 author: Frode B, Martin Pavlas, Bergfrid Dias, Erik Lebiko
-date: 10.29.2024
-version_sofo: 2024.8.12
+date: 05.05.2026
+version_sofo: 6.2.0
 content_type: howto
 category: integration
 topic: SuperOffice for Outlook
@@ -85,15 +85,27 @@ The location of add-ins is different in classic Outlook for Windows and the new 
 
 * In new Outlook for Window, select **Apps** from the action bar of an email.
 
-## Pin/unpin the add-in
+## Pin or unpin SuperOffice for Outlook
 
-After installing the add-in, you can pin it for quick access while reading emails. We recommend pinning it for easier use.
+After installing the add-in, you can pin it for quick access. We recommend pinning it for easier use.
 
-* When the SuperOffice sidebar is displayed, press the **Pin** symbol to pin the​ sidebar to the page.​
+### Pin SuperOffice for Outlook while reading an email
 
-    The sidebar will now be available when reading emails.​
+* When the SuperOffice sidebar is displayed, select the **Pin** symbol to pin the sidebar to the page.
 
-* To unpin SuperOffice, press the **Pin** symbol again, and notice that the symbol will change its state.
+    The sidebar will now be available when reading emails.
+
+* To unpin SuperOffice, select the **Pin** symbol again.
+
+
+### Pin SuperOffice for Outlook while composing a new email
+
+You can also pin the SuperOffice for Outlook panel while composing a new email. This keeps the panel open while you prepare the message, so you can review or adjust SuperOffice archiving details before sending.
+
+1. Select **New mail** in Outlook.
+2. Open SuperOffice for Outlook.
+3. Select the **Pin** icon in the SuperOffice panel.
+4. The panel remains available while you compose the email.
 
 ![SuperOffice for Outlook, pin add-in -screenshot][img2]
 

--- a/integrations/superoffice-for-outlook/get.md
+++ b/integrations/superoffice-for-outlook/get.md
@@ -5,7 +5,7 @@ description: How to install SuperOffice for Outlook for your account (1 user).
 keywords: SuperOffice for Outlook, Outlook, email, get add-in, SOFO
 author: Frode B, Martin Pavlas, Bergfrid Dias, Erik Lebiko
 date: 05.05.2026
-version_sofo: 6.2.0
+version_sofo: 6.3.0
 content_type: howto
 category: integration
 topic: SuperOffice for Outlook

--- a/integrations/superoffice-for-outlook/index.md
+++ b/integrations/superoffice-for-outlook/index.md
@@ -27,7 +27,7 @@ redirect_from:
 
 [View in the SuperOffice App Store][11]
 
-The **SuperOffice for Outlook** add-in helps you work effortlessly between Microsoft 365 and SuperOffice CRM. With this integration, you can manage key CRM tasks directly from your email without switching between systems, saving you time and helping you stay productive.
+The **SuperOffice for Outlook** add-in helps you work effortlessly between Microsoft 365 and SuperOffice CRM. SuperOffice for Outlook works with your personal mailbox and, when your Microsoft 365 permissions allow it, shared mailboxes that you access in Outlook. With this integration, you can manage key CRM tasks directly from your email without switching between systems, saving you time and helping you stay productive.
 
 ## Why SuperOffice for Outlook?
 
@@ -54,6 +54,7 @@ The SuperOffice for Outlook add-in lets you:
 * [Create requests][5]
 * [Add messages to request​][5]
 * [Add CRM data to calendar events][6] (Requires [Synchronizer for SuperOffice][12])
+* Work with emails from shared mailboxes, including archiving emails, saving attachments, removing archived emails from the inbox, and composing new emails from a shared mailbox
 
 Everything you need is integrated into your inbox, making your workflow smoother and more efficient.
 

--- a/integrations/superoffice-for-outlook/index.md
+++ b/integrations/superoffice-for-outlook/index.md
@@ -3,9 +3,9 @@ uid: sofo
 title: SuperOffice for Outlook
 description: The SuperOffice for Outlook add-in lets you work effortlessly between your Microsoft 365 and SuperOffice CRM solution, by letting you access key information and features from SuperOffice directly in your email.
 keywords: email, SuperOffice for Outlook, Outlook, SOFO
-author: Bergfrid Dias
-date: 10.29.2024
-version_sofo: 2024.8.12
+author: Andrea Schilde
+date: 05.05.2026
+version_sofo: 6.2.0
 content_type: concept
 category: integration
 topic: SuperOffice for Outlook

--- a/integrations/superoffice-for-outlook/index.md
+++ b/integrations/superoffice-for-outlook/index.md
@@ -5,7 +5,7 @@ description: The SuperOffice for Outlook add-in lets you work effortlessly betwe
 keywords: email, SuperOffice for Outlook, Outlook, SOFO
 author: Andrea Schilde
 date: 05.05.2026
-version_sofo: 6.2.0
+version_sofo: 6.3.0
 content_type: concept
 category: integration
 topic: SuperOffice for Outlook

--- a/integrations/superoffice-for-outlook/requirements.md
+++ b/integrations/superoffice-for-outlook/requirements.md
@@ -5,7 +5,7 @@ description: Requirements and known limitations of SuperOffice for Outlook add-i
 keywords: SuperOffice for Outlook, Outlook, email, SOFO
 author: Frode B, Martin Pavlas
 date: 05.05.2026
-version_sofo: 6.2.0
+version_sofo: 6.3.0
 content_type: reference
 category: integration
 topic: SuperOffice for Outlook

--- a/integrations/superoffice-for-outlook/requirements.md
+++ b/integrations/superoffice-for-outlook/requirements.md
@@ -65,6 +65,17 @@ Shared mailbox access is controlled by Microsoft 365. If a shared mailbox does n
 
 See also: [SuperOffice for Outlook: Authorisation guide](https://community.superoffice.com/en/support-faqs/faq/superoffice-for-outlook-authorisation-guide/)
 
+> [!NOTE]
+SuperOffice for Outlook requires a Microsoft 365 or Exchange account. 
+This is a Microsoft limitation - SuperOffice for Outlook uses Microsoft's 
+Graph API, which only supports work or school accounts within Microsoft 365 
+or Exchange. Consumer email accounts from providers such as Gmail, Yahoo, 
+Hotmail, iCloud, and AOL are not supported.
+
+> [!TIP]
+> If you use Gmail, SuperOffice offers a separate integration. 
+> See [SuperOffice for Gmail](https://online.superoffice.com/appstore/superoffice-as/superoffice-gmail-link).
+
 ## Attachment size limit
 
 Attachments saved to SuperOffice from SuperOffice for Outlook cannot exceed 28 MB. Attachments larger than this limit cannot be saved.

--- a/integrations/superoffice-for-outlook/requirements.md
+++ b/integrations/superoffice-for-outlook/requirements.md
@@ -4,8 +4,8 @@ title: Requirements
 description: Requirements and known limitations of SuperOffice for Outlook add-in
 keywords: SuperOffice for Outlook, Outlook, email, SOFO
 author: Frode B, Martin Pavlas
-date: 12.17.2025
-version_sofo: 2025.1.20
+date: 05.05.2026
+version_sofo: 6.2.0
 content_type: reference
 category: integration
 topic: SuperOffice for Outlook

--- a/integrations/superoffice-for-outlook/requirements.md
+++ b/integrations/superoffice-for-outlook/requirements.md
@@ -63,7 +63,7 @@ Users may be asked to approve additional Microsoft permissions the first time th
 
 Shared mailbox access is controlled by Microsoft 365. If a shared mailbox does not appear in Outlook, or if you cannot send from it, contact your Microsoft 365 administrator.
 
-See also: [SuperOffice for Outlook: Authorisation guide](https://community.superoffice.com/en/support-faqs/faq/superoffice-for-outlook-authorisation-guide/)
+See also: See also: [SuperOffice for Outlook: Authorisation guide][1]
 
 > [!NOTE]
 SuperOffice for Outlook requires a Microsoft 365 or Exchange account. 
@@ -74,7 +74,7 @@ Hotmail, iCloud, and AOL are not supported.
 
 > [!TIP]
 > If you use Gmail, SuperOffice offers a separate integration. 
-> See [SuperOffice for Gmail](https://online.superoffice.com/appstore/superoffice-as/superoffice-gmail-link).
+> See [SuperOffice for Gmail][4].
 
 ## Attachment size limit
 
@@ -87,6 +87,8 @@ Learn more about the requirements for [Centralized Deployment][5] from Microsof
 If an add-in update significantly increases the scope of data access, you must re-approve it before the update is deployed.
 
 <!-- Referenced links -->
+[1]: https://community.superoffice.com/en/support-faqs/faq/superoffice-for-outlook-authorisation-guide/
 [2]: https://apps.apple.com/us/app/microsoft-outlook/id951937596
 [3]: https://play.google.com/store/apps/details?id=com.microsoft.office.outlook
+[4]: https://online.superoffice.com/appstore/superoffice-as/superoffice-gmail-link
 [5]: https://aka.ms/centralized-deployment-guidance

--- a/integrations/superoffice-for-outlook/requirements.md
+++ b/integrations/superoffice-for-outlook/requirements.md
@@ -65,6 +65,10 @@ Shared mailbox access is controlled by Microsoft 365. If a shared mailbox does n
 
 See also: [SuperOffice for Outlook: Authorisation guide](https://community.superoffice.com/en/support-faqs/faq/superoffice-for-outlook-authorisation-guide/)
 
+## Attachment size limit
+
+Attachments saved to SuperOffice from SuperOffice for Outlook cannot exceed 28 MB. Attachments larger than this limit cannot be saved.
+
 ## Requirements for centralized deployment
 
 Learn more about the requirements for [Centralized Deployment][5] from Microsoft.

--- a/integrations/superoffice-for-outlook/requirements.md
+++ b/integrations/superoffice-for-outlook/requirements.md
@@ -55,9 +55,15 @@ The latest version of the following browsers are supported for Outlook on the we
 * Mozilla Firefox
 * Apple Safari (macOS)
 
-## Limitations
+## Shared mailbox support
 
-SuperOffice for Outlook works only with the main account. Shared mailboxes are not supported.
+SuperOffice for Outlook supports shared mailboxes when the mailbox is available to the user in Outlook and the required Microsoft 365 permissions have been granted.
+
+Users may be asked to approve additional Microsoft permissions the first time they use SuperOffice for Outlook with a shared mailbox. In some organizations, an administrator must approve these permissions on behalf of all users before shared mailbox features can be used.
+
+Shared mailbox access is controlled by Microsoft 365. If a shared mailbox does not appear in Outlook, or if you cannot send from it, contact your Microsoft 365 administrator.
+
+See also: [SuperOffice for Outlook: Authorisation guide](https://community.superoffice.com/en/support-faqs/faq/superoffice-for-outlook-authorisation-guide/)
 
 ## Requirements for centralized deployment
 

--- a/integrations/superoffice-for-outlook/save-to-superoffice.md
+++ b/integrations/superoffice-for-outlook/save-to-superoffice.md
@@ -36,6 +36,9 @@ To archive information from an email in Outlook and save it to SuperOffice:
 
 1. [Open SuperOffice for Outlook][1] (if not pinned)​.
 
+> [!TIP]
+> You can pin the SuperOffice for Outlook panel to keep it visible while you work. See [Pin or unpin SuperOffice for Outlook](get.md#pin-or-unpin-superoffice-for-outlook).
+
 1. The SuperOffice sidebar will attempt to match the sender to a contact. If the email address is associated with multiple contacts in SuperOffice, you will be prompted to select the correct contact. The Company and Contact fields will then populate when you select your action.
 
 1. Choose the appropriate action in the SuperOffice sidebar.
@@ -94,6 +97,9 @@ To send an email and automatically archive it to SuperOffice, follow these steps
 1. Select **New mail** in Outlook.
 
 1. [Open SuperOffice for Outlook][1].
+
+> [!TIP]
+> You can pin the SuperOffice for Outlook panel while composing to keep it visible as you write. See [Pin or unpin SuperOffice for Outlook](get.md#pin-or-unpin-superoffice-for-outlook).
 
 1. The **Archive email in SuperOffice** toggle is turned on by default. Turn it 
    off if you do not want this email archived in SuperOffice.

--- a/integrations/superoffice-for-outlook/save-to-superoffice.md
+++ b/integrations/superoffice-for-outlook/save-to-superoffice.md
@@ -33,7 +33,7 @@ redirect_from:
 To archive information from an email in Outlook and save it to SuperOffice:
 
 > [!TIP]
-> You can pin the SuperOffice for Outlook panel to keep it visible while you work. See [Pin or unpin SuperOffice for Outlook](get.md#pin-or-unpin-superoffice-for-outlook).
+> You can pin the SuperOffice for Outlook panel to keep it visible while you work. See [Pin or unpin SuperOffice for Outlook][2].
 
 1. Open or select the email you want to archive.
 
@@ -56,7 +56,7 @@ To archive information from an email in Outlook and save it to SuperOffice:
 If you have access to a shared mailbox in Outlook, you can archive emails from that mailbox to SuperOffice in the same way as emails from your personal mailbox.
 
 > [!IMPORTANT]
-> The first time you use SuperOffice for Outlook with a shared mailbox, you may be asked to approve additional Microsoft permissions. If you do not have sufficient rights to approve these yourself, contact your Microsoft 365 administrator. See [SuperOffice for Outlook: Authorisation guide](https://community.superoffice.com/en/support-faqs/faq/superoffice-for-outlook-authorisation-guide/) for details.
+> The first time you use SuperOffice for Outlook with a shared mailbox, you may be asked to approve additional Microsoft permissions. If you do not have sufficient rights to approve these yourself, contact your Microsoft 365 administrator. See [SuperOffice for Outlook: Authorisation guide][3] for details.
 
 > [!NOTE]
 > The shared mailbox must already be available to you in Outlook. Access to shared mailboxes is managed in Microsoft 365.
@@ -78,7 +78,7 @@ If you have access to a shared mailbox in Outlook, you can archive emails from t
 1. Click **Save** to archive the email.
 
 > [!TIP]
-> You can pin the SuperOffice for Outlook panel to keep it visible while you work. See [Pin or unpin SuperOffice for Outlook](get.md#pin-or-unpin-superoffice-for-outlook).
+> You can pin the SuperOffice for Outlook panel to keep it visible while you work. See [Pin or unpin SuperOffice for Outlook][2].
 
 ## Save attachments to SuperOffice
 
@@ -105,7 +105,7 @@ You can also save email attachments directly to SuperOffice by following these s
 To send an email and automatically archive it to SuperOffice, follow these steps:
 
 > [!TIP]
-> You can pin the SuperOffice for Outlook panel while composing to keep it visible as you write. See [Pin or unpin SuperOffice for Outlook](get.md#pin-or-unpin-superoffice-for-outlook).
+> You can pin the SuperOffice for Outlook panel while composing to keep it visible as you write. See [Pin or unpin SuperOffice for Outlook][2].
 
 1. Select **New mail** in Outlook.
 
@@ -132,7 +132,7 @@ You can compose a new email from a shared mailbox and archive it to SuperOffice 
 Before sending, make sure the correct sender address is selected in the Outlook **From** field. If the **From** field is not visible, enable it in Outlook first. This is standard Outlook functionality.
 
 > [!TIP]
-> You can pin the SuperOffice for Outlook panel while composing to keep it visible as you write. See [Pin or unpin SuperOffice for Outlook](get.md#pin-or-unpin-superoffice-for-outlook).
+> You can pin the SuperOffice for Outlook panel while composing to keep it visible as you write. See [Pin or unpin SuperOffice for Outlook][2].
 
 > [!CAUTION]
 > Always check the **From** address before sending from a shared mailbox.
@@ -147,6 +147,8 @@ Before sending, make sure the correct sender address is selected in the Outlook 
 
 <!-- Referenced links -->
 [1]: get.md#open
+[2]: get.md#pin-or-unpin-superoffice-for-outlook
+[3]: https://community.superoffice.com/en/support-faqs/faq/superoffice-for-outlook-authorisation-guide/
 
 <!-- Referenced images -->
 [img1]: media/outlook-save-to-superoffice.png

--- a/integrations/superoffice-for-outlook/save-to-superoffice.md
+++ b/integrations/superoffice-for-outlook/save-to-superoffice.md
@@ -32,12 +32,12 @@ redirect_from:
 
 To archive information from an email in Outlook and save it to SuperOffice:
 
-1. Open or select the email you want to archive.
-
-1. [Open SuperOffice for Outlook][1] (if not pinned)​.
-
 > [!TIP]
 > You can pin the SuperOffice for Outlook panel to keep it visible while you work. See [Pin or unpin SuperOffice for Outlook](get.md#pin-or-unpin-superoffice-for-outlook).
+
+1. Open or select the email you want to archive.
+
+1. [Open SuperOffice for Outlook][1] (if not pinned).
 
 1. The SuperOffice sidebar will attempt to match the sender to a contact. If the email address is associated with multiple contacts in SuperOffice, you will be prompted to select the correct contact. The Company and Contact fields will then populate when you select your action.
 
@@ -45,12 +45,9 @@ To archive information from an email in Outlook and save it to SuperOffice:
 
 1. Make any necessary changes to the fields.
 
-1. By default, **Include attachments** is selected. Uncheck it if you want to archive the email without its attachments.
+1. If the email has attachments, a **Do not archive attachments** checkbox will appear. Check it if you want to archive the email without its attachments.
 
 1. Click **Save** to archive the email.
-
-> [!NOTE]
-> Attachments are included by default. Uncheck **Include attachments** only if you want to store the email body without the attached files.
 
 ![SuperOffice for Outlook, archive email -screenshot][img1]
 
@@ -64,14 +61,24 @@ If you have access to a shared mailbox in Outlook, you can archive emails from t
 > [!NOTE]
 > The shared mailbox must already be available to you in Outlook. Access to shared mailboxes is managed in Microsoft 365.
 
-1. Open the shared mailbox in Outlook.
-1. Select the email you want to archive.
-1. Open SuperOffice for Outlook.
-1. Choose the action you want to perform, such as archiving the email, saving attachments, creating a request, or adding the message to an existing request.
-1. Check the company, contact, sale, project, or request details.
-1. Choose whether to include attachments.
+1. Open the shared mailbox in Outlook and select the email you want to archive.
+
+1. [Open SuperOffice for Outlook][1] (if not pinned).
+
+1. The SuperOffice sidebar will attempt to match the sender to a contact. If the email address is associated with multiple contacts in SuperOffice, you will be prompted to select the correct contact. The Company and Contact fields will then populate when you select your action.
+
+1. Choose the appropriate action in the SuperOffice sidebar.
+
+1. Make any necessary changes to the fields.
+
+1. If the email has attachments, a **Do not archive attachments** checkbox will appear. Check it if you want to archive the email without its attachments.
+
 1. Select whether to remove the email from the inbox after archiving, if this option is available.
-1. Select **Save**.
+
+1. Click **Save** to archive the email.
+
+> [!TIP]
+> You can pin the SuperOffice for Outlook panel to keep it visible while you work. See [Pin or unpin SuperOffice for Outlook](get.md#pin-or-unpin-superoffice-for-outlook).
 
 ## Save attachments to SuperOffice
 
@@ -94,12 +101,12 @@ You can also save email attachments directly to SuperOffice by following these s
 
 To send an email and automatically archive it to SuperOffice, follow these steps:
 
+> [!TIP]
+> You can pin the SuperOffice for Outlook panel while composing to keep it visible as you write. See [Pin or unpin SuperOffice for Outlook](get.md#pin-or-unpin-superoffice-for-outlook).
+
 1. Select **New mail** in Outlook.
 
 1. [Open SuperOffice for Outlook][1].
-
-> [!TIP]
-> You can pin the SuperOffice for Outlook panel while composing to keep it visible as you write. See [Pin or unpin SuperOffice for Outlook](get.md#pin-or-unpin-superoffice-for-outlook).
 
 1. The **Archive email in SuperOffice** toggle is turned on by default. Turn it 
    off if you do not want this email archived in SuperOffice.

--- a/integrations/superoffice-for-outlook/save-to-superoffice.md
+++ b/integrations/superoffice-for-outlook/save-to-superoffice.md
@@ -97,6 +97,9 @@ You can also save email attachments directly to SuperOffice by following these s
 > [!NOTE]
 > Previously saved attachments will be marked as "Attachment already saved."
 
+> [!NOTE]
+> The maximum attachment size is 28 MB. Attachments larger than this limit cannot be saved to SuperOffice.
+
 ## Send and archive
 
 To send an email and automatically archive it to SuperOffice, follow these steps:

--- a/integrations/superoffice-for-outlook/save-to-superoffice.md
+++ b/integrations/superoffice-for-outlook/save-to-superoffice.md
@@ -55,6 +55,9 @@ To archive information from an email in Outlook and save it to SuperOffice:
 
 If you have access to a shared mailbox in Outlook, you can archive emails from that mailbox to SuperOffice in the same way as emails from your personal mailbox.
 
+> [!IMPORTANT]
+> The first time you use SuperOffice for Outlook with a shared mailbox, you may be asked to approve additional Microsoft permissions. If you do not have sufficient rights to approve these yourself, contact your Microsoft 365 administrator. See [SuperOffice for Outlook: Authorisation guide](https://community.superoffice.com/en/support-faqs/faq/superoffice-for-outlook-authorisation-guide/) for details.
+
 > [!NOTE]
 > The shared mailbox must already be available to you in Outlook. Access to shared mailboxes is managed in Microsoft 365.
 

--- a/integrations/superoffice-for-outlook/save-to-superoffice.md
+++ b/integrations/superoffice-for-outlook/save-to-superoffice.md
@@ -4,7 +4,7 @@ title: Save to SuperOffice
 description: Save to SuperOffice
 keywords: SuperOffice for Outlook, Outlook, archive email, email, save to SuperOffice, send and archive, save attachment, SOFO
 author: Erik Lebiko, Bergfrid Dias, Andrea Schilde
-date: 04.16.2026
+date: 05.05.2026
 version_sofo: 6.2.0
 content_type: howto
 category: integration
@@ -51,6 +51,22 @@ To archive information from an email in Outlook and save it to SuperOffice:
 
 ![SuperOffice for Outlook, archive email -screenshot][img1]
 
+## Archive email from a shared mailbox
+
+If you have access to a shared mailbox in Outlook, you can archive emails from that mailbox to SuperOffice in the same way as emails from your personal mailbox.
+
+> [!NOTE]
+> The shared mailbox must already be available to you in Outlook. Access to shared mailboxes is managed in Microsoft 365.
+
+1. Open the shared mailbox in Outlook.
+1. Select the email you want to archive.
+1. Open SuperOffice for Outlook.
+1. Choose the action you want to perform, such as archiving the email, saving attachments, creating a request, or adding the message to an existing request.
+1. Check the company, contact, sale, project, or request details.
+1. Choose whether to include attachments.
+1. Select whether to remove the email from the inbox after archiving, if this option is available.
+1. Select **Save**.
+
 ## Save attachments to SuperOffice
 
 You can also save email attachments directly to SuperOffice by following these steps:
@@ -89,6 +105,26 @@ To send an email and automatically archive it to SuperOffice, follow these steps
 1. Fill in any missing information or make adjustments as needed.
 
 1. Click **Send** to both send the email and archive it to SuperOffice.
+
+## Send and archive from a shared mailbox
+
+You can compose a new email from a shared mailbox and archive it to SuperOffice while sending.
+
+Before sending, make sure the correct sender address is selected in the Outlook **From** field. If the **From** field is not visible, enable it in Outlook first. This is standard Outlook functionality.
+
+> [!TIP]
+> You can pin the SuperOffice for Outlook panel while composing to keep it visible as you write. See [Pin or unpin SuperOffice for Outlook](get.md#pin-or-unpin-superoffice-for-outlook).
+
+> [!CAUTION]
+> Always check the **From** address before sending from a shared mailbox.
+
+1. Select **New mail** in Outlook.
+1. Open and, if needed, pin SuperOffice for Outlook.
+1. In Outlook, select the shared mailbox address in the **From** field.
+1. Add recipients and write the email.
+1. In SuperOffice for Outlook, keep **Archive email in SuperOffice** turned on if the email should be archived.
+1. Check or adjust the SuperOffice fields.
+1. Select **Send**.
 
 <!-- Referenced links -->
 [1]: get.md#open

--- a/integrations/superoffice-for-outlook/save-to-superoffice.md
+++ b/integrations/superoffice-for-outlook/save-to-superoffice.md
@@ -5,7 +5,7 @@ description: Save to SuperOffice
 keywords: SuperOffice for Outlook, Outlook, archive email, email, save to SuperOffice, send and archive, save attachment, SOFO
 author: Erik Lebiko, Bergfrid Dias, Andrea Schilde
 date: 05.05.2026
-version_sofo: 6.2.0
+version_sofo: 6.3.0
 content_type: howto
 category: integration
 topic: SuperOffice for Outlook


### PR DESCRIPTION
> [!IMPORTANT]
> Do not merge or publish before Monday 11 May 2026.

## What this PR does

Documents two new capabilities in SuperOffice for Outlook 6.3.0:

1. **Shared mailbox support** - Users can archive emails, save attachments, remove archived emails from the inbox, and compose new emails from shared mailboxes in Outlook.
2. **Pin panel while composing** - The SuperOffice for Outlook panel can now be pinned while composing a new email.
3. Added a note regarding file size limit of 28 MB

## Files changed

- `requirements.md` - Removed "Shared mailboxes are not supported"; added shared mailbox requirements and consent info
- `index.md` - Updated intro and added shared mailbox to the feature list
- `get.md` - Expanded pin/unpin section to cover composing new emails
- `save-to-superoffice.md` - Added shared mailbox archive and send-and-archive sections; fixed attachment checkbox wording; added pinning tips
- `deploy.md` - Added admin consent guidance for shared mailbox permissions

## Reviewer notes

- Please do a repo-wide search for "shared mailboxes are not supported" to confirm no other pages contain this statement
- Screenshots for shared mailbox flows are not included - please log a follow-up task