### PR TITLE
Document CRM Suite plan limits and fencing UI (#2930)

### DIFF
--- a/docs/da/admin/license/index.md
+++ b/docs/da/admin/license/index.md
@@ -53,7 +53,24 @@ Opdaterede oplysninger om systemet vises under fanen **Status** i skærmbilledet
 
 #### Database
 
-Her vises den ejer af databasen, det serienummer og den type, som angives ved installation. Derudover vises, om det er en central database eller en satellitdatabase. Du kan se den næste udløbsdato og navnet på den bruger, der er logget på.
+Her vises databasens ejer, serienummer, abonnement og type, som angives ved installation. Du kan se den næste udløbsdato og navnet på den bruger, der er logget på.
+
+Hvis din organisation er på et **SuperOffice CRM Suite**-abonnement, viser **Database**-sektionen også:
+
+* **Plan:** den plan, der er inkluderet i dit abonnement, f.eks. *SuperOffice Core Suite*
+* **Begrænsninger:** dit aktuelle forbrug i forhold til planens grænser, f.eks. *1 af 100 aktive projekter*
+
+Plangrænser forhindrer din organisation i at overskride kapaciteten i den aktuelle plan. Indikatoren **Begrænsninger** viser, hvor tæt du er på en grænse:
+
+| Forbrug | Indikator | Betydning |
+|---|---|---|
+| Under 85 % | Antal vist med sort, f.eks. *1 af 100 aktive projekter* | Normal – ingen handling nødvendig |
+| 85 % eller mere | <i class="ph ph-warning" aria-label="Warning"></i> Antal vist med rødt | Nærmer sig grænsen |
+| 100 % | <i class="ph ph-prohibit" aria-label="Limit reached"></i> Antal vist med rødt | Grænse nået – funktionen er blokeret |
+
+Vælg indikatoren for at åbne siden [Plangrænser][16] for yderligere oplysninger.
+
+Hvis du er systemadministrator, vises en **Opgrader**-knap ud for advarsel- eller stopindikatoren. Vælg den for at åbne en kontaktformular for at anmode om mere kapacitet eller planopgradering.
 
 #### Forbrugstjenester
 
@@ -183,6 +200,7 @@ Samme SCIM-forbehold: Tell antall brukte brukerplaner, ikke total tilgjengelig m
 * [Systemhændelser][3]
 
 <!-- Referenced links -->
+[16]: crm-suite.md
 [1]: activate.md
 [2]: ../../saint/learn/index.md
 [3]: https://help.superoffice.com/docs/11/da/admin/onsite/add-system-event.html

--- a/docs/da/custom-objects/learn/index.md
+++ b/docs/da/custom-objects/learn/index.md
@@ -4,8 +4,8 @@ title: Brugerdefinerede objekter og felter
 description: Brugerdefinerede objekter
 keywords: brugerdefinerede objekter, udef, ekstrafelt, ekstra tabel, tilpassede felter
 author: Bergfrid Dias
-date: 05.11.2026
-version: 10
+date: 05.28.2026
+version: 11
 content_type: concept
 tier: core
 audience: person
@@ -31,6 +31,9 @@ SuperOffice CRM og Service var engang to separate applikationer med forskellige 
 
 [!include[License requirement](../../includes/req-dev-tools-transition.md)]
 
+> [!NOTE]
+> **CRM Suite (Growth-plan):** Din plan inkluderer en grænse for antallet af brugerdefinerede objekter. Når grænsen er nået, er oprettelse af yderligere objekter blokeret. Se [Plangrænser][13] for detaljer.
+
 Felter vises automatisk på [fanen Mere][12], når de er tilføjet.
 
 ## Layout (placering af felter)
@@ -52,3 +55,4 @@ Hvis du ikke har **Core**-planen, skal du bruge rækkefølgen af de forskellige 
 [5]: ../../customization/screen-designer/admin/index.md
 [6]: ../../../en/ui/blogic/custom-screens/index.md
 [12]: more-tab.md
+[13]: ../../admin/license/crm-suite.md

--- a/docs/da/dashboard/learn/working-with-tiles.md
+++ b/docs/da/dashboard/learn/working-with-tiles.md
@@ -132,6 +132,9 @@ Brug denne rude til at vise formateret tekst i dashboardet. Det kan for eksempel
 1. Klik på <i class="ph ph-translate" aria-label="Translate"></i> for at [tilføje en oversættelse][7] af rudens titel og etiketter.
 1. Klik på **Gem**.
 
+> [!NOTE]
+> **CRM Suite:** Redigering af rudelayout (diagramtype, etiketter og andre visuelle indstillinger i fanen **Layout**) kræver **Growth**-planen eller højere. På Starter- eller Core-planer er felterne på fanen Layout skrivebeskyttede, og en meddelelse i bunden af dialogen forklarer begrænsningen. Administratorer kan vælge **Opgrader** for at åbne en kontaktformular.
+
 ## <a id="copy"></a>Duplikér eller kopier en rude
 
 Du kan genbruge en eksisterende rude ved enten at duplikere den i samme dashboard eller kopiere den til et andet dashboard. Du skal have **redigeringstilladelse til måldashboardet** for at kunne kopiere en rude til det.
@@ -217,6 +220,10 @@ Klik på <i class="ph ph-dots-three-vertical" aria-label="Task menu"></i> i rude
 
 * **Jeg har ikke adgang til fanen Layout eller felterne**
   * Du har muligvis ikke de nødvendige funktionelle rettigheder. Kontakt din administrator.
+  * **CRM Suite:** På Starter- eller Core-planer er felterne på fanen Layout skrivebeskyttede. Redigering af rudelayout kræver **Growth**-planen eller højere.
+
+* **Jeg kan ikke oprette eller duplikere et dashboard**
+  * **CRM Suite (Starter-plan):** Starter-planen inkluderer op til 3 dashboards. Når denne grænse er nået, er **Opret dashboard** og **Duplikér dashboard** utilgængelige. Slet et eksisterende dashboard, eller opgrader til Core-planen eller højere. Se [Plangrænser][8].
 
 * **Et udvalg mangler i fanen Udvalg**
   * Se [Om ruder baseret på udvalg](#selection-chart)
@@ -230,6 +237,7 @@ Klik på <i class="ph ph-dots-three-vertical" aria-label="Task menu"></i> i rude
 * [Brug dashboards til at administrere din salgspipeline][2]
 
 <!-- Referenced links -->
+[8]: ../../admin/license/crm-suite.md
 [1]: create.md
 [2]: show-sales-targets.md
 [3]: index.md#charts

--- a/docs/da/marketing/flows/learn/index.md
+++ b/docs/da/marketing/flows/learn/index.md
@@ -4,8 +4,8 @@ title: Marketing automation - flows
 description: Introduktion til SuperOffice Marketing automatisering og flows.
 keywords: Marketing, flow, kundesegment, kunderejse, kommunikation
 author: Bergfrid Dias, Trude Lien Smedbråten
-date: 09.26.2025
-version: 11.3
+date: 05.28.2026
+version: 11.12
 content_type: howto
 category: marketing
 topic: flows
@@ -127,6 +127,9 @@ Det er tilrådeligt for de fleste automatiserede flows at sætte succeskriterier
 * **Service Essentials eller Premium**-licens for at oprette en sag
 * SMS connector - for at sende SMS
 
+> [!NOTE]
+> **CRM Suite (Plus-plan):** Din plan inkluderer maksimalt 10 aktive flows ad gangen. Både kørende og pausede flows tæller med i denne grænse. Når du nærmer dig grænsen, vises en advarsel i flowets sidehoved. Når grænsen er nået, er til/fra-knappen **I gang** ikke tilgængelig for inaktive flows. Se [Plangrænser][13] for detaljer.
+
 ### Funktionelle rettigheder
 
 Adgang til flows og flowindhold styres af en brugers rolle og [funktionelle rettigheder][11].
@@ -156,6 +159,7 @@ Adgang til flows og flowindhold styres af en brugers rolle og [funktionelle rett
 [9]: ../../forms/learn/tutorial-contact-me.md
 [11]: ../../../admin/user-management/role/functional-rights.md
 [12]: ../../../learn/section-tabs/index.md
+[13]: ../../../admin/license/crm-suite.md
 
 <!-- Referenced images -->
 [img1]: ../../../../media/loc/en/marketing/flows-panel.png

--- a/docs/da/marketing/flows/learn/run-pause-end.md
+++ b/docs/da/marketing/flows/learn/run-pause-end.md
@@ -4,8 +4,8 @@ title: Køre, pause og afslutte flow
 description: Sådan kører, pauser, genoptager, afslutter og sletter en SuperOffice Marketing automation-strøm.
 keywords: Marketing, flow
 author: Bergfrid Dias, Trude Lien Smedbråten
-date: 09.26.2025
-version: 10.5
+date: 05.28.2026
+version: 11.12
 content_type: howto
 category: marketing
 topic: flows
@@ -24,7 +24,7 @@ language: da
 
 * **I gang:** Ingen ændringer er tilladt, mens flowet er i gang. Automatiske triggere er aktiveret, og deltagere tilføjes til flowet.
 
-* **På pause:** Triggere forbliver aktiveret. Deltagere tilføjes til flowet, men de afventer bevægelse til det første trin. Eksisterende deltagere forbliver på deres nuværende trin, når flowet er pauset. Denne status bruges, når man foretager ændringer eller forbedringer af et flow.
+* **På pause:** Triggere forbliver aktiveret. Deltagere tilføjes til flowet, men de afventer bevægelse til det første trin. Eksisterende deltagere forbliver på deres nuværende trin, når flowet er pauset. Denne status bruges, når man foretager ændringer eller forbedringer af et flow. På **CRM Suite-planer** anses et pauset flow stadig som aktivt, fordi det fortsætter med at indsamle indkommende kontakter til efterfølgende behandling og tæller mod grænsen for aktive flows.
 
 ![Marketing flows med forskellige status og statistik -screenshot][img1]
 
@@ -92,11 +92,24 @@ Alle nødvendige indstillinger skal være gyldige, før flowet kan køre. For ek
 
 Du kan ikke slette et flow, der er i gang. Først skal du pause flowet. Derefter skal du afslutte flowet, så status ændres til **Stoppet**. Til sidst skal du klikke på <i class="ph ph-dots-three-circle-vertical" aria-label="Opgavemenu"></i> og vælge **Slet flow**.
 
+### Grænsen for aktive flows er nået (CRM Suite)
+
+På **Plus**-planen kan din organisation have maksimalt 10 aktive flows på samme tid. Både kørende og pausede flows tæller med i denne grænse.
+
+Når grænsen er nået:
+
+* Til/fra-knappen **I gang** er ikke tilgængelig for flows, der ikke kører.
+* Flowets sidehoved viser det aktuelle antal, for eksempel *10 af 10 aktive flows*.
+* Hvis du holder musen over den utilgængelige til/fra-knap, vises: *Du har nået grænsen på 10 kørende flows, der er tilladt på Plus-pakken. Stop venligst nogle kørende flows, før du starter andre, eller opgradér til Super-pakken.*
+
+For at frigøre kapacitet skal du afslutte nogle flows, så deres status ændres til **Stoppet**. Hvis du har brug for flere aktive flows, skal du opgradere til **Super**-planen. Se [Plangrænser][2].
+
 ## Relateret indhold
 
 * [Opdater flow][1]
 
 <!-- Referenced links -->
+[2]: ../../../admin/license/crm-suite.md
 [1]: update.md
 
 <!-- Referenced images -->

--- a/docs/da/project/learn/index.md
+++ b/docs/da/project/learn/index.md
@@ -4,8 +4,8 @@ title: Projekt
 description: Denne vejledning viser dig, hvordan du opretter og bruger projekter til at holde styr på dit arbejde.
 keywords: projekt
 author: Bergfrid Dias
-date: 03.07.2025
-version: 10.5.2
+date: 05.28.2026
+version: 11.12
 content_type: concept
 license: salespremium, servicepremium, marketingessentials
 tier: core
@@ -32,6 +32,9 @@ Skærmbilledet **Projekt** indeholder informationer om de projekter, der er regi
 Du kan navigere mellem projekter ved at klikke på **Forrige** og **Næste**-knapperne (<i class="ph ph-caret-circle-left" aria-hidden="true"></i><i class="ph ph-caret-circle-right" aria-hidden="true"></i>) nederst til højre på kortene.
 
 Hvis du vælger en projekttype, hvor en [projektguide][1] er defineret, vises fanen **Projektguide** på detaljekortet.
+
+> [!NOTE]
+> **CRM Suite (Core-plan):** Din plan inkluderer op til 100 aktive projekter. Når du nærmer dig denne grænse, vises en advarsel i projektets sidefod under redigering. Når grænsen er nået, er knappen **Ny** ikke tilgængelig, og en besked forklarer, hvordan du kan frigøre kapacitet (markér eksisterende projekter som afsluttede) eller opgradere til Growth-planen. Se [Plangrænser][21].
 
 ## Faner på projektkortet
 
@@ -83,6 +86,7 @@ Den nederste del af skærmbilledet **Projekt** indeholder detaljekort, hvor du k
 [18]: ../../learn/section-tabs/requests-tab.md
 [19]: ../../custom-objects/learn/more-tab.md
 [20]: https://www.superoffice.com/blog/guest-blog-use-your-crm-to-manage-projects-for-all-industries/
+[21]: ../../admin/license/crm-suite.md
 
 <!-- Referenced images -->
 [img1]: ../../../media/loc/en/project/projects.png

--- a/docs/de/admin/license/index.md
+++ b/docs/de/admin/license/index.md
@@ -53,7 +53,24 @@ Aktualisierte Informationen zum System werden auf der Registerkarte **Status** i
 
 #### Datenbank
 
-Zeigt den bei der Installation festgelegten Datenbankbesitzer, die Seriennummer und den Datenbanktyp an. Außerdem wird angezeigt, ob es eine zentrale DB oder eine Satelliten-Datenbank ist. Sie können das nächste Ablaufdatum und den Namen des derzeit angemeldeten Benutzers sehen.
+Zeigt den bei der Installation festgelegten Datenbankbesitzer, die Seriennummer, das Abonnement und den Datenbanktyp an. Sie können das nächste Ablaufdatum und den Namen des derzeit angemeldeten Benutzers sehen.
+
+Wenn Ihre Organisation über ein **SuperOffice CRM Suite**-Abonnement verfügt, werden im Abschnitt **Datenbank** auch folgende Informationen angezeigt:
+
+* **Plan:** der im Abonnement enthaltene Plan, zum Beispiel *SuperOffice Core Suite*
+* **Einschränkungen:** Ihre aktuelle Nutzung gegenüber den Plangrenzen, zum Beispiel *1 von 100 aktiven Projekten*
+
+Plangrenzen verhindern, dass Ihre Organisation die in Ihrem aktuellen Plan enthaltene Kapazität überschreitet. Der Indikator **Einschränkungen** zeigt, wie nah Sie an einer Grenze sind:
+
+| Nutzung | Indikator | Bedeutung |
+|---|---|---|
+| Unter 85 % | Anzahl in Schwarz angezeigt, zum Beispiel *1 von 100 aktiven Projekten* | Normal – keine Aktion erforderlich |
+| 85 % oder mehr | <i class="ph ph-warning" aria-label="Warning"></i> Anzahl in Rot angezeigt | Annäherung an die Grenze |
+| 100 % | <i class="ph ph-prohibit" aria-label="Limit reached"></i> Anzahl in Rot angezeigt | Grenze erreicht – die Funktion ist gesperrt |
+
+Wählen Sie den Indikator aus, um die Seite [Plangrenzen][16] für weitere Informationen zu öffnen.
+
+Wenn Sie Systemadministrator sind, erscheint neben dem Warn- oder Stoppindikator die Schaltfläche **Upgrade**. Wählen Sie sie aus, um ein Kontaktformular zu öffnen und mehr Kapazität oder ein Plan-Upgrade anzufordern.
 
 #### Gemessene Dienstleistungen
 
@@ -191,6 +208,7 @@ Dasselbe gilt bei SCIM: Zähle die genutzten Benutzerpläne, nicht die Gesamtanz
 * [Systemereignisse][3]
 
 <!-- Referenced links -->
+[16]: crm-suite.md
 [1]: activate.md
 [2]: ../../saint/learn/index.md
 [3]: https://help.superoffice.com/docs/11/de/admin/onsite/add-system-event.html

--- a/docs/de/custom-objects/learn/index.md
+++ b/docs/de/custom-objects/learn/index.md
@@ -4,8 +4,8 @@ title: Benutzerdefinierte Objekte
 description: Benutzerdefinierte Objekte
 keywords: benutzerdefiniertes Objekt, Felder, udef
 author: Bergfrid Dias
-date: 05.11.2026
-version: 10
+date: 05.28.2026
+version: 11
 content_type: concept
 tier: core
 audience: user
@@ -31,6 +31,9 @@ SuperOffice CRM und Service waren einmal zwei separate Anwendungen mit unterschi
 
 [!include[License requirement](../../includes/req-dev-tools-transition.md)]
 
+> [!NOTE]
+> **CRM Suite (Growth-Plan):** Ihr Plan beinhaltet eine Begrenzung der Anzahl benutzerdefinierter Objekte. Wenn das Limit erreicht ist, ist die Erstellung weiterer Objekte gesperrt. Siehe [Plangrenzen][13] für Details.
+
 Felder werden automatisch auf der [Registerkarte Mehr][12] angezeigt, sobald sie hinzugefügt wurden.
 
 ## Layout (Positionierung von Feldern)
@@ -50,5 +53,6 @@ Wenn Sie keinen **Core**-Plan haben, verwenden Sie die Reihenfolge der verschied
 [5]: ../../customization/screen-designer/admin/index.md
 [6]: ../../../en/ui/blogic/custom-screens/index.md
 [12]: more-tab.md
+[13]: ../../admin/license/crm-suite.md
 
 <!-- Referenced images -->

--- a/docs/de/dashboard/learn/working-with-tiles.md
+++ b/docs/de/dashboard/learn/working-with-tiles.md
@@ -132,6 +132,9 @@ Verwenden Sie diese Kachel, um formatierten Text in Ihrem Dashboard anzuzeigen, 
 1. Klicken Sie auf <i class="ph ph-translate" aria-label="Translate"></i>, um eine [Übersetzung][7] für den Kacheltitel und die Beschriftungen hinzuzufügen.
 1. Klicken Sie auf **Speichern**.
 
+> [!NOTE]
+> **CRM Suite:** Das Bearbeiten des Kachel-Layouts (Diagrammtyp, Beschriftungen und andere visuelle Einstellungen auf der Registerkarte **Layout**) erfordert den **Growth**-Plan oder höher. Bei Starter- oder Core-Plänen sind die Felder auf der Registerkarte Layout schreibgeschützt, und eine Meldung am unteren Rand des Dialogs erklärt die Einschränkung. Administratoren können **Upgrade** wählen, um ein Kontaktformular zu öffnen.
+
 ## <a id="copy"></a>Eine Kachel duplizieren oder kopieren
 
 Sie können eine vorhandene Kachel wiederverwenden, indem Sie sie entweder im selben Dashboard duplizieren oder in ein anderes Dashboard kopieren. Um eine Kachel zu kopieren, benötigen Sie **Bearbeitungsrechte für das Ziel-Dashboard**.
@@ -217,6 +220,10 @@ Klicken Sie im Kopfbereich einer Kachel auf <i class="ph ph-dots-three-vertical"
 
 * **Ich kann die Registerkarte Layout oder Felder nicht öffnen**
   * Möglicherweise fehlen Ihnen die erforderlichen funktionellen Rechte. Wenden Sie sich an Ihren Administrator.
+  * **CRM Suite:** Bei Starter- oder Core-Plänen sind die Felder auf der Registerkarte Layout schreibgeschützt. Das Bearbeiten des Kachel-Layouts erfordert den **Growth**-Plan oder höher.
+
+* **Ich kann kein Dashboard erstellen oder duplizieren**
+  * **CRM Suite (Starter-Plan):** Der Starter-Plan umfasst bis zu 3 Dashboards. Wenn diese Grenze erreicht ist, sind **Dashboard erstellen** und **Dashboard duplizieren** nicht verfügbar. Löschen Sie ein vorhandenes Dashboard oder upgraden Sie auf den Core-Plan oder höher. Siehe [Plangrenzen][8].
 
 * **Eine Selektion fehlt auf der Registerkarte Selektionen**
   * Siehe [Über Kacheln auf Basis von Selektionen](#selection-chart)
@@ -230,6 +237,7 @@ Klicken Sie im Kopfbereich einer Kachel auf <i class="ph ph-dots-three-vertical"
 * [Verwenden Sie Dashboards, um Ihre Vertriebspipeline zu verwalten][2]
 
 <!-- Referenced links -->
+[8]: ../../admin/license/crm-suite.md
 [1]: create.md
 [2]: show-sales-targets.md
 [3]: index.md#charts

--- a/docs/de/marketing/flows/learn/index.md
+++ b/docs/de/marketing/flows/learn/index.md
@@ -4,8 +4,8 @@ title: Marketing-Automatisierung - Flows
 description: Einführung in die Marketing-Automatisierung und Flows von SuperOffice.
 keywords: Marketing, Flow, Automatisierung, Kampagne, Segmentieren, Kundenreise
 author: Bergfrid Dias
-date: 09.26.2025
-version: 11.3
+date: 05.28.2026
+version: 11.12
 content_type: howto
 category: marketing
 topic: flows
@@ -127,6 +127,9 @@ Für die meisten automatisierten Flows ist es ratsam, Erfolgskriterien für eing
 * **Service Essentials oder Premium**-Lizenz um eine Anfrage zu erstellen
 * SMS-Connector - zum Senden von SMS
 
+> [!NOTE]
+> **CRM Suite (Plus-Plan):** Ihr Plan umfasst maximal 10 aktive Flows gleichzeitig. Sowohl laufende als auch angehaltene Flows werden auf dieses Limit angerechnet. Wenn Sie sich dem Limit nähern, erscheint eine Warnung in der Flow-Kopfzeile. Wenn das Limit erreicht ist, ist der Umschalter **Wird ausgeführt** für inaktive Flows nicht verfügbar. Siehe [Plangrenzen][13] für Details.
+
 ### Funktionale Rechte
 
 Der Zugriff auf Flows und Flow-Inhalte wird durch die Rolle und die [funktionalen Rechte][11] eines Benutzers gesteuert.
@@ -156,6 +159,7 @@ Der Zugriff auf Flows und Flow-Inhalte wird durch die Rolle und die [funktionale
 [9]: ../../forms/learn/tutorial-contact-me.md
 [11]: ../../../admin/user-management/role/functional-rights.md
 [12]: ../../../learn/section-tabs/index.md
+[13]: ../../../admin/license/crm-suite.md
 
 <!-- Referenced images -->
 [img1]: ../../../../media/loc/en/marketing/flows-panel.png

--- a/docs/de/marketing/flows/learn/run-pause-end.md
+++ b/docs/de/marketing/flows/learn/run-pause-end.md
@@ -4,8 +4,8 @@ title: Ausführen, pausieren und beenden des Flow
 description: Ausführen, pausieren und beenden des Flow
 keywords: Marketing, Flow, Ausführen, Pausieren, Beenden, Status
 author: Bergfrid Dias
-date: 09.26.2025
-version: 10.5
+date: 05.28.2026
+version: 11.12
 content_type: howto
 category: marketing
 topic: flows
@@ -24,7 +24,7 @@ language: de
 
 * **Wird ausgeführt:** Keine Änderungen sind während des laufenden Flows zulässig. Automatisierte Trigger sind aktiviert, und Teilnehmer werden dem Flow hinzugefügt.
 
-* **Pausiert:** Trigger bleiben aktiviert. Teilnehmer werden dem Flow hinzugefügt, aber sie warten auf Bewegung zum ersten Schritt. Bestehende Teilnehmer bleiben auf ihrem aktuellen Schritt, wenn der Flow angehalten ist. Dieser Status wird verwendet, um Änderungen oder Verbesserungen an einem Flow vorzunehmen.
+* **Pausiert:** Trigger bleiben aktiviert. Teilnehmer werden dem Flow hinzugefügt, aber sie warten auf Bewegung zum ersten Schritt. Bestehende Teilnehmer bleiben auf ihrem aktuellen Schritt, wenn der Flow angehalten ist. Dieser Status wird verwendet, um Änderungen oder Verbesserungen an einem Flow vorzunehmen. Bei **CRM Suite-Plänen** wird ein angehaltener Flow weiterhin als aktiv betrachtet, da er eingehende Kontakte zur späteren Verarbeitung sammelt und auf das Limit aktiver Flows angerechnet wird.
 
 ![Marketing-Flow mit unterschiedlichem Status und Statistiken -screenshot][img1]
 
@@ -92,11 +92,24 @@ Alle erforderlichen Einstellungen müssen gültig sein, bevor der Flow ausgefüh
 
 Sie können keinen laufenden Flow löschen. Pausieren Sie zuerst den Flow, damit sich der Status zu **Pausiert** ändert. Beenden Sie dann den Flow, damit sich der Status zu **Wird nicht ausgeführt** ändert. Danach klicken Sie auf <i class="ph ph-dots-three-circle-vertical" aria-label="Aufgabenmenü"></i> und wählen **Flow löschen**.
 
+### Limit für aktive Flows erreicht (CRM Suite)
+
+Beim **Plus**-Plan kann Ihre Organisation maximal 10 aktive Flows gleichzeitig haben. Sowohl laufende als auch angehaltene Flows werden auf dieses Limit angerechnet.
+
+Wenn das Limit erreicht ist:
+
+* Der Umschalter **Wird ausgeführt** ist für Flows, die nicht laufen, nicht verfügbar.
+* Die Kopfzeile des Flow zeigt die aktuelle Anzahl, zum Beispiel *10 von 10 aktive Flows*.
+* Wenn Sie mit der Maus über den nicht verfügbaren Umschalter fahren, wird Folgendes angezeigt: *Sie haben das Limit von 10 laufenden Flows für den Plus-Plan erreicht. Bitte stoppen Sie einige laufende Flows, bevor Sie andere starten, oder upgraden Sie auf den Super-Plan.*
+
+Um Kapazität freizugeben, beenden Sie einige Flows, damit ihr Status zu **Wird nicht ausgeführt** wechselt. Wenn Sie mehr aktive Flows benötigen, upgraden Sie auf den **Super**-Plan. Siehe [Plangrenzen][2].
+
 ## Verwandte Inhalte
 
 * [Flow aktualisieren][1]
 
 <!-- Referenced links -->
+[2]: ../../../admin/license/crm-suite.md
 [1]: update.md
 
 <!-- Referenced images -->

--- a/docs/de/project/learn/index.md
+++ b/docs/de/project/learn/index.md
@@ -4,8 +4,8 @@ title: Projekt
 description: Diese Anleitung zeigt Ihnen, wie Sie Projekte erstellen und verwenden, um den Überblick über Ihre Arbeit zu behalten.
 keywords: Projektkarte, Projektansicht, Prozessmanagement, Projekt
 author: Bergfrid Dias
-date: 02.11.2025
-version: 10.5.2
+date: 05.28.2026
+version: 11.12
 content_type: concept
 license: salespremium, servicepremium, marketingessentials
 tier: core
@@ -32,6 +32,9 @@ Die Projektansicht enthält Informationen über die in SuperOffice CRM eingegebe
 Sie können zwischen Projekten mit den Schaltflächen **Zurück** und **Weiter** (<i class="ph ph-caret-circle-left" aria-hidden="true"></i><i class="ph ph-caret-circle-right" aria-hidden="true"></i>) im unteren rechten Bereich der Karten navigieren.
 
 Wenn Sie einen Projekttyp auswählen, für den ein [Projektleitfaden][1] definiert ist, wird die Registerkarte **Projektleitfaden** in den Bereichsregisterkarten angezeigt.
+
+> [!NOTE]
+> **CRM Suite (Core-Plan):** Ihr Plan umfasst bis zu 100 aktive Projekte. Wenn Sie sich diesem Limit nähern, erscheint eine Warnung in der Projektfußzeile während der Bearbeitung. Wenn das Limit erreicht ist, steht die Schaltfläche **Neu** nicht zur Verfügung, und eine Meldung erklärt, wie Sie Kapazität freigeben können (vorhandene Projekte als abgeschlossen markieren) oder auf den Growth-Plan upgraden. Siehe [Plangrenzen][21].
 
 ## Registerkarten auf der Projektkarte
 
@@ -83,6 +86,7 @@ Der untere Bereich der Projektansicht besteht aus mehreren Bereichsregisterkarte
 [18]: ../../learn/section-tabs/requests-tab.md
 [19]: ../../custom-objects/learn/more-tab.md
 [20]: https://www.superoffice.com/blog/guest-blog-use-your-crm-to-manage-projects-for-all-industries/
+[21]: ../../admin/license/crm-suite.md
 
 <!-- Referenced images -->
 [img1]: ../../../media/loc/en/project/projects.png

--- a/docs/en/admin/license/index.md
+++ b/docs/en/admin/license/index.md
@@ -54,7 +54,24 @@ Updated information about the system is displayed in the **Status** tab in the L
 
 #### Database
 
-Shows the database owner, serial number, and type, which are specified on installation. It also shows if it is a central database or a satellite database. You can see the next expiry date and the name of the user currently logged in.
+Shows the database owner, serial number, subscription, and type, which are specified on installation. You can see the next expiry date and the name of the user currently logged in.
+
+If your organization is on a **SuperOffice CRM Suite** subscription, the **Database** section also shows:
+
+* **Plan:** the plan included in your subscription, for example, *SuperOffice Core Suite*
+* **Restrictions:** your current usage against one or more plan limits, for example, *1 of 100 active projects*
+
+Plan limits prevent your organization from exceeding the capacity included in your current plan. The **Restrictions** indicator reflects how close you are to a limit:
+
+| Usage | Indicator | Meaning |
+|---|---|---|
+| Below 85% | Count shown in black, for example, *1 of 100 active projects* | Normal – no action needed |
+| 85% or more | <i class="ph ph-warning" aria-label="Warning"></i> Count shown in red | Approaching the limit |
+| 100% | <i class="ph ph-prohibit" aria-label="Limit reached"></i> Count shown in red | Limit reached – the feature is blocked |
+
+Select the indicator to open the [Plan limits][16] page for more information.
+
+If you are a system administrator, an **Upgrade** button appears next to the warning or stop indicator. Select it to open a contact form to request more capacity or a plan upgrade.
 
 #### Metered services
 
@@ -185,6 +202,7 @@ The same SCIM caveat applies: count the number of user plans in use, rather than
 * [Hidden licenses][15]
 
 <!-- Referenced links -->
+[16]: crm-suite.md
 [1]: activate.md
 [2]: ../../saint/learn/index.md
 [3]: https://help.superoffice.com/docs/11/en/admin/onsite/add-system-event.html

--- a/docs/en/custom-objects/learn/index.md
+++ b/docs/en/custom-objects/learn/index.md
@@ -31,6 +31,9 @@ SuperOffice CRM and Service were once two separate applications, with different 
 
 [!include[License requirement](../../includes/req-dev-tools-transition.md)]
 
+> [!NOTE]
+> **CRM Suite (Growth plan):** Your plan includes a limit on the number of custom objects. When the limit is reached, creating additional ones is blocked. See [Plan limits][13] for details.
+
 Fields are automatically displayed on the [More tab][12] once added.
 
 ## Layout (positioning fields)
@@ -46,6 +49,7 @@ If you do not have the **Core** plan, use the rank of the different fields to so
 * [Extra tables][3]
 
 <!-- Referenced links -->
+[13]: ../../admin/license/crm-suite.md
 [1]: udef.md
 [2]: extra-field.md
 [3]: extra-table.md

--- a/docs/en/dashboard/learn/working-with-tiles.md
+++ b/docs/en/dashboard/learn/working-with-tiles.md
@@ -132,6 +132,9 @@ Use this tile to display formatted text in your dashboard. For example, a welcom
 1. Click <i class="ph ph-translate" aria-label="Translate"></i> to [add a translation][7] to the tile title and labels.
 1. Click **Save**.
 
+> [!NOTE]
+> **CRM Suite:** Editing tile layout (chart type, labels, and other visual settings on the **Layout** tab) requires the **Growth** plan or higher. On Starter or Core plans, the Layout tab fields are read-only and a message at the bottom of the dialog explains the restriction. Administrators can click **Upgrade** to open a contact form.
+
 ## <a id="copy"></a>Duplicate or copy a tile
 
 You can reuse an existing tile by either duplicating it in the same dashboard or copying it to another dashboard. You must have **edit access to the target dashboard** to copy a tile to it.
@@ -217,6 +220,10 @@ Click <i class="ph ph-dots-three-vertical" aria-label="Task menu"></i> in the he
 
 * **I cannot access the layout tab or fields**
   * You may not have the required functional rights. Contact your administrator.
+  * **CRM Suite:** On Starter or Core plans, the **Layout** tab fields are read-only. Editing tile layout requires the **Growth** plan or higher.
+
+* **I cannot create or duplicate a dashboard**
+  * **CRM Suite (Starter plan):** The Starter plan includes up to 3 dashboards. When this limit is reached, **Create dashboard** and **Duplicate dashboard** are unavailable. Delete an existing dashboard or upgrade to the Core plan or higher. See [Plan limits][8].
 
 * **A selection is missing from the Selections tab**
   * See [About selection-based tiles](#selection-chart)
@@ -230,6 +237,7 @@ Click <i class="ph ph-dots-three-vertical" aria-label="Task menu"></i> in the he
 * [Use dashboards to manage your sales pipeline][2]
 
 <!-- Referenced links -->
+[8]: ../../admin/license/crm-suite.md
 [1]: create.md
 [2]: show-sales-targets.md
 [3]: index.md#charts

--- a/docs/en/marketing/flows/learn/index.md
+++ b/docs/en/marketing/flows/learn/index.md
@@ -127,6 +127,9 @@ It is advisable for most automated flows to set success criteria for enrolled pa
 * **Service Essentials or Premium** license to create a request
 * SMS connector - to send SMS
 
+> [!NOTE]
+> **CRM Suite (Plus plan):** Your plan includes a maximum of 10 active flows at any one time. Both running and paused flows count toward this limit. When you approach the limit, a warning appears in the flow header. When the limit is reached, the **Running** toggle is unavailable for inactive flows. See [Plan limits][13] for details.
+
 ### Functional rights
 
 Access to flows and flow content is controlled by a user's role and [functional rights][11].
@@ -146,6 +149,7 @@ Access to flows and flow content is controlled by a user's role and [functional 
 * [View statistics][3]
 
 <!-- Referenced links -->
+[13]: ../../../admin/license/crm-suite.md
 [1]: create.md
 [2]: run-pause-end.md
 [3]: view-statistics.md

--- a/docs/en/marketing/flows/learn/run-pause-end.md
+++ b/docs/en/marketing/flows/learn/run-pause-end.md
@@ -24,7 +24,7 @@ language: en
 
 * **Running:** No changes are permitted while the flow is in progress. Automated triggers are activated, and participants are added to the flow.
 
-* **Paused:** Triggers remain activated. Participants are added to the flow, but they await movement to the first step. Existing participants remain on their current step when the flow is paused. This status is used when making changes or improvements to a flow.
+* **Paused:** Triggers remain activated. Participants are added to the flow, but they await movement to the first step. Existing participants remain on their current step when the flow is paused. This status is used when making changes or improvements to a flow. On **CRM Suite plans**, a paused flow is still considered active because it continues collecting incoming contacts for later processing, and counts toward the active flow limit.
 
 ![Marketing flows with different status and stats -screenshot][img1]
 
@@ -92,11 +92,24 @@ All required settings must be valid before the flow can run. For example, a flow
 
 You cannot delete a running flow. First, pause the flow. Then, end the flow so the status changes to **Not running**. After that, click <i class="ph ph-dots-three-circle-vertical" aria-label="Task menu"></i> and select **Delete flow**.
 
+### Active flow limit reached (CRM Suite)
+
+On the **Plus** plan, your organization can have a maximum of 10 active flows at the same time. Both running and paused flows count toward this limit.
+
+When the limit is reached:
+
+* The **Running** toggle is unavailable on flows that are not running.
+* The flow header shows the current count, for example, *10 of 10 active flows*.
+* Hovering over the unavailable toggle shows: *You have reached the limit for 10 running flows allowed on the Plus suite. Please stop some running flows before starting others, or upgrade to the Super suite.*
+
+To free up capacity, end some flows so their status changes to **Not running**. If you need more active flows, upgrade to the **Super** plan. See [Plan limits][2].
+
 ## Related content
 
 * [Update flow][1]
 
 <!-- Referenced links -->
+[2]: ../../../admin/license/crm-suite.md
 [1]: update.md
 
 <!-- Referenced images -->

--- a/docs/en/project/learn/index.md
+++ b/docs/en/project/learn/index.md
@@ -35,6 +35,9 @@ You can navigate between projects using the **Previous** and **Next** buttons (<
 
 If you select a project type for which a [project guide][1] is defined, the **Project guide** tab is displayed on the section tab.
 
+> [!NOTE]
+> **CRM Suite (Core plan):** Your plan includes up to 100 active projects. When you approach this limit, a warning appears in the project footer while editing. When the limit is reached, the **New** button is unavailable and a message explains how to free up capacity (mark existing projects as completed) or upgrade to the Growth plan. See [Plan limits][21].
+
 ## Tabs on the Project card
 
 <!-- markdownlint-disable-file MD059 -->
@@ -70,6 +73,7 @@ The lower part of the Project screen consists of section tabs.
 * [See what our customers in different industries use Project for][20] - blog
 
 <!-- Referenced links -->
+[21]: ../../admin/license/crm-suite.md
 [1]: project-guides.md
 [2]: create.md
 [3]: edit.md

--- a/docs/nl/admin/license/index.md
+++ b/docs/nl/admin/license/index.md
@@ -53,7 +53,24 @@ U vindt bijgewerkte informatie over het systeem in het tabblad **Status** op het
 
 #### Database
 
-Geeft informatie over de eigenaar, het serienummer en het type van de database (opgegeven tijdens de installatie). Hier wordt ook aangegeven of het gaat om een centrale database of een satellietdatabase. U kunt de volgende vervaldatum en de naam van de aangemelde gebruiker zien.
+Geeft informatie over de eigenaar, het serienummer, het abonnement en het type van de database (opgegeven tijdens de installatie). U kunt de volgende vervaldatum en de naam van de aangemelde gebruiker zien.
+
+Als uw organisatie een **SuperOffice CRM Suite**-abonnement heeft, worden in de sectie **Database** ook de volgende gegevens weergegeven:
+
+* **Plan:** het plan dat bij uw abonnement is inbegrepen, bijvoorbeeld *SuperOffice Core Suite*
+* **Beperkingen:** uw huidige gebruik ten opzichte van de plangrenzen, bijvoorbeeld *1 van 100 actieve projecten*
+
+Plangrenzen voorkomen dat uw organisatie de capaciteit van het huidige plan overschrijdt. De indicator **Beperkingen** geeft aan hoe dicht u bij een limiet bent:
+
+| Gebruik | Indicator | Betekenis |
+|---|---|---|
+| Minder dan 85% | Aantal in zwart weergegeven, bijvoorbeeld *1 van 100 actieve projecten* | Normaal – geen actie vereist |
+| 85% of meer | <i class="ph ph-warning" aria-label="Warning"></i> Aantal in rood weergegeven | Nadert de limiet |
+| 100% | <i class="ph ph-prohibit" aria-label="Limit reached"></i> Aantal in rood weergegeven | Limiet bereikt – de functie is geblokkeerd |
+
+Selecteer de indicator om de pagina [Plangrenzen][16] te openen voor meer informatie.
+
+Als u systeembeheerder bent, verschijnt er naast de waarschuwings- of stopindicator een knop **Upgrade**. Selecteer deze om een contactformulier te openen voor het aanvragen van meer capaciteit of een planupgrade.
 
 #### Diensten met datalimiet
 
@@ -181,6 +198,7 @@ Zelfde SCIM-uitzondering: tel het aantal actieve gebruikersplannen – niet het 
 * [Systeemgebeurtenissen][3]
 
 <!-- Referenced links -->
+[16]: crm-suite.md
 [1]: activate.md
 [2]: ../../saint/learn/index.md
 [3]: https://help.superoffice.com/docs/11/nl/admin/onsite/add-system-event.html

--- a/docs/nl/custom-objects/learn/index.md
+++ b/docs/nl/custom-objects/learn/index.md
@@ -4,8 +4,8 @@ title: Aangepaste objecten  en velden
 description: Aangepaste objecten en velden
 keywords: aangepast object, veld
 author: Bergfrid Dias
-date: 05.11.2026
-version: 10
+date: 05.28.2026
+version: 11
 content_type: concept
 tier: core
 audience: person
@@ -31,6 +31,9 @@ SuperOffice CRM en Service waren ooit twee aparte toepassingen met verschillende
 
 [!include[License requirement](../../includes/req-dev-tools-transition.md)]
 
+> [!NOTE]
+> **CRM Suite (Growth-abonnement):** Uw abonnement bevat een limiet op het aantal aangepaste objecten. Wanneer de limiet is bereikt, is het aanmaken van extra objecten geblokkeerd. Zie [Plangrenzen][13] voor meer informatie.
+
 Velden worden automatisch weergegeven op het [tabblad Meer][12] zodra ze zijn toegevoegd.
 
 ## Layout (positionering van velden)
@@ -52,5 +55,6 @@ Als u geen **Core**-plan heeft, gebruikt u de rang van de verschillende velden o
 [5]: ../../customization/screen-designer/admin/index.md
 [6]: ../../../en/ui/blogic/custom-screens/index.md
 [12]: more-tab.md
+[13]: ../../admin/license/crm-suite.md
 
 <!-- Referenced images -->

--- a/docs/nl/dashboard/learn/working-with-tiles.md
+++ b/docs/nl/dashboard/learn/working-with-tiles.md
@@ -132,6 +132,9 @@ Gebruik deze tegel om opgemaakte tekst in uw dashboard weer te geven, zoals een 
 1. Klik op <i class="ph ph-translate" aria-label="Translate"></i> om een [vertaling toe te voegen][7] aan de tegelnaam en labels.
 1. Klik op **Opslaan**.
 
+> [!NOTE]
+> **CRM Suite:** Voor het bewerken van de tegelopmaak (grafiektype, labels en andere visuele instellingen op het tabblad **Opmaak**) is het **Growth**-abonnement of hoger vereist. Op Starter- of Core-abonnementen zijn de velden op het tabblad Opmaak alleen-lezen en een bericht onderaan het dialoogvenster legt de beperking uit. Beheerders kunnen **Upgrade** selecteren om een contactformulier te openen.
+
 ## <a id="copy"></a>Een tegel dupliceren of kopiëren
 
 U kunt een bestaande tegel opnieuw gebruiken door deze te dupliceren in hetzelfde dashboard of te kopiëren naar een ander dashboard. U moet **bewerkingstoegang tot het doeldashboard** hebben om een tegel daarheen te kopiëren.
@@ -217,6 +220,10 @@ Klik op <i class="ph ph-dots-three-vertical" aria-label="Task menu"></i> in de k
 
 * **Ik heb geen toegang tot het tabblad Opmaak of tot velden**
   * U hebt mogelijk niet de vereiste functionele rechten. Neem contact op met uw beheerder.
+  * **CRM Suite:** Op Starter- of Core-abonnementen zijn de velden op het tabblad Opmaak alleen-lezen. Voor het bewerken van de tegelopmaak is het **Growth**-abonnement of hoger vereist.
+
+* **Ik kan geen dashboard aanmaken of dupliceren**
+  * **CRM Suite (Starter-abonnement):** Het Starter-abonnement bevat maximaal 3 dashboards. Als deze limiet is bereikt, zijn **Dashboard aanmaken** en **Dashboard dupliceren** niet beschikbaar. Verwijder een bestaand dashboard of upgrade naar het Core-abonnement of hoger. Zie [Plangrenzen][8].
 
 * **Een selectie ontbreekt in het tabblad Selecties**
   * Zie [Over selectie-gebaseerde tegels](#selection-chart)
@@ -230,6 +237,7 @@ Klik op <i class="ph ph-dots-three-vertical" aria-label="Task menu"></i> in de k
 * [Dashboards gebruiken om uw verkooppijplijn te beheren][2]
 
 <!-- Referenced links -->
+[8]: ../../admin/license/crm-suite.md
 [1]: create.md
 [2]: ../../search-options/selection/learn/howto/display-as-charts.md
 [3]: index.md#charts

--- a/docs/nl/marketing/flows/learn/index.md
+++ b/docs/nl/marketing/flows/learn/index.md
@@ -4,8 +4,8 @@ title: Marketing automatisering - flows
 description: Inleiding tot SuperOffice marketingautomatisering en flows.
 keywords: Marketing, flow, automatisering, klantsegment, klantreis, segment, campaign, succespercentage, succescriteria
 author: Bergfrid Dias, Trude Lien Smedbråten
-date: 09.26.2025
-version: 11.3
+date: 05.28.2026
+version: 11.12
 content_type: howto
 category: marketing
 topic: flows
@@ -127,6 +127,9 @@ Voor de meeste geautomatiseerde flows is het raadzaam om succescriteria voor ing
 * **Service Essentials of Premium**-licentie om een verzoek te maken
 * SMS connector - om SMS te verzenden
 
+> [!NOTE]
+> **CRM Suite (Plus-plan):** Uw abonnement bevat maximaal 10 actieve flows tegelijk. Zowel actieve als gepauzeerde flows tellen mee voor deze limiet. Wanneer u de limiet nadert, verschijnt er een waarschuwing in de flow-koptekst. Wanneer de limiet is bereikt, is de schakelaar **Wordt uitgevoerd** niet beschikbaar voor inactieve flows. Zie [Plangrenzen][13] voor meer informatie.
+
 ### Functionele rechten
 
 Toegang tot flows en flowinhoud wordt beheerd door de rol en [functionele rechten][11] van een gebruiker.
@@ -156,6 +159,7 @@ Toegang tot flows en flowinhoud wordt beheerd door de rol en [functionele rechte
 [9]: ../../forms/learn/tutorial-contact-me.md
 [11]: ../../../admin/user-management/role/functional-rights.md
 [12]: ../../../learn/section-tabs/index.md
+[13]: ../../../admin/license/crm-suite.md
 
 <!-- Referenced images -->
 [img1]: ../../../../media/loc/en/marketing/flows-panel.png

--- a/docs/nl/marketing/flows/learn/run-pause-end.md
+++ b/docs/nl/marketing/flows/learn/run-pause-end.md
@@ -4,8 +4,8 @@ title: Flow uitvoeren, pauzeren en beëindigen
 description: Hoe u een SuperOffice Marketing-automatiseringsflow start, pauzeert, hervat, beëindigt en verwijdert.
 keywords: Marketing, flow, flow uitvoeren, flow pauzeren, flow beëindigen, wordt uitgevoerd, gepauzeerd
 author: Bergfrid Dias, Trude Lien Smedbråten
-date: 09.26.2025
-version: 10.5
+date: 05.28.2026
+version: 11.12
 content_type: howto
 category: marketing
 topic: flows
@@ -24,7 +24,7 @@ language: nl
 
 * **Wordt uitgevoerd:** Geen wijzigingen zijn toegestaan terwijl de flow bezig is. Geautomatiseerde triggers zijn geactiveerd en deelnemers worden aan de flow toegevoegd.
 
-* **Gepauzeerd:** Triggers blijven geactiveerd. Deelnemers worden aan de flow toegevoegd, maar wachten op beweging naar de eerste stap. Bestaande deelnemers blijven op hun huidige stap wanneer de flow is gepauzeerd. Deze status wordt gebruikt bij het maken van wijzigingen of verbeteringen aan een flow.
+* **Gepauzeerd:** Triggers blijven geactiveerd. Deelnemers worden aan de flow toegevoegd, maar wachten op beweging naar de eerste stap. Bestaande deelnemers blijven op hun huidige stap wanneer de flow is gepauzeerd. Deze status wordt gebruikt bij het maken van wijzigingen of verbeteringen aan een flow. Op **CRM Suite-plannen** wordt een gepauzeerde flow nog steeds beschouwd als actief, omdat het doorgaat met het verzamelen van inkomende contacten voor latere verwerking en meetelt voor het limiet van actieve flows.
 
 ![Marketingflows met verschillende statussen en statistieken -screenshot][img1]
 
@@ -92,11 +92,24 @@ Alle vereiste instellingen moeten geldig zijn voordat de flow kan worden gestart
 
 Je kunt geen actieve flow verwijderen. Pauzeer eerst de flow. Beëindig vervolgens de flow, zodat de status verandert naar **Wordt niet uitgevoerd**. Daarna klik je op <i class="ph ph-dots-three-circle-vertical" aria-label="Taakmenu"></i> en selecteer je **Flow verwijderen**.
 
+### Limiet voor actieve flows bereikt (CRM Suite)
+
+Op het **Plus**-plan kan uw organisatie maximaal 10 actieve flows tegelijkertijd hebben. Zowel actieve als gepauzeerde flows tellen mee voor dit limiet.
+
+Wanneer het limiet is bereikt:
+
+* De schakelaar **Wordt uitgevoerd** is niet beschikbaar voor flows die niet actief zijn.
+* De flow-koptekst toont het huidige aantal, bijvoorbeeld *10 van 10 actieve flows*.
+* Als u met de muis over de niet-beschikbare schakelaar beweegt, verschijnt: *U heeft het limiet van 10 actieve flows bereikt dat is toegestaan op het Plus-plan. Stop eerst enkele actieve flows voordat u andere start, of upgrade naar het Super-plan.*
+
+Beëindig om capaciteit vrij te maken enkele flows zodat hun status verandert naar **Wordt niet uitgevoerd**. Als u meer actieve flows nodig heeft, upgradet u naar het **Super**-plan. Zie [Plangrenzen][2].
+
 ## Gerelateerde inhoud
 
 * [Flow bijwerken][1]
 
 <!-- Referenced links -->
+[2]: ../../../admin/license/crm-suite.md
 [1]: update.md
 
 <!-- Referenced images -->

--- a/docs/nl/project/learn/index.md
+++ b/docs/nl/project/learn/index.md
@@ -4,8 +4,8 @@ title: Project
 description: Deze how-to gids laat u zien hoe u projecten kunt maken en gebruiken om uw werk te organiseren.
 keywords: Projectkaart, Projectscherm, tabblad Afbeelding, project
 author: Bergfrid Dias
-date: 03.14.2025
-version: 10.5.2
+date: 05.28.2026
+version: 11.12
 content_type: concept
 license: salespremium, servicepremium, marketingessentials
 tier: core
@@ -32,6 +32,9 @@ Het scherm Project bevat informatie over de projecten die zijn ingevoerd in Supe
 U kunt tussen projecten navigeren met de knoppen **Vorige** en **Volgende** (<i class="ph ph-caret-circle-left" aria-hidden="true"></i><i class="ph ph-caret-circle-right" aria-hidden="true"></i>) rechtsonder op de kaarten.
 
 Als u een projecttype selecteert waarvoor een [projectgids][1] is gedefinieerd, wordt het sectietabblad **Projectgids** weergegeven.
+
+> [!NOTE]
+> **CRM Suite (Core-abonnement):** Uw abonnement bevat maximaal 100 actieve projecten. Wanneer u deze limiet nadert, verschijnt er een waarschuwing in de projectvoettekst tijdens het bewerken. Wanneer de limiet is bereikt, is de knop **Nieuw** niet beschikbaar en legt een bericht uit hoe u capaciteit kunt vrijmaken (bestaande projecten als voltooid markeren) of kunt upgraden naar het Growth-abonnement. Zie [Plangrenzen][21].
 
 ## Tabbladen op de projectkaart
 
@@ -83,6 +86,7 @@ Het onderste deel van het scherm Project bestaat uit sectietabbladen.
 [18]: ../../learn/section-tabs/requests-tab.md
 [19]: ../../custom-objects/learn/more-tab.md
 [20]: https://www.superoffice.com/blog/guest-blog-use-your-crm-to-manage-projects-for-all-industries/
+[21]: ../../admin/license/crm-suite.md
 
 <!-- Referenced images -->
 [img1]: ../../../media/loc/en/project/projects.png

--- a/docs/no/admin/license/index.md
+++ b/docs/no/admin/license/index.md
@@ -53,7 +53,24 @@ I **Status**-fanen i Lisenser-bildet finner du oppdatert informasjon om systemet
 
 #### Database
 
-Her vises databasens eier, serienummer og type, som angis ved installering. Det viser også om det er en sentral database eller en satellittdatabase. Du kan se neste utløpsdato og navnet til pålogget bruker.
+Her vises databasens eier, serienummer, abonnement og type, som angis ved installering. Du kan se neste utløpsdato og navnet til pålogget bruker.
+
+Hvis organisasjonen din har et **SuperOffice CRM Suite**-abonnement, viser **Database**-delen også:
+
+* **Plan:** planen som inngår i abonnementet ditt, for eksempel *SuperOffice Core Suite*
+* **Begrensninger:** gjeldende forbruk mot plangrensene dine, for eksempel *1 av 100 aktive prosjekter*
+
+Plangrenser hindrer organisasjonen din fra å overskride kapasiteten i gjeldende plan. Indikatoren **Begrensninger** viser hvor nær du er en grense:
+
+| Forbruk | Indikator | Betydning |
+|---|---|---|
+| Under 85 % | Antall vist i svart, for eksempel *1 av 100 aktive prosjekter* | Normal – ingen handling nødvendig |
+| 85 % eller mer | <i class="ph ph-warning" aria-label="Warning"></i> Antall vist i rødt | Nærmer seg grensen |
+| 100 % | <i class="ph ph-prohibit" aria-label="Limit reached"></i> Antall vist i rødt | Grense nådd – funksjonen er blokkert |
+
+Velg indikatoren for å åpne siden [Plangrenser][16] for mer informasjon.
+
+Hvis du er systemadministrator, vises en **Oppgrader**-knapp ved siden av advarsel- eller stoppindikatoren. Velg den for å åpne et kontaktskjema for å be om mer kapasitet eller planoppgradering.
 
 #### Forbruk
 
@@ -191,6 +208,7 @@ Samme SCIM-unntak gjelder: tell antall brukte brukerplaner, ikke totalen som er 
 * [Systemoperasjoner][3]
 
 <!-- Referenced links -->
+[16]: crm-suite.md
 [1]: activate.md
 [2]: ../../saint/learn/index.md
 [3]: https://help.superoffice.com/docs/11/no/admin/onsite/add-system-event.html

--- a/docs/no/custom-objects/learn/index.md
+++ b/docs/no/custom-objects/learn/index.md
@@ -4,8 +4,8 @@ title: Egendefinerte objekter og felt
 description: Egendefinerte objekter og felt
 keywords: egendefinert objekt, felt, brukerdefinert, udef, ekstrafelt, ekstratabell
 author: Bergfrid Dias
-date: 05.11.2026
-version: 10
+date: 05.28.2026
+version: 11
 content_type: concept
 tier: core
 audience: user
@@ -31,6 +31,9 @@ SuperOffice CRM og Service var en gang to separate applikasjoner med ulike utvid
 
 [!include[License requirement](../../includes/req-dev-tools-transition.md)]
 
+> [!NOTE]
+> **CRM Suite (Growth-plan):** Planen din har en grense for antall egendefinerte objekter. Når grensen er nådd, er opprettelse av flere objekter blokkert. Se [Plangrenser][13] for detaljer.
+
 Felt vises automatisk på [fanen Mer][12] når de er lagt til.
 
 ## Oppsett (plassering av felt)
@@ -52,5 +55,6 @@ Hvis du ikke har **Core**-planen, bruk rangeringen av de forskjellige feltene fo
 [5]: ../../customization/screen-designer/admin/index.md
 [6]: ../../../en/ui/blogic/custom-screens/index.md
 [12]: more-tab.md
+[13]: ../../admin/license/crm-suite.md
 
 <!-- Referenced images -->

--- a/docs/no/dashboard/learn/working-with-tiles.md
+++ b/docs/no/dashboard/learn/working-with-tiles.md
@@ -132,6 +132,9 @@ Bruk denne typen figur til å vise formatert tekst i dashbordet. For eksempel en
 5. Klikk på <i class="ph ph-translate" aria-label="Translate"></i> for å [legge til oversettelser][7] av figurens tittel og etiketter.
 6. Klikk på **Lagre**.
 
+> [!NOTE]
+> **CRM Suite:** Redigering av figurlayout (diagramtype, etiketter og andre visuelle innstillinger i **Layout**-fanen) krever **Growth**-planen eller høyere. På Starter- eller Core-planer er feltene i Layout-fanen skrivebeskyttet, og en melding nederst i dialogen forklarer begrensningen. Administratorer kan velge **Oppgrader** for å åpne et kontaktskjema.
+
 ## <a id="copy"></a>Duplisere eller kopiere en figur
 
 Du kan gjenbruke en eksisterende figur ved å duplisere den i samme dashbord eller kopiere den til et annet. Du må ha **redigeringstilgang til måldashbordet** for å kunne kopiere figurer dit.
@@ -217,6 +220,10 @@ Klikk på <i class="ph ph-dots-three-vertical" aria-label="Task menu"></i> i ove
 
 * **Jeg har ikke tilgang til Layout-fanen eller felt**
   * Du har kanskje ikke nødvendige funksjonelle rettigheter. Kontakt systemansvarlig.
+  * **CRM Suite:** På Starter- eller Core-planer er feltene i Layout-fanen skrivebeskyttet. Redigering av figurlayout krever **Growth**-planen eller høyere.
+
+* **Jeg kan ikke opprette eller duplisere et dashbord**
+  * **CRM Suite (Starter-plan):** Starter-planen inkluderer opptil 3 dashbord. Når denne grensen er nådd, er **Opprett dashbord** og **Dupliser dashbord** ikke tilgjengelig. Slett et eksisterende dashbord, eller oppgrader til Core-planen eller høyere. Se [Plangrenser][8].
 
 * **Et utvalg mangler på fanen Utvalg**
   * Se [Om figurer basert på utvalg](#selection-chart)
@@ -230,6 +237,7 @@ Klikk på <i class="ph ph-dots-three-vertical" aria-label="Task menu"></i> i ove
 * [Bruke dashbord til å administrere salgspipelinen din][2]
 
 <!-- Referenced links -->
+[8]: ../../admin/license/crm-suite.md
 [1]: create.md
 [2]: show-sales-targets.md
 [3]: index.md#charts

--- a/docs/no/marketing/flows/learn/index.md
+++ b/docs/no/marketing/flows/learn/index.md
@@ -4,8 +4,8 @@ title: Markedsføringsautomatisering - flyter
 description: Introduksjon til markedsføringsautomatisering og flyter.
 keywords: flyt, markedsføringsautomatisering, kampanje, suksesskriterie, segment
 author: Bergfrid Dias
-date: 09.26.2025
-version: 11.3
+date: 05.28.2026
+version: 11.12
 content_type: concept
 category: marketing
 topic: flows
@@ -127,6 +127,9 @@ Det er tilrådelig for de fleste automatiserte flyter å sette suksesskriterier 
 * **Service Essentials eller Premium**-lisens for å opprette en sak
 * SMS-modul - for å sende SMS
 
+> [!NOTE]
+> **CRM Suite (Plus-plan):** Planen din inkluderer maksimalt 10 aktive flyter om gangen. Både kjørende og pauserte flyter teller mot denne grensen. Når du nærmer deg grensen, vises en advarsel i flytens overskrift. Når grensen er nådd, er bryteren **Kjører** ikke tilgjengelig for inaktive flyter. Se [Plangrenser][13] for detaljer.
+
 ### Funksjonelle rettigheter
 
 Tilgang til flyter og flytinnhold kontrolleres av en brukers rolle og [funksjonelle rettigheter][11].
@@ -156,6 +159,7 @@ Tilgang til flyter og flytinnhold kontrolleres av en brukers rolle og [funksjone
 [9]: ../../forms/learn/tutorial-contact-me.md
 [11]: ../../../admin/user-management/role/functional-rights.md
 [12]: ../../../learn/section-tabs/index.md
+[13]: ../../../admin/license/crm-suite.md
 
 <!-- Referenced images -->
 [img1]: ../../../../media/loc/en/marketing/flows-panel.png

--- a/docs/no/marketing/flows/learn/run-pause-end.md
+++ b/docs/no/marketing/flows/learn/run-pause-end.md
@@ -4,8 +4,8 @@ title: Kjør, pause og avslutt flyt
 description: Hvordan kjøre, pause, gjenoppta, avslutte og slette en SuperOffice-markedsføringsautomatiseringsflyt.
 keywords: flyt, markedsføring, automatisering, kjøre flyt, kjørende, pause flyt, gjenoppta flyt, avslutte flyt, slette flyt, flytstatus
 author: Bergfrid Dias
-date: 09.26.2025
-version: 10.5
+date: 05.28.2026
+version: 11.12
 content_type: howto
 category: marketing
 topic: flows
@@ -24,7 +24,7 @@ language: no
 
 * **Kjørende:** Ingen endringer er tillatt mens flyten pågår. Automatiske triggere er aktive, og deltakere legges til i flyten.
 
-* **Pauset:** Triggere forblir aktive. Deltakere legges til i flyten, men venter før første trinn. Eksisterende deltakere forblir på gjeldende trinn når flyten er satt på pause. Denne statusen brukes når man gjør endringer eller forbedringer i en flyt.
+* **Pauset:** Triggere forblir aktive. Deltakere legges til i flyten, men venter før første trinn. Eksisterende deltakere forblir på gjeldende trinn når flyten er satt på pause. Denne statusen brukes når man gjør endringer eller forbedringer i en flyt. På **CRM Suite-planer** regnes en pauset flyt fortsatt som aktiv fordi den fortsetter å samle inn innkommende kontakter for senere behandling, og teller mot grensen for aktive flyter.
 
 ![Markedsføringsflyter med forskjellig status og statistikk -screenshot][img1]
 
@@ -92,11 +92,24 @@ Alle påkrevde innstillinger må være gyldige før flyten kan kjøres. For ekse
 
 Du kan ikke slette en kjørende flyt. Først må du sette flyten på pause. Deretter må du avslutte flyten, slik at statusen endres til **Stoppet**. Til slutt klikker du på <i class="ph ph-dots-three-circle-vertical" aria-label="Oppgavemeny"></i> og velger **Slett flyt**.
 
+### Grensen for aktive flyter er nådd (CRM Suite)
+
+På **Plus**-planen kan organisasjonen din ha maksimalt 10 aktive flyter om gangen. Både kjørende og pauserte flyter teller mot denne grensen.
+
+Når grensen er nådd:
+
+* Bryteren **Kjører** er ikke tilgjengelig for flyter som ikke kjører.
+* Flytens topptekst viser gjeldende antall, for eksempel *10 av 10 aktive flyter*.
+* Hvis du holder musepekeren over den utilgjengelige bryteren, vises: *Du har nådd grensen på 10 kjørende flyter som er tillatt på Plus-pakken. Stopp noen kjørende flyter før du starter andre, eller oppgrader til Super-pakken.*
+
+For å frigjøre kapasitet, avslutt noen flyter slik at statusen endres til **Stoppet**. Hvis du trenger flere aktive flyter, oppgrader til **Super**-planen. Se [Plangrenser][2].
+
 ## Relatert innhold
 
 * [Oppdater flyt][1]
 
 <!-- Referenced links -->
+[2]: ../../../admin/license/crm-suite.md
 [1]: update.md
 
 <!-- Referenced images -->

--- a/docs/no/project/learn/index.md
+++ b/docs/no/project/learn/index.md
@@ -4,8 +4,8 @@ title: Prosjekt
 description: Denne veiledningen viser deg hvordan du oppretter og bruker prosjekter for å holde oversikt over arbeidet ditt.
 keywords: prosjektkort, Prosjekt-bilde, prosjekt
 author: Bergfrid Dias
-date: 01.30.2025
-version: 10.3.11
+date: 05.28.2026
+version: 11.12
 content_type: concept
 license: salespremium, servicepremium, marketingessentials
 tier: core
@@ -32,6 +32,9 @@ Prosjekt-bildet viser informasjon om prosjektene som er opprettet i SuperOffice 
 Du kan navigere mellom prosjekter ved å bruke knappene **Forrige** og **Neste** (<i class="ph ph-caret-circle-left" aria-hidden="true"></i><i class="ph ph-caret-circle-right" aria-hidden="true"></i>) nederst til høyre på kortene.
 
 Hvis du velger en prosjekttype som har en [prosjektguide][1], vises fanen **Prosjektguide**.
+
+> [!NOTE]
+> **CRM Suite (Core-plan):** Planen din inkluderer opptil 100 aktive prosjekter. Når du nærmer deg denne grensen, vises en advarsel i prosjektets bunntekst under redigering. Når grensen er nådd, er knappen **Ny** ikke tilgjengelig, og en melding forklarer hvordan du kan frigjøre kapasitet (merk eksisterende prosjekter som fullførte) eller oppgradere til Growth-planen. Se [Plangrenser][21].
 
 ## Faner i prosjektkortet
 
@@ -83,6 +86,7 @@ Den nederste delen av Prosjekt-bildet består av flere detaljkort:
 [18]: ../../learn/section-tabs/requests-tab.md
 [19]: ../../custom-objects/learn/more-tab.md
 [20]: https://www.superoffice.com/blog/guest-blog-use-your-crm-to-manage-projects-for-all-industries/
+[21]: ../../admin/license/crm-suite.md
 
 <!-- Refererte bilder -->
 [img1]: ../../../media/loc/en/project/projects.png

--- a/docs/sv/admin/license/index.md
+++ b/docs/sv/admin/license/index.md
@@ -53,7 +53,24 @@ På fliken **Status** i fönstret Licenser finns uppdaterad information om syste
 
 #### Databas
 
-Här visas databasens ägare, serienummer och typ som anges vid installation. Här anges också om det är en central databas eller en satellitdatabas. Du kan även se nästa utgångsdatum och namnet på den inloggade användaren.
+Här visas databasens ägare, serienummer, abonnemang och typ som anges vid installation. Du kan även se nästa utgångsdatum och namnet på den inloggade användaren.
+
+Om din organisation har ett **SuperOffice CRM Suite**-abonnemang visas även följande i **Databas**-avsnittet:
+
+* **Plan:** den plan som ingår i ditt abonnemang, till exempel *SuperOffice Core Suite*
+* **Begränsningar:** din aktuella användning i förhållande till plangränserna, till exempel *1 av 100 aktiva projekt*
+
+Plangränser förhindrar din organisation från att överskrida kapaciteten i den aktuella planen. Indikatorn **Begränsningar** visar hur nära du är en gräns:
+
+| Användning | Indikator | Betydelse |
+|---|---|---|
+| Under 85 % | Antal visas i svart, till exempel *1 av 100 aktiva projekt* | Normalt – ingen åtgärd krävs |
+| 85 % eller mer | <i class="ph ph-warning" aria-label="Warning"></i> Antal visas i rött | Närmar sig gränsen |
+| 100 % | <i class="ph ph-prohibit" aria-label="Limit reached"></i> Antal visas i rött | Gränsen nådd – funktionen är blockerad |
+
+Välj indikatorn för att öppna sidan [Plangränser][16] för mer information.
+
+Om du är systemadministratör visas en **Uppgradera**-knapp bredvid varnings- eller stoppindikatorn. Välj den för att öppna ett kontaktformulär för att begära mer kapacitet eller en planuppgradering.
 
 #### Tjänster med datapriser
 
@@ -181,6 +198,7 @@ Samma undantag gäller för SCIM: räkna antalet aktiva användarplaner – inte
 * [Systemhändelser][3]
 
 <!-- Referenced links -->
+[16]: crm-suite.md
 [1]: activate.md
 [2]: ../../saint/learn/index.md
 [3]: https://help.superoffice.com/docs/11/sv/admin/onsite/add-system-event.html

--- a/docs/sv/custom-objects/learn/index.md
+++ b/docs/sv/custom-objects/learn/index.md
@@ -3,8 +3,8 @@ uid: help-sv-custom-objects
 title: Egendefinierade objekt och fält
 description: Egendefinierade objekt och fält
 author: Bergfrid Dias
-date: 05.11.2026
-version: 10
+date: 05.28.2026
+version: 11
 keywords: egendefinierade objekt, användardefinierade fält, extratabell, extrafält, tilläggsfält, anpassat fält
 content_type: concept
 tier: core
@@ -31,6 +31,9 @@ SuperOffice CRM och Service var en gång två separata applikationer med olika m
 
 [!include[License requirement](../../includes/req-dev-tools-transition.md)]
 
+> [!NOTE]
+> **CRM Suite (Growth-plan):** Din plan inkluderar en gräns för antalet egendefinierade objekt. När gränsen nås är det inte möjligt att skapa fler objekt. Se [Plangränser][13] för mer information.
+
 Fält visas automatiskt på [fliken Mer][12] när de har lagts till.
 
 ## Layout (positionering av fält)
@@ -52,5 +55,6 @@ Om du inte har **Core**-planen, använd rangordningen av de olika fälten för a
 [5]: ../../customization/screen-designer/admin/index.md
 [6]: ../../../en/ui/blogic/custom-screens/index.md
 [12]: more-tab.md
+[13]: ../../admin/license/crm-suite.md
 
 <!-- Referenced images -->

--- a/docs/sv/dashboard/learn/working-with-tiles.md
+++ b/docs/sv/dashboard/learn/working-with-tiles.md
@@ -132,6 +132,9 @@ Använd den här panelen för att visa formaterad text i dashboarden. Exempelvis
 1. Klicka på <i class="ph ph-translate" aria-label="Translate"></i> för att [lägga till en översättning][7] för panelens titel och etiketter.
 1. Klicka på **Spara**.
 
+> [!NOTE]
+> **CRM Suite:** Redigering av panelens layout (diagramtyp, etiketter och andra visuella inställningar på fliken **Layout**) kräver **Growth**-planen eller högre. På Starter- eller Core-planer är fälten på layoutfliken skrivskyddade och ett meddelande längst ned i dialogrutan förklarar begränsningen. Administratörer kan välja **Uppgradera** för att öppna ett kontaktformulär.
+
 ## <a id="copy"></a>Duplicera eller kopiera en panel
 
 Du kan återanvända en befintlig panel genom att antingen duplicera den i samma dashboard eller kopiera den till en annan dashboard. Du måste ha **redigeringsbehörighet till mål-dashboarden** för att kunna kopiera en panel dit.
@@ -217,6 +220,10 @@ Klicka på <i class="ph ph-dots-three-vertical" aria-label="Task menu"></i> i pa
 
 * **Jag har inte tillgång till layoutfliken eller fälten**
   * Du har kanske inte rätt funktionsbehörigheter. Kontakta administratören.
+  * **CRM Suite:** På Starter- eller Core-planer är fälten på layoutfliken skrivskyddade. Redigering av panelens layout kräver **Growth**-planen eller högre.
+
+* **Jag kan inte skapa eller duplicera en dashboard**
+  * **CRM Suite (Starter-plan):** Starter-planen inkluderar upp till 3 dashboards. När den här gränsen nås är **Skapa dashboard** och **Duplicera dashboard** inte tillgängliga. Ta bort en befintlig dashboard eller uppgradera till Core-planen eller högre. Se [Plangränser][8].
 
 * **Ett urval saknas i fliken Urval**
   * Se [Om paneler baserade på urval](#selection-chart)
@@ -230,6 +237,7 @@ Klicka på <i class="ph ph-dots-three-vertical" aria-label="Task menu"></i> i pa
 * [Använd dashboards för att hantera din säljpipeline][2]
 
 <!-- Referenced links -->
+[8]: ../../admin/license/crm-suite.md
 [1]: create.md
 [2]: show-sales-targets.md
 [3]: index.md#charts

--- a/docs/sv/marketing/flows/learn/index.md
+++ b/docs/sv/marketing/flows/learn/index.md
@@ -4,8 +4,8 @@ title: Marknadsföringsautomatisering - flöden
 description: Introduktion till SuperOffice marknadsföringsautomatisering och flöden.
 keywords: flöde, marknadsföringsautomatisering, kundsegment, kundresa, kampanj, framgångskriterier, segmentera, flödespanel, Marketing premium, flödesadministratör
 author: Bergfrid Dias, Trude Lien Smedbråten
-date: 09.26.2025
-version: 11.3
+date: 05.28.2026
+version: 11.12
 content_type: howto
 category: marketing
 topic: flows
@@ -127,6 +127,9 @@ Det är tillrådligt för de flesta automatiserade flöden att sätta framgångs
 * **Service Essentials eller Premium**-licens för att skapa ett ärende
 * SMS-kontakt - för att skicka SMS
 
+> [!NOTE]
+> **CRM Suite (Plus-plan):** Din plan inkluderar maximalt 10 aktiva flöden åt gången. Både körande och pausade flöden räknas mot denna gräns. När du närmar dig gränsen visas en varning i flödets rubrik. När gränsen nås är reglaget **Körs** inte tillgängligt för inaktiva flöden. Se [Plangränser][13] för mer information.
+
 ### Funktionella rättigheter
 
 Åtkomst till flöden och flödesinnehåll styrs av en användares roll och [funktionella rättigheter][11].
@@ -156,6 +159,7 @@ Det är tillrådligt för de flesta automatiserade flöden att sätta framgångs
 [9]: ../../forms/learn/tutorial-contact-me.md
 [11]: ../../../admin/user-management/role/functional-rights.md
 [12]: ../../../learn/section-tabs/index.md
+[13]: ../../../admin/license/crm-suite.md
 
 <!-- Referenced images -->
 [img1]: ../../../../media/loc/en/marketing/flows-panel.png

--- a/docs/sv/marketing/flows/learn/run-pause-end.md
+++ b/docs/sv/marketing/flows/learn/run-pause-end.md
@@ -4,8 +4,8 @@ title: Kör, pausa och avsluta flöde
 description: Kör, pausa och avsluta flöde
 keywords: flöde, flödestatus, starta flöde, pausa flöde, körs
 author: Bergfrid Dias, Trude Lien Smedbråten
-date: 09.26.2025
-version: 10.5
+date: 05.28.2026
+version: 11.12
 content_type: howto
 category: marketing
 topic: flows
@@ -24,7 +24,7 @@ language: sv
 
 * **Körs:** Inga ändringar är tillåtna medan flödet kör. Automatiska triggers är aktiverade och deltagare läggs till i flödet.
 
-* **Pausad:** Triggers förblir aktiverade. Deltagare läggs till i flödet, men de väntar på att skrida till första steget. Deltagare som redan finns i flödet förblir på sitt nuvarande steg när flödet är pausat. Den här statusen används vid ändringar eller förbättringar av ett flöde.
+* **Pausad:** Triggers förblir aktiverade. Deltagare läggs till i flödet, men de väntar på att skrida till första steget. Deltagare som redan finns i flödet förblir på sitt nuvarande steg när flödet är pausat. Den här statusen används vid ändringar eller förbättringar av ett flöde. På **CRM Suite-planer** anses ett pausat flöde fortfarande som aktivt eftersom det fortsätter att samla in inkommande kontakter för senare bearbetning och räknas mot gränsen för aktiva flöden.
 
 ![Marknadsföringsflöden med olika status och statistik -screenshot][img1]
 
@@ -92,11 +92,24 @@ Alla nödvändiga inställningar måste vara giltiga innan flödet kan köras. T
 
 Du kan inte ta bort ett körande flöde. Pausa först flödet. Avsluta sedan flödet så att statusen ändras till **Inte igång**. Därefter klickar du på <i class="ph ph-dots-three-circle-vertical" aria-label="Uppgiftsmeny"></i> och väljer **Ta bort flöde**.
 
+### Gränsen för aktiva flöden har nåtts (CRM Suite)
+
+På **Plus**-planen kan din organisation ha maximalt 10 aktiva flöden samtidigt. Både körande och pausade flöden räknas mot denna gräns.
+
+När gränsen nås:
+
+* Reglaget **Körs** är inte tillgängligt för flöden som inte kör.
+* Flödets rubrik visar det aktuella antalet, till exempel *10 av 10 aktiva flöden*.
+* Om du håller muspekaren över det otillgängliga reglaget visas: *Du har nått gränsen på 10 körande flöden som tillåts på Plus-paketet. Stoppa några körande flöden innan du startar andra, eller uppgradera till Super-paketet.*
+
+För att frigöra kapacitet, avsluta några flöden så att deras status ändras till **Inte igång**. Om du behöver fler aktiva flöden uppgraderar du till **Super**-planen. Se [Plangränser][2].
+
 ## Relaterat innehåll
 
 * [Uppdatera flöde][1]
 
 <!-- Referenced links -->
+[2]: ../../../admin/license/crm-suite.md
 [1]: update.md
 
 <!-- Referenced images -->

--- a/docs/sv/project/learn/index.md
+++ b/docs/sv/project/learn/index.md
@@ -4,8 +4,8 @@ title: Projekt
 description: Den här guiden visar hur du skapar och använder projekt för att hålla koll på ditt arbete.
 keywords: projektkort, projekt-fönstret, fliken bild, projekt
 author: Bergfrid Dias
-date: 02.25.2025
-version: 10.5.2
+date: 05.28.2026
+version: 11.12
 content_type: concept
 license: salespremium, servicepremium, marketingessentials
 tier: core
@@ -32,6 +32,9 @@ All information du sparar i projektet taggas med ett datum och en ägare, vilket
 För att navigera mellan projekt klickar du på knapparna **Föregående** och **Nästa** (<i class="ph ph-caret-circle-left" aria-hidden="true"></i><i class="ph ph-caret-circle-right" aria-hidden="true"></i>) längst ned till höger på korten.
 
 Om du har valt en projekttyp för vilken en [projektguide][1] har definierats, visas fliken **Projektguide** på detaljkortet.
+
+> [!NOTE]
+> **CRM Suite (Core-plan):** Din plan inkluderar upp till 100 aktiva projekt. När du närmar dig den här gränsen visas en varning i projektets sidfot under redigering. När gränsen nås är knappen **Ny** inte tillgänglig, och ett meddelande förklarar hur du kan frigöra kapacitet (markera befintliga projekt som slutförda) eller uppgradera till Growth-planen. Se [Plangränser][21].
 
 ## Flikar på projektkortet
 
@@ -83,6 +86,7 @@ Den nedre delen av **Projekt**-fönstret består av detaljkort.
 [18]: ../../learn/section-tabs/requests-tab.md
 [19]: ../../custom-objects/learn/more-tab.md
 [20]: https://www.superoffice.com/blog/guest-blog-use-your-crm-to-manage-projects-for-all-industries/
+[21]: ../../admin/license/crm-suite.md
 
 <!-- Referenced images -->
 [img1]: ../../../media/loc/en/project/projects.png


### PR DESCRIPTION
## Summary

Documents the new plan-limit fencing UI introduced for SuperOffice CRM Suite across five fenced areas, plus a cleanup of onsite-specific content in the license page.

**Fenced areas documented:**

| Plan | Area | Limit |
|---|---|---|
| Starter | Dashboards | 3 |
| Core | Active projects | 100 |
| Growth | Custom objects | 15 |
| Plus | Active flows | 10 |
| (all) | License Status tab | Restrictions indicator + Upgrade button |

**Files changed (EN + DA, DE, NL, NO, SV for each):**

- `admin/license/index.md` — Added Restrictions indicator table, plan limits UI, and Upgrade button to the Status tab Database section. Removed onsite-only sentence about central vs satellite database.
- `dashboard/learn/working-with-tiles.md` — Added Starter plan dashboard limit note.
- `project/learn/index.md` — Added Core plan active project limit note.
- `custom-objects/learn/index.md` — Added Growth plan custom object limit note.
- `marketing/flows/learn/index.md` — Added Plus plan active flow limit note.
- `marketing/flows/learn/run-pause-end.md` — Clarified that paused flows count toward the active flow limit; added "Active flow limit reached" troubleshooting section.

## Notes

- All `[16]: crm-suite.md` links are mock links — the Fencing FAQ page will be created in #2924.
- Screenshot for the license Status tab (Restrictions indicator at ≥85%) is pending CRM Suite tenant access and will be added before merging #2912.
- This PR targets branch `2912`, not `main`.