### PR TITLE
Update SoProtocol targets and cache docs (#2894)

### DIFF
--- a/docs/en/customization/soprotocol/navigation-points.md
+++ b/docs/en/customization/soprotocol/navigation-points.md
@@ -1,11 +1,11 @@
 ---
 uid: so-protocol-nav
 title: Navigation points (where)
-description: SoProtocol navigation points
-keywords: soprotocol, deeplinking
-author: Michel Krohn-Dale
-date: 12.10.2024
-version: 10.3.13
+description: SoProtocol navigation targets, dialog targets, query parameters, and admin screens reference
+keywords: soprotocol, deeplinking, navigation, targets
+author: Michel Krohn-Dale, digitaldiina, MargretheR
+date: 29.05.2026
+version: 11
 content_type: reference
 category: customization
 topic: soprotocol
@@ -14,26 +14,114 @@ redirect_from: /en/ui/soprotocol/navigation-points
 language: en
 ---
 
-# SoProtocol entity targets
+# SoProtocol targets reference
 
-Entity-specific navigation points are used to navigate to a specific entity in the SuperOffice CRM client. The following table lists the entity-specific navigation points.
+SoProtocol targets define the `{{WHERE}}` part of an SoProtocol URL — which screen to open and which tabs to activate. The `{{WHAT}}` query parameters are covered in the [Query parameters](#query-parameters) section below.
 
-| Entity | target name | Upper Tab Views | Lower Tab Views |
-|--------|------------|-----------------|-----------------|
-| Chat | chat | main | - |
-| Company | contact | main, udef, interest, info | personarchive, relationarchive, projectarchive, activityarchive, salearchive, ticketarchive |
-| Contact | person | main, details, udef, interest, info | projectarchive, relationarchive, activityarchive, salearchive, ticketarchive |
-| Diary | diary | day, week, month, view | activityarchive, diarysalearchive |
-| Inbox | newinbox | main | - |
-| Marketing | emarketing | mailings, mmlisttemplates, mmlistlinks, mmlistimages, mmlistbounces, mmlistforms, mmlistformtemplates, mmlistformsubmissions | - |
-| Project | project | main, udef, info, image, links | guide, projectmembersarchive, activityarchive, salearchive, ticketarchive |
-| Requests | ticket | main, findticket | - |
-| Sale | sale | main, details, udef, links, info | guide, quote, saleactivityarchive, stakeholderarchive, ticketarchive |
-| Selection | selectionsearch | main, findpane, detailspane, newchartspane, selmailingspane, webpanelpane | - |
-| Appointment Dialog | appointment | main, details, status, links, udef | - |
-| Document Dialog | document | main, links, more | - |
-| Invitations Dialog | invitations | archive, main | - |
-| Custom object (pilot) | customobject?customobject_name= | - | - |
+## Main screen targets
+
+| Entity | Target | Upper tab views | Lower tab views | Notes |
+|--------|--------|-----------------|-----------------|-------|
+| Chat | chat | main | - | |
+| Company | contact | main, udef, interest, info | personarchive, relationarchive, projectarchive, activityarchive, salearchive, ticketarchive | |
+| Custom object (pilot) | customobject?customobject_name= | - | - | |
+| Custom objects overview | customobjectoverview | main | - | |
+| Dashboards | dashboard2 | main | - | <i class="ph ph-warning" aria-hidden="true"></i> Not `dashboard` or `dashboards` |
+| Diary | diary | day, week, month, view | activityarchive, diarysalearchive | |
+| Email flows | flows | main | - | |
+| Free-text search results | freetextresult | main | - | |
+| Inbox | newinbox | main | - | <i class="ph ph-warning" aria-hidden="true"></i> Not `mailbox` |
+| Marketing | emarketing | mailings, mmlisttemplates, mmlistlinks, mmlistimages, mmlistbounces, mmlistforms, mmlistformtemplates, mmlistformsubmissions | - | |
+| Person | person | main, details, udef, interest, info | projectarchive, relationarchive, activityarchive, salearchive, ticketarchive | |
+| Project | project | main, udef, info, image, links | guide, projectmembersarchive, activityarchive, salearchive, ticketarchive | |
+| Requests | ticket | main, findticket | - | Requires NewServiceRequest feature toggle |
+| Sale | sale | main, details, udef, links, info | guide, quote, saleactivityarchive, stakeholderarchive, ticketarchive | |
+| Selection | selection | - | - | Auto-rewrites — [see below](#selection-auto-rewriting) |
+| Selection — board/kanban | selectionboard | main | - | Requires BoardView feature toggle |
+| Selection — browse view | selectionbrowse | main | - | |
+| Selection — find view | selectionfind | main | - | For new selections (`selection_id=0`) |
+| Selection — search view | selectionsearch | main, findpane, detailspane, newchartspane, selmailingspane, webpanelpane | - | For existing selections |
+| Simple iframe | simpleiframe | main | - | |
+| Web panel browser | browser | main | - | |
+
+## Selection auto-rewriting
+
+When you use `selection` as the target, the protocol parser automatically rewrites the URL based on the value of `selection_id`:
+
+| Condition | Rewrites to | Purpose |
+|-----------|-------------|---------|
+| `selection_id=0` | `selectionfind` | Open the create-new-selection view |
+| `selection_id=` existing ID | `selectionsearch` | Open an existing selection |
+
+You can also navigate directly to `selectionbrowse` or `selectionboard` for alternative views.
+
+## Dialog targets
+
+The following targets open dialogs rather than navigating to a full screen. In SCIL pages, navigation uses `SCIL.Router.navigateTo()`.
+
+| Target | Dialog | Notes |
+|--------|--------|-------|
+| appsettings | Application settings | |
+| appointment | Follow-up/appointment | Tabs: main, details, status, links, udef |
+| consentperson | Consent for person | |
+| document | Document | Tabs: main, links, more |
+| find | Find dialog | |
+| groupview | Group view (diary) | |
+| invitations | Invitations | Tabs: archive, main |
+| maildialog | Email compose | |
+| preferences | User preferences | |
+| recyclebin | Recycle bin | |
+| relation | Relation | |
+| statusmonitor | Saint status monitor | |
+
+## Query parameters
+
+The `?what` portion of an SoProtocol URL specifies which record to display. The following entity ID parameters are supported:
+
+| Parameter | Entity |
+|-----------|--------|
+| appointment_id | Follow-up/appointment |
+| associate_id | Associate/user |
+| contact_id | Company/contact |
+| dashboard_id | Dashboard |
+| day_id / week_id / month_id | Calendar date navigation |
+| diaryowner_id | Diary owner |
+| document_id | Document |
+| email_flow_id | Email flow |
+| person_id | Person |
+| project_id | Project |
+| sale_id | Sale |
+| selection_id | Selection |
+| ticket_id | Request/ticket |
+
+**Example:** `superoffice:contact.main.personarchive?contact_id=5&person_id=10`
+
+## Admin targets
+
+The following targets navigate to administrator screens. The signed-in user must have administrator rights.
+
+| Target | Admin area |
+|--------|-----------|
+| adminlicense | Licenses |
+| adminusers | Users |
+| adminroles | Roles |
+| adminprivacy | Privacy |
+| adminsaint | SAINT |
+| adminhugoai | AI services |
+| adminlists | Lists |
+| adminquote | Quote/Sync |
+| adminworkflow | Workflow |
+| adminconfigscreens | Screen designer |
+| adminpreferences | Preferences |
+| adminchat | Chat |
+| adminmarketing | Marketing |
+| adminsystem | Options |
+| adminimportwizard | Import |
+| adminfields | Fields |
+| crmscript | CRMScript |
+| adminrequests | Requests |
+| admincustcenter | Customer center |
+| adminsystemdesign | System design |
 
 ## Minicard addresses
 
@@ -63,5 +151,3 @@ The following minicard addresses are available:
   * `contact.interest.projectarchive.minicontact`
 
 * To go to the diary and view the *day* tab: `diary.day`
-
-<!-- Referenced links -->

--- a/docs/en/customization/soprotocol/page-control-and-cache.md
+++ b/docs/en/customization/soprotocol/page-control-and-cache.md
@@ -3,8 +3,8 @@ uid: so-protocol-page-control
 title: Page control and cache
 description: SoProtocol page control and cache
 keywords: soprotocol, deeplinking, cache
-author: Tony Yates
-date: 10.03.2025
+author: Tony Yates, digitaldiina, MargretheR
+date: 29.05.2026
 content_type: reference
 category: customization
 topic: soprotocol
@@ -33,8 +33,27 @@ language: en
 
 ## Web only
 
-| Mode     | Description                              |
-|:---------|:-----------------------------------------|
-| Flush    | QueryString parameter (...?flush)        |
+| Mode | Description |
+|:--|:--|
+| Flush | Flushes the client cache (`?flush`) |
+| Refresh | Refreshes the current page (`?refresh`) |
 
-<!-- Referenced links -->
+### Service redirects
+
+Use `service.{program}?action={action}` to redirect to Customer Service screens:
+
+```html
+superoffice:service.ticket?action=listTickets&ticket_id=123
+```
+
+The `flush` command can also be used inline within a navigation path:
+
+```html
+contact[flush=true].main
+```
+
+### Examples
+
+* To flush the cache: `superoffice:contact.main?flush`
+* To refresh the current page: `superoffice:contact.main?refresh`
+* To navigate to a specific request in Customer Service: `superoffice:service.ticket?action=listTickets&ticket_id=123`


### PR DESCRIPTION
- Expand main screen targets table with 10 missing targets (dashboard2, flows, customobjectoverview, freetextresult, simpleiframe, browser, selection variants)
- Add Selection auto-rewriting section
- Add Dialog targets section (12 dialogs, incl. 9 previously undocumented)
- Add Query parameters section with full set of supported entity IDs
- Add Admin targets section (20 screens)
- Expand page-control-and-cache.md web section with Refresh mode, service redirects, and inline flush syntax