### PR TITLE
Update add-crm-data-to-event.md

### DIFF
--- a/integrations/superoffice-for-outlook/add-crm-data-to-event.md
+++ b/integrations/superoffice-for-outlook/add-crm-data-to-event.md
@@ -55,10 +55,8 @@ Use SuperOffice for Outlook to add CRM data to meetings and appointments in Outl
 
 1. If SuperOffice CRM data exists for the attendees, it is displayed.
 
-    * If a contact is found but the **Contact** field is not auto-filled, multiple contacts with the same email exist in SuperOffice.
-        * Click **Select Contact** and choose the correct contact.
-    * If no contact is found, you can add a new contact to SuperOffice:
-        * Select **Click to add new contact** and enter the required details.
+    * If a contact is found but the **Contact** field is not auto-filled, multiple contacts with the same email exist in SuperOffice. Click **Select Contact** and choose the correct contact.
+    * If no contact is found, you can add a new contact to SuperOffice: Select **Click to add new contact** and enter the required details.
 
 1. If no data exists, the add-in attempts to find the organizer in SuperOffice CRM.
 

--- a/integrations/superoffice-for-outlook/add-crm-data-to-event.md
+++ b/integrations/superoffice-for-outlook/add-crm-data-to-event.md
@@ -40,10 +40,8 @@ Use SuperOffice for Outlook to add CRM data to meetings and appointments in Outl
     ![SuperOffice for Outlook, add CRM data to event -screenshot][img1]
 
     * If the email or contact is stored in SuperOffice, their contact information will appear, and the **Company** and **Contact** fields will auto-fill.
-    * If a contact is found but the **Contact** field is not auto-filled, multiple contacts with the same email exist in SuperOffice.
-        * Click **Select Contact** and choose the correct contact.
-    * If no contact is found, you can add a new contact to SuperOffice:
-        * Select **Click to add new contact** and enter the required details.
+    * If a contact is found but the **Contact** field is not auto-filled, multiple contacts with the same email exist in SuperOffice. Click **Select Contact** and choose the correct contact.
+    * If no contact is found, you can add a new contact to SuperOffice: Select **Click to add new contact** and enter the required details.
 
 1. Adjust the event details as needed.
 

--- a/integrations/superoffice-for-outlook/add-crm-data-to-event.md
+++ b/integrations/superoffice-for-outlook/add-crm-data-to-event.md
@@ -98,8 +98,8 @@ You can also work with calendar events from shared mailboxes in Outlook.
 
 You can use the **Type** field to set the meeting type.
 
-- This value is saved with the event and synchronized to SuperOffice.
-- It can be used to categorize meetings for reporting and filtering.
+* This value is saved with the event and synchronized to SuperOffice.
+* It can be used to categorize meetings for reporting and filtering.
 
 ### Notes
 

--- a/integrations/superoffice-for-outlook/add-crm-data-to-event.md
+++ b/integrations/superoffice-for-outlook/add-crm-data-to-event.md
@@ -1,11 +1,11 @@
 ---
 uid: sofo-add-crm-data-to-event
 title: Add CRM data to Outlook event
-description: Add CRM data to Outlook event
+description: How to add CRM data to meetings and appointments in Outlook using SuperOffice for Outlook
 keywords: SuperOffice for Outlook, Outlook, email, event, calendar, CRM data, SOFO
-author: Erik Lebiko, Bergfrid Dias
-date: 10.29.2024
-version_sofo: 2024.8.12
+author: Erik Lebiko, Bergfrid Dias, schildea
+date: 06.05.2026
+version_sofo: 2026.6.3
 content_type: howto
 category: integration
 topic: SuperOffice for Outlook
@@ -24,19 +24,26 @@ redirect_from:
 
 # Add CRM data to Outlook event
 
+Use SuperOffice for Outlook to add CRM data to meetings and appointments in Outlook.
+
+> [!NOTE]
+> You need [Synchronizer for SuperOffice][2] for this functionality.
+
 ## New event
 
 1. Select **New event** in Outlook.
 
-1. [Open SuperOffice for Outlook][1] (if not pinned)​.
+1. [Open SuperOffice for Outlook][1].
 
 1. Add persons to the **Invite attendees** field in Outlook.
 
     ![SuperOffice for Outlook, add CRM data to event -screenshot][img1]
 
-    If the email or contact is stored in SuperOffice, their contact information will appear, and the **Company** and **Contact** fields will auto-fill. You can hover over the contact and click **Open in CRM** to view detailed information in SuperOffice CRM.
-
-    You can also **invite contacts from SuperOffice** for added convenience.
+    * If the email or contact is stored in SuperOffice, their contact information will appear, and the **Company** and **Contact** fields will auto-fill.
+    * If a contact is found but the **Contact** field is not auto-filled, multiple contacts with the same email exist in SuperOffice.
+        * Click **Select Contact** and choose the correct contact.
+    * If no contact is found, you can add a new contact to SuperOffice:
+        * Select **Click to add new contact** and enter the required details.
 
 1. Adjust the event details as needed.
 
@@ -46,22 +53,51 @@ redirect_from:
 
 1. Open an existing event in Outlook.
 
-1. [Open SuperOffice for Outlook][1] (if not pinned)​.
+1. [Open SuperOffice for Outlook][1].
 
-    * If SuperOffice CRM data exists for the attendees, it will be displayed.
-    * If no data exists, the add-in will attempt to find the organizer in SuperOffice CRM.
+1. If SuperOffice CRM data exists for the attendees, it is displayed.
 
-1. Follow the same steps as outlined above to modify or save the event.
+    * If a contact is found but the **Contact** field is not auto-filled, multiple contacts with the same email exist in SuperOffice.
+        * Click **Select Contact** and choose the correct contact.
+    * If no contact is found, you can add a new contact to SuperOffice:
+        * Select **Click to add new contact** and enter the required details.
 
-> [!NOTE]
-> You need [Synchronizer for SuperOffice][2] for this functionality. Calendar events synced from SuperOffice CRM are view-only in Outlook, but you can still view contact information.
+1. If no data exists, the add-in attempts to find the organizer in SuperOffice CRM.
+
+1. Follow the same steps as for a new event to modify or save the event.
 
 ## Additional information
 
-To view sales, projects, or activities related to a contact, follow these steps:
+### View contact details
 
-1. In the SuperOffice sidebar, navigate to the **Action** or **People** tab and select the contact's name.
-2. You will see vital details about the contact, including their requests, sales, and follow-ups.
+To view additional CRM data:
+
+1. In the SuperOffice panel, locate the contact.
+1. Hover over the contact and select **Open in CRM**.
+
+SuperOffice CRM opens with detailed information about the contact.
+
+### Meetings created in SuperOffice
+
+Calendar events created in SuperOffice and synchronized to Outlook are view-only in Outlook.
+
+* These events may contain information indicating they originate from SuperOffice.
+* Editing or deleting must be done in SuperOffice.
+* You do not need to press **Save**, as the event is already stored in SuperOffice.
+
+### Shared mailbox calendars
+
+You can also work with calendar events from shared mailboxes in Outlook.
+
+1. Open the event from the shared mailbox.
+1. [Open SuperOffice for Outlook][1].
+1. Add or update CRM data.
+1. Press **Save**.
+
+### Notes
+
+* Calendar events synchronized from SuperOffice are view-only in Outlook, but CRM information is still available.
+* Contact matching is based on participants and organizer.
 
 <!-- Referenced links -->
 [1]: get.md#open

--- a/integrations/superoffice-for-outlook/add-crm-data-to-event.md
+++ b/integrations/superoffice-for-outlook/add-crm-data-to-event.md
@@ -94,6 +94,13 @@ You can also work with calendar events from shared mailboxes in Outlook.
 1. Add or update CRM data.
 1. Press **Save**.
 
+### Type
+
+You can use the **Type** field to set the meeting type.
+
+- This value is saved with the event and synchronized to SuperOffice.
+- It can be used to categorize meetings for reporting and filtering.
+
 ### Notes
 
 * Calendar events synchronized from SuperOffice are view-only in Outlook, but CRM information is still available.


### PR DESCRIPTION
## Summary
Updated the Add CRM data to Outlook event article to reflect the latest functionality in SuperOffice for Outlook 2026.6.3.

## Changes
- Rewrote New event and Existing event sections with improved step-by-step instructions
- Added handling for multiple contacts with the same email (Select Contact flow)
- Added steps for adding a new contact directly from the event
- Added new sections: View contact details, Meetings created in SuperOffice, Shared mailbox calendars, and Notes
- Moved the Synchronizer for SuperOffice requirement note to the top of the article
- add Type field information
- Updated frontmatter: version, date, and author

## Type of change
- [x] Documentation update