### PR TITLE
Add Mark as Spam documentation for requests (#3004)

### DIFF
--- a/docs/da/admin/user-management/role/functional-rights.md
+++ b/docs/da/admin/user-management/role/functional-rights.md
@@ -4,8 +4,8 @@ title: Functional rights in SuperOffice
 description: What are all available functional rights in SuperOffice and what each of them mean?
 keywords: user management, role, access, rights
 author: PhilipYates, digitaldiina
-date: 05.04.2026
-version: 11.13
+date: 06.11.2026
+version: 12.0
 content_type: reference
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -35,6 +35,7 @@ Using [role-based security][3], we can [customize roles][2] to give access to di
 | Can export data to file | The user may export company and contact information to a file. | |
 | Can lock and unlock targets | The user may lock and unlock sale targets. | |
 | Can manage (move and merge) entities | The user may move, merge, and copy contacts, companies, and so on. | |
+| Can mark requests as Spam | The user may mark requests as spam. | |
 | Can modify interests for selection members | The user may modify the interests for all members of a selection. | |
 | Can override consent in mailings | The user may override the consent check when sending mailings. | |
 | Can override read-only fields | The user may modify read-only user-defined fields. | |

--- a/docs/da/request/learn/index.md
+++ b/docs/da/request/learn/index.md
@@ -155,6 +155,7 @@ SuperOffice Service hjælper dig med at give personer de svar, de har brug for, 
 * [Videresend meddelelser eller flere sager til eksterne parter][8]
 * [Tilføj sager til listen over favoritter][18]
 * [Luk sager][3]
+* [Markér sager som spam][27]
 
 Forskellige firmaer har forskellige rutiner for sagsbehandling og kan bruge SuperOffice Service på forskellige måder. Nedenfor har vi sat to scenarier fra den virkelige verden op, der viser nogle af de muligheder, der findes. Disse scenarier viser dig, hvordan du kan svare effektivt, når en person har sendt en sag via e-mail, og når en person ringer ind med et problem eller et spørgsmål.
 
@@ -271,6 +272,7 @@ Nogle indstillinger, der påvirker supportagenter, inkluderer:
 [23]: ../../knowledge-base/learn/reply-templates/index.md
 [20]: https://community.superoffice.com/en/learning/best-practices-tips/service/7-tips-to-provide-best-in-class-customer-service-with-superoffice-service/
 [26]: ../../admin/preferences/service-settings.md
+[27]: spam.md
 
 <!-- Referenced images -->
 [img1]: ../../../media/loc/en/request/request-list-preview.png

--- a/docs/da/request/learn/spam.md
+++ b/docs/da/request/learn/spam.md
@@ -1,0 +1,69 @@
+---
+uid: help-da-request-spam
+title: Marker sager som spam
+description: Sådan markerer du svigagtige eller uønskede sager som spam i SuperOffice Service.
+keywords: marker som spam, spam-sag, svigagtig sag, uønsket sag, sag
+author: digitaldiina
+date: 06.11.2026
+version: 12.0
+content_type: howto
+functional_right: Can mark requests as Spam
+license: serviceessentials
+tier: starter
+audience: person
+audience_tooltip: SuperOffice Service
+language: da
+---
+
+# Marker sager som spam
+
+> [!NOTE]
+> Du skal have den funktionelle rettighed **Can mark requests as Spam**.
+
+Brug **Marker som spam** til at klassificere svigagtige eller uønskede sager. Spam-sager er ekskluderet fra alle visninger, søgninger, rapporter og udvalg og tæller ikke med i målet [Løste servicesager][7].
+
+Du kan markere sager som spam fra tre steder:
+
+| Kontekst | Find Marker som spam her |
+|---|---|
+| Én eller flere sager på en liste | Kontekstmenuen (højreklik) |
+| Én åben sag | **Opgave**-menuen |
+| Et udvalg af sager | **Opgave**-menuen |
+
+Sager markeret som spam flyttes til [papirkurven][5], hvor du kan gendanne dem om nødvendigt. De slettes permanent fra papirkurven efter en konfigurerbar periode (standard: 14 dage).
+
+## Marker sager som spam fra en liste
+
+Når du ser en liste over sager:
+
+1. Vælg én eller flere sager.
+1. Højreklik på markeringen og vælg **Marker som spam** fra kontekstmenuen.
+1. Vælg **Ja** i bekræftelsesdialogboksen for at bekræfte, eller **Nej** for at annullere.
+
+    ![Højreklik på sager på en liste og vælg Marker som spam -screenshot][img1]
+
+## Marker en enkelt sag som spam
+
+1. [Åbn sagen][1].
+1. Klik på <i class="ph ph-dots-three-circle-vertical" aria-label="Opgavemenu"></i> og vælg **Marker som spam**.
+1. Vælg **Ja** i bekræftelsesdialogboksen for at bekræfte, eller **Nej** for at annullere.
+
+## Relateret indhold
+
+* [Slet sager][2]
+* [Luk sag][3]
+* [Find sag][4]
+* [Slet og gendan elementer – papirkurv][5]
+* [Funktionelle rettigheder][6]
+
+<!-- Referenced links -->
+[1]: index.md#open
+[2]: delete.md
+[3]: close.md
+[4]: find.md
+[5]: ../../learn/basics/deleting-elements.md
+[6]: ../../admin/user-management/role/functional-rights.md
+[7]: ../../admin/license/crm-suite.md
+
+<!-- Referenced images -->
+[img1]: ../../../media/loc/en/request/requests-list-mark-spam-context-menu.png

--- a/docs/da/request/learn/toc.yml
+++ b/docs/da/request/learn/toc.yml
@@ -13,6 +13,8 @@ items:
   href: edit-message.md
 - name: Automatisk tildeling
   href: assign.md
+- name: Marker sag som spam
+  href: spam.md
 - name: Tag ansvar for sag
   href: accept.md
 - name: Bed en anden sagsbehandler om hjælp

--- a/docs/de/admin/user-management/role/functional-rights.md
+++ b/docs/de/admin/user-management/role/functional-rights.md
@@ -4,8 +4,8 @@ title: Functional rights in SuperOffice
 description: What are all available functional rights in SuperOffice and what each of them mean?
 keywords: user management, role, access, rights
 author: PhilipYates, digitaldiina
-date: 05.04.2026
-version: 11.13
+date: 06.11.2026
+version: 12.0
 content_type: reference
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -35,6 +35,7 @@ Using [role-based security][3], we can [customize roles][2] to give access to di
 | Can export data to file | The user may export company and contact information to a file. | |
 | Can lock and unlock targets | The user may lock and unlock sale targets. | |
 | Can manage (move and merge) entities | The user may move, merge, and copy contacts, companies, and so on. | |
+| Can mark requests as Spam | The user may mark requests as spam. | |
 | Can modify interests for selection members | The user may modify the interests for all members of a selection. | |
 | Can override consent in mailings | The user may override the consent check when sending mailings. | |
 | Can override read-only fields | The user may modify read-only user-defined fields. | |

--- a/docs/de/request/learn/index.md
+++ b/docs/de/request/learn/index.md
@@ -155,6 +155,7 @@ Ein Kundenservicesystem dient dazu, Ihren Kunden die gesuchten Antworten bereitz
 * [Nachrichten oder mehrere Anfragen an externe Parteien weiterleiten][8]
 * [Anfragen zur Favoritenliste hinzufügen][18]
 * [Anfragen schließen][3]
+* [Anfragen als Spam markieren][27]
 
 Jedes Unternehmen hat eigene Abläufe zur Bearbeitung von Anfragen und nutzt SuperOffice Service auf unterschiedliche Weise. Nachfolgend zeigen zwei reale Szenarien, wie Anfragen effizient bearbeitet werden können.
 
@@ -270,6 +271,7 @@ Einige Einstellungen, die Support-Agenten betreffen, umfassen:
 [23]: ../../knowledge-base/learn/reply-templates/index.md
 [20]: https://community.superoffice.com/en/learning/best-practices-tips/service/7-tips-to-provide-best-in-class-customer-service-with-superoffice-service/
 [26]: ../../admin/preferences/service-settings.md
+[27]: spam.md
 
 <!-- Referenced images -->
 [img1]: ../../../media/loc/en/request/request-list-preview.png

--- a/docs/de/request/learn/spam.md
+++ b/docs/de/request/learn/spam.md
@@ -1,0 +1,69 @@
+---
+uid: help-de-request-spam
+title: Anfragen als Spam markieren
+description: So markieren Sie betrügerische oder unerwünschte Anfragen als Spam in SuperOffice Service.
+keywords: als Spam markieren, Spam-Anfrage, betrügerische Anfrage, unerwünschte Anfrage, Anfrage
+author: digitaldiina
+date: 06.11.2026
+version: 12.0
+content_type: howto
+functional_right: Can mark requests as Spam
+license: serviceessentials
+tier: starter
+audience: person
+audience_tooltip: SuperOffice Service
+language: de
+---
+
+# Anfragen als Spam markieren
+
+> [!NOTE]
+> Sie benötigen das Funktionsrecht **Can mark requests as Spam**.
+
+Verwenden Sie **Als Spam markieren**, um betrügerische oder unerwünschte Anfragen zu klassifizieren. Als Spam markierte Anfragen sind von allen Ansichten, Suchen, Berichten und Selektionen ausgeschlossen und werden nicht in der Kennzahl [Gelöste Service-Anfragen][7] gezählt.
+
+Sie können Anfragen an drei Stellen als Spam markieren:
+
+| Kontext | Wo Sie Als Spam markieren finden |
+|---|---|
+| Eine oder mehrere Anfragen in einer Liste | Das Kontextmenü (Rechtsklick) |
+| Eine einzelne geöffnete Anfrage | Das Menü **Aufgabe** |
+| Eine Auswahl von Anfragen | Das Menü **Aufgabe** |
+
+Als Spam markierte Anfragen werden in den [Papierkorb][5] verschoben, wo Sie sie bei Bedarf wiederherstellen können. Sie werden nach einem konfigurierbaren Zeitraum endgültig aus dem Papierkorb gelöscht (Standard: 14 Tage).
+
+## Anfragen aus einer Liste als Spam markieren
+
+Wenn Sie eine Liste von Anfragen anzeigen:
+
+1. Wählen Sie eine oder mehrere Anfragen aus.
+1. Klicken Sie mit der rechten Maustaste auf die Auswahl und wählen Sie **Als Spam markieren** aus dem Kontextmenü aus.
+1. Klicken Sie im Bestätigungsdialog auf **Ja**, um zu bestätigen, oder auf **Nein**, um abzubrechen.
+
+    ![Rechtsklick auf Anfragen in einer Liste und Als Spam markieren auswählen -screenshot][img1]
+
+## Eine einzelne Anfrage als Spam markieren
+
+1. [Öffnen Sie die Anfrage][1].
+1. Klicken Sie auf <i class="ph ph-dots-three-circle-vertical" aria-label="Aufgabenmenü"></i> und wählen Sie **Als Spam markieren** aus.
+1. Klicken Sie im Bestätigungsdialog auf **Ja**, um zu bestätigen, oder auf **Nein**, um abzubrechen.
+
+## Zugehörige Inhalte
+
+* [Anfragen löschen][2]
+* [Anfrage abschließen][3]
+* [Anfrage suchen][4]
+* [Elemente löschen und wiederherstellen – Papierkorb][5]
+* [Funktionsrechte][6]
+
+<!-- Referenced links -->
+[1]: index.md#open
+[2]: delete.md
+[3]: close.md
+[4]: find.md
+[5]: ../../learn/basics/deleting-elements.md
+[6]: ../../admin/user-management/role/functional-rights.md
+[7]: ../../admin/license/crm-suite.md
+
+<!-- Referenced images -->
+[img1]: ../../../media/loc/en/request/requests-list-mark-spam-context-menu.png

--- a/docs/de/request/learn/toc.yml
+++ b/docs/de/request/learn/toc.yml
@@ -13,6 +13,8 @@ items:
   href: edit-message.md
 - name: Automatische Zuordnung
   href: assign.md
+- name: Anfrage als Spam markieren
+  href: spam.md
 - name: Anfrage übernehmen
   href: accept.md
 - name: Einen anderen Bearbeiter um Hilfe bitten

--- a/docs/en/admin/user-management/role/functional-rights.md
+++ b/docs/en/admin/user-management/role/functional-rights.md
@@ -4,8 +4,8 @@ title: Functional rights in SuperOffice
 description: What are all available functional rights in SuperOffice and what each of them mean?
 keywords: user management, role, access, rights
 author: PhilipYates, digitaldiina
-date: 05.04.2026
-version: 11.13
+date: 06.11.2026
+version: 12.0
 content_type: reference
 tier: starter
 audience: settings
@@ -37,6 +37,7 @@ Using [role-based security][3], we can [customize roles][2] to give access to di
 | Can export data to file | The user may export company and contact information to a file. | |
 | Can lock and unlock targets | The user may lock and unlock sale targets. | |
 | Can manage (move and merge) entities | The user may move, merge, and copy contacts, companies, and so on. | |
+| Can mark requests as Spam | The user may mark requests as spam. | |
 | Can modify interests for selection members | The user may modify the interests for all members of a selection. | |
 | Can override consent in mailings | The user may override the consent check when sending mailings. | |
 | Can override read-only fields | The user may modify read-only user-defined fields. | |

--- a/docs/en/request/learn/index.md
+++ b/docs/en/request/learn/index.md
@@ -155,6 +155,7 @@ A contact service system is all about providing your contacts the answers they a
 * [Forward messages or multiple requests to external parties][8]
 * [Add requests to the favorites list][18]
 * [Close requests][3]
+* [Mark requests as spam][27]
 
 Different companies have different routines for request handling and can use SuperOffice Service in different ways. Below we have set up two real-life scenarios showing some of the available options. These scenarios will show you how you can reply efficiently when a contact has submitted a request by email and when a contact calls in with a problem or a question.
 
@@ -270,6 +271,7 @@ Some settings that affect support agents include:
 [18]: ../../learn/basics/fav.md
 [23]: ../../knowledge-base/learn/reply-templates/index.md
 [26]: ../../admin/preferences/service-settings.md
+[27]: spam.md
 
 [20]: https://community.superoffice.com/en/learning/best-practices-tips/service/7-tips-to-provide-best-in-class-customer-service-with-superoffice-service/
 

--- a/docs/en/request/learn/spam.md
+++ b/docs/en/request/learn/spam.md
@@ -1,0 +1,69 @@
+---
+uid: help-en-request-spam
+title: Mark requests as spam
+description: How to mark fraudulent or unwanted requests as spam in SuperOffice Service.
+keywords: mark as spam, spam request, fraudulent request, unwanted request, request
+author: digitaldiina
+date: 06.11.2026
+version: 12.0
+content_type: howto
+functional_right: Can mark requests as Spam
+license: serviceessentials
+tier: starter
+audience: person
+audience_tooltip: SuperOffice Service
+language: en
+---
+
+# Mark requests as spam
+
+> [!NOTE]
+> You need the **Can mark requests as Spam** functional right.
+
+Use **Mark as Spam** to classify fraudulent or unwanted requests. Spam requests are excluded from all views, searches, reports, and selections, and do not count toward the [Resolved service requests][7] metric.
+
+You can mark requests as spam from three places:
+
+| Context | Where to find Mark as Spam |
+|---|---|
+| One or more requests in a list | The context menu (right-click) |
+| A single open request | The **Task** menu |
+| A selection of requests | The **Task** menu |
+
+Requests marked as spam move to the [Recycle bin][5], where you can restore them if needed. They are permanently deleted from the Recycle bin after a configurable period (default: 14 days).
+
+## Mark requests as spam from a list
+
+When viewing a list of requests:
+
+1. Select one or more requests.
+1. Right-click the selection and select **Mark as Spam** from the context menu.
+1. In the confirmation dialog, select **Yes** to confirm, or **No** to cancel.
+
+    ![Right-click requests in a list and select Mark as Spam -screenshot][img1]
+
+## Mark a single request as spam
+
+1. [Open the request][1].
+1. Click <i class="ph ph-dots-three-circle-vertical" aria-label="Task menu"></i> and select **Mark as Spam**.
+1. In the confirmation dialog, select **Yes** to confirm, or **No** to cancel.
+
+## Related content
+
+* [Delete requests][2]
+* [Close request][3]
+* [Find request][4]
+* [Delete and restore items - Recycle bin][5]
+* [Functional rights][6]
+
+<!-- Referenced links -->
+[1]: index.md#open
+[2]: delete.md
+[3]: close.md
+[4]: find.md
+[5]: ../../learn/basics/deleting-elements.md
+[6]: ../../admin/user-management/role/functional-rights.md
+[7]: ../../admin/license/crm-suite.md
+
+<!-- Referenced images -->
+[img1]: ../../../media/loc/en/request/requests-list-mark-spam-context-menu.png

--- a/docs/en/request/learn/toc.yml
+++ b/docs/en/request/learn/toc.yml
@@ -13,6 +13,8 @@ items:
   href: edit-message.md
 - name: Automatic assignment
   href: assign.md
+- name: Mark request as spam
+  href: spam.md
 - name: Accept request
   href: accept.md
 - name: Ask another request handler for help

--- a/docs/nl/admin/user-management/role/functional-rights.md
+++ b/docs/nl/admin/user-management/role/functional-rights.md
@@ -4,8 +4,8 @@ title: Functional rights in SuperOffice
 description: What are all available functional rights in SuperOffice and what each of them mean?
 keywords: user management, role, access, rights
 author: PhilipYates, digitaldiina
-date: 05.04.2026
-version: 11.13
+date: 06.11.2026
+version: 12.0
 content_type: reference
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -35,6 +35,7 @@ Using [role-based security][3], we can [customize roles][2] to give access to di
 | Can export data to file | The user may export company and contact information to a file. | |
 | Can lock and unlock targets | The user may lock and unlock sale targets. | |
 | Can manage (move and merge) entities | The user may move, merge, and copy contacts, companies, and so on. | |
+| Can mark requests as Spam | The user may mark requests as spam. | |
 | Can modify interests for selection members | The user may modify the interests for all members of a selection. | |
 | Can override consent in mailings | The user may override the consent check when sending mailings. | |
 | Can override read-only fields | The user may modify read-only user-defined fields. | |

--- a/docs/nl/request/learn/index.md
+++ b/docs/nl/request/learn/index.md
@@ -155,6 +155,7 @@ Een contactservicesysteem draait om het bieden van de antwoorden die uw personen
 * [Berichten of meerdere verzoeken doorsturen naar externe partijen][8]
 * [Verzoeken aan de lijst met favorieten toevoegen][18]
 * [Verzoeken sluiten][3]
+* [Verzoeken markeren als spam][27]
 
 Verschillende bedrijven hebben verschillende routines voor verzoekafhandeling en kunnen SuperOffice Service op verschillende manieren gebruiken. Hieronder staan twee praktijkgevallen die enkele van de beschikbare opties laten zien. Deze scenario's laten u zien hoe u efficiënt kunt antwoorden wanneer een persoon een verzoek per e-mail heeft ingediend en wanneer een persoon belt met een probleem of een vraag.
 
@@ -271,6 +272,7 @@ Enkele instellingen die ondersteuningsagenten beïnvloeden zijn:
 [23]: ../../knowledge-base/learn/reply-templates/index.md
 [20]: https://community.superoffice.com/en/learning/best-practices-tips/service/7-tips-to-provide-best-in-class-customer-service-with-superoffice-service/
 [26]: ../../admin/preferences/service-settings.md
+[27]: spam.md
 
 <!-- Referenced images -->
 [img1]: ../../../media/loc/en/request/request-list-preview.png

--- a/docs/nl/request/learn/spam.md
+++ b/docs/nl/request/learn/spam.md
@@ -1,0 +1,69 @@
+---
+uid: help-nl-request-spam
+title: Verzoeken markeren als spam
+description: Hoe u frauduleuze of ongewenste verzoeken als spam markeert in SuperOffice Service.
+keywords: markeren als spam, spam-verzoek, frauduleus verzoek, ongewenst verzoek, verzoek
+author: digitaldiina
+date: 06.11.2026
+version: 12.0
+content_type: howto
+functional_right: Can mark requests as Spam
+license: serviceessentials
+tier: starter
+audience: person
+audience_tooltip: SuperOffice Service
+language: nl
+---
+
+# Verzoeken markeren als spam
+
+> [!NOTE]
+> U hebt het functionele recht **Can mark requests as Spam** nodig.
+
+Gebruik **Markeren als spam** om frauduleuze of ongewenste verzoeken te classificeren. Spam-verzoeken zijn uitgesloten van alle weergaven, zoekopdrachten, rapporten en selecties, en tellen niet mee in de metriek [Opgeloste serviceverzoeken][7].
+
+U kunt verzoeken als spam markeren op drie plaatsen:
+
+| Context | Waar u Markeren als spam vindt |
+|---|---|
+| Een of meer verzoeken in een lijst | Het contextmenu (rechtermuisknop) |
+| Eén geopend verzoek | Het menu **Taak** |
+| Een selectie van verzoeken | Het menu **Taak** |
+
+Verzoeken die als spam zijn gemarkeerd, worden verplaatst naar de [Prullenbak][5], waar u ze indien nodig kunt herstellen. Ze worden na een configureerbare periode permanent verwijderd uit de Prullenbak (standaard: 14 dagen).
+
+## Verzoeken als spam markeren vanuit een lijst
+
+Wanneer u een lijst met verzoeken bekijkt:
+
+1. Selecteer een of meer verzoeken.
+1. Klik met de rechtermuisknop op de selectie en selecteer **Markeren als spam** in het contextmenu.
+1. Selecteer **Ja** in het bevestigingsvenster om te bevestigen, of **Nee** om te annuleren.
+
+    ![Klik met de rechtermuisknop op verzoeken in een lijst en selecteer Markeren als spam -screenshot][img1]
+
+## Eén verzoek als spam markeren
+
+1. [Open het verzoek][1].
+1. Klik op <i class="ph ph-dots-three-circle-vertical" aria-label="Taakmenu"></i> en selecteer **Markeren als spam**.
+1. Selecteer **Ja** in het bevestigingsvenster om te bevestigen, of **Nee** om te annuleren.
+
+## Gerelateerde inhoud
+
+* [Verzoeken verwijderen][2]
+* [Verzoek sluiten][3]
+* [Verzoek zoeken][4]
+* [Elementen verwijderen en herstellen – Prullenbak][5]
+* [Functionele rechten][6]
+
+<!-- Referenced links -->
+[1]: index.md#open
+[2]: delete.md
+[3]: close.md
+[4]: find.md
+[5]: ../../learn/basics/deleting-elements.md
+[6]: ../../admin/user-management/role/functional-rights.md
+[7]: ../../admin/license/crm-suite.md
+
+<!-- Referenced images -->
+[img1]: ../../../media/loc/en/request/requests-list-mark-spam-context-menu.png

--- a/docs/nl/request/learn/toc.yml
+++ b/docs/nl/request/learn/toc.yml
@@ -13,6 +13,8 @@ items:
   href: edit-message.md
 - name: Automatische toewijzing
   href: assign.md
+- name: Verzoek markeren als spam
+  href: spam.md
 - name: Verantwoordelijkheid voor verzoeken opeisen
   href: accept.md
 - name: Andere verzoekbehandelaar om hulp vragen

--- a/docs/no/admin/user-management/role/functional-rights.md
+++ b/docs/no/admin/user-management/role/functional-rights.md
@@ -4,8 +4,8 @@ title: Functional rights in SuperOffice
 description: What are all available functional rights in SuperOffice and what each of them mean?
 keywords: user management, role, access, rights
 author: PhilipYates, digitaldiina
-date: 05.04.2026
-version: 11.13
+date: 06.11.2026
+version: 12.0
 content_type: reference
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -35,6 +35,7 @@ Using [role-based security][3], we can [customize roles][2] to give access to di
 | Can export data to file | The user may export company and contact information to a file. | |
 | Can lock and unlock targets | The user may lock and unlock sale targets. | |
 | Can manage (move and merge) entities | The user may move, merge, and copy contacts, companies, and so on. | |
+| Can mark requests as Spam | The user may mark requests as spam. | |
 | Can modify interests for selection members | The user may modify the interests for all members of a selection. | |
 | Can override consent in mailings | The user may override the consent check when sending mailings. | |
 | Can override read-only fields | The user may modify read-only user-defined fields. | |

--- a/docs/no/request/learn/index.md
+++ b/docs/no/request/learn/index.md
@@ -155,6 +155,7 @@ Et personservicesystem handler om å gi personer svarene de er ute etter, og å 
 * [Videresende meldinger eller flere saker til eksterne parter][8]
 * [Legge til saker i favorittlisten][18]
 * [Avslutte saker][3]
+* [Merk saker som spam][27]
 
 Ulike firmaer har ulike rutiner for saksbehandling og kan bruke SuperOffice Service på forskjellige måter. Nedenfor har vi satt opp to scenarioer fra virkeligheten som viser noen av mulighetene som finnes. Disse scenarioene viser deg hvordan du kan svare effektivt når en person har sendt inn en sak via e-post, og når en person ringer inn med et problem eller et spørsmål.
 
@@ -272,6 +273,7 @@ Noen innstillinger som påvirker kundestøtteagenter inkluderer:
 [23]: ../../knowledge-base/learn/reply-templates/index.md
 [20]: https://community.superoffice.com/en/learning/best-practices-tips/service/7-tips-to-provide-best-in-class-customer-service-with-superoffice-service/
 [26]: ../../admin/preferences/service-settings.md
+[27]: spam.md
 
 <!-- Referenced images -->
 [img1]: ../../../media/loc/en/request/request-list-preview.png

--- a/docs/no/request/learn/spam.md
+++ b/docs/no/request/learn/spam.md
@@ -1,0 +1,69 @@
+---
+uid: help-no-request-spam
+title: Merk saker som spam
+description: Slik merker du falske eller uønskede saker som spam i SuperOffice Service.
+keywords: merk som spam, spam-sak, falsk sak, uønsket sak, sak
+author: digitaldiina
+date: 06.11.2026
+version: 12.0
+content_type: howto
+functional_right: Can mark requests as Spam
+license: serviceessentials
+tier: starter
+audience: person
+audience_tooltip: SuperOffice Service
+language: no
+---
+
+# Merk saker som spam
+
+> [!NOTE]
+> Du trenger funksjonell rettighet **Can mark requests as Spam**.
+
+Bruk **Merk som spam** til å klassifisere falske eller uønskede saker. Spam-saker er ekskludert fra alle visninger, søk, rapporter og utvalg, og telles ikke med i målet [Løste servicesaker][7].
+
+Du kan merke saker som spam fra tre steder:
+
+| Kontekst | Finn Merk som spam her |
+|---|---|
+| Én eller flere saker i en liste | Hurtigmenyen (høyreklikk) |
+| Én åpen sak | **Oppgave**-menyen |
+| Et utvalg av saker | **Oppgave**-menyen |
+
+Saker merket som spam flyttes til [papirkurven][5], der du kan gjenopprette dem om nødvendig. De slettes permanent fra papirkurven etter en konfigurerbar periode (standard: 14 dager).
+
+## Merk saker som spam fra en liste
+
+Når du ser en liste over saker:
+
+1. Velg én eller flere saker.
+1. Høyreklikk utvalget og velg **Merk som spam** fra hurtigmenyen.
+1. Velg **Ja** i bekreftelsesdialogboksen for å bekrefte, eller **Nei** for å avbryte.
+
+    ![Høyreklikk på saker i en liste og velg Merk som spam -screenshot][img1]
+
+## Merk én sak som spam
+
+1. [Åpne saken][1].
+1. Klikk <i class="ph ph-dots-three-circle-vertical" aria-label="Oppgave-knappen"></i> og velg **Merk som spam**.
+1. Velg **Ja** i bekreftelsesdialogboksen for å bekrefte, eller **Nei** for å avbryte.
+
+## Aktuelt innhold
+
+* [Slette saker][2]
+* [Avslutte sak][3]
+* [Finn sak][4]
+* [Slette og gjenopprette elementer – papirkurv][5]
+* [Funksjonelle rettigheter][6]
+
+<!-- Refererte lenker -->
+[1]: index.md#open
+[2]: delete.md
+[3]: close.md
+[4]: find.md
+[5]: ../../learn/basics/deleting-elements.md
+[6]: ../../admin/user-management/role/functional-rights.md
+[7]: ../../admin/license/crm-suite.md
+
+<!-- Refererte bilder -->
+[img1]: ../../../media/loc/en/request/requests-list-mark-spam-context-menu.png

--- a/docs/no/request/learn/toc.yml
+++ b/docs/no/request/learn/toc.yml
@@ -13,6 +13,8 @@ items:
   href: edit-message.md
 - name: Automatisk tilordning
   href: assign.md
+- name: Merk sak som spam
+  href: spam.md
 - name: Ta ansvar for sak
   href: accept.md
 - name: Be en annen saksbehandler om hjelp

--- a/docs/sv/admin/user-management/role/functional-rights.md
+++ b/docs/sv/admin/user-management/role/functional-rights.md
@@ -4,8 +4,8 @@ title: Functional rights in SuperOffice
 description: What are all available functional rights in SuperOffice and what each of them mean?
 keywords: user management, role, access, rights
 author: PhilipYates, digitaldiina
-date: 05.04.2026
-version: 11.13
+date: 06.11.2026
+version: 12.0
 content_type: reference
 audience: settings
 audience_tooltip: Settings and maintenance
@@ -35,6 +35,7 @@ Using [role-based security][3], we can [customize roles][2] to give access to di
 | Can export data to file | The user may export company and contact information to a file. | |
 | Can lock and unlock targets | The user may lock and unlock sale targets. | |
 | Can manage (move and merge) entities | The user may move, merge, and copy contacts, companies, and so on. | |
+| Can mark requests as Spam | The user may mark requests as spam. | |
 | Can modify interests for selection members | The user may modify the interests for all members of a selection. | |
 | Can override consent in mailings | The user may override the consent check when sending mailings. | |
 | Can override read-only fields | The user may modify read-only user-defined fields. | |

--- a/docs/sv/request/learn/index.md
+++ b/docs/sv/request/learn/index.md
@@ -155,6 +155,7 @@ Ett kontaktservicesystem handlar om att ge dina kunder de svar de söker på ett
 * [Vidarebefordra ärenden till externa parter][8]
 * [Lägga till ärenden i favoriter][18]
 * [Avsluta ärenden][3]
+* [Markera ärenden som skräppost][27]
 
 Olika företag har olika rutiner för ärendehantering och kan använda SuperOffice Service på varierande sätt beroende på sina behov och arbetsflöden. Nedan har vi beskrivit två verkliga scenarier som illustrerar några av de olika alternativ som finns tillgängliga. Dessa exempel visar hur du kan hantera och besvara kundförfrågningar effektivt, både när en kund skickar in ett ärende via e-post och när en kund ringer in med ett problem eller en fråga.
 
@@ -271,6 +272,7 @@ Några inställningar som påverkar supportagenter inkluderar:
 [23]: ../../knowledge-base/learn/reply-templates/index.md
 [20]: https://community.superoffice.com/en/learning/best-practices-tips/service/7-tips-to-provide-best-in-class-customer-service-with-superoffice-service/
 [26]: ../../admin/preferences/service-settings.md
+[27]: spam.md
 
 <!-- Referenced images -->
 [img1]: ../../../media/loc/en/request/request-list-preview.png

--- a/docs/sv/request/learn/spam.md
+++ b/docs/sv/request/learn/spam.md
@@ -1,0 +1,69 @@
+---
+uid: help-sv-request-spam
+title: Markera ärenden som skräppost
+description: Hur du markerar bedrägliga eller oönskade ärenden som skräppost i SuperOffice Service.
+keywords: markera som skräppost, skräppostärende, bedrägligt ärende, oönskat ärende, ärende
+author: digitaldiina
+date: 06.11.2026
+version: 12.0
+content_type: howto
+functional_right: Can mark requests as Spam
+license: serviceessentials
+tier: starter
+audience: person
+audience_tooltip: SuperOffice Service
+language: sv
+---
+
+# Markera ärenden som skräppost
+
+> [!NOTE]
+> Du behöver den funktionella rättigheten **Can mark requests as Spam**.
+
+Använd **Markera som skräppost** för att klassificera bedrägliga eller oönskade ärenden. Skräppostärenden är uteslutna från alla vyer, sökningar, rapporter och urval, och räknas inte mot måttet [Lösta serviceärenden][7].
+
+Du kan markera ärenden som skräppost på tre ställen:
+
+| Sammanhang | Var du hittar Markera som skräppost |
+|---|---|
+| Ett eller flera ärenden i en lista | Snabbmenyn (högerklicka) |
+| Ett enskilt öppet ärende | Menyn **Uppgift** |
+| Ett urval av ärenden | Menyn **Uppgift** |
+
+Ärenden som markerats som skräppost flyttas till [papperskorgen][5], där du kan återställa dem om det behövs. De raderas permanent från papperskorgen efter en konfigurerbar period (standard: 14 dagar).
+
+## Markera ärenden som skräppost från en lista
+
+När du granskar en lista över ärenden:
+
+1. Välj ett eller flera ärenden.
+1. Högerklicka på markeringen och välj **Markera som skräppost** från snabbmenyn.
+1. Välj **Ja** i bekräftelsedialogrutan för att bekräfta, eller **Nej** för att avbryta.
+
+    ![Högerklicka på ärenden i en lista och välj Markera som skräppost -screenshot][img1]
+
+## Markera ett enskilt ärende som skräppost
+
+1. [Öppna ärendet][1].
+1. Klicka på <i class="ph ph-dots-three-circle-vertical" aria-label="Uppgiftsmeny"></i> och välj **Markera som skräppost**.
+1. Välj **Ja** i bekräftelsedialogrutan för att bekräfta, eller **Nej** för att avbryta.
+
+## Relaterat innhåll
+
+* [Ta bort ärenden][2]
+* [Avsluta ärende][3]
+* [Söka ärende][4]
+* [Ta bort och återställa objekt – papperskorgen][5]
+* [Funktionella rättigheter][6]
+
+<!-- Referenced links -->
+[1]: index.md#open
+[2]: delete.md
+[3]: close.md
+[4]: find.md
+[5]: ../../learn/basics/deleting-elements.md
+[6]: ../../admin/user-management/role/functional-rights.md
+[7]: ../../admin/license/crm-suite.md
+
+<!-- Referenced images -->
+[img1]: ../../../media/loc/en/request/requests-list-mark-spam-context-menu.png

--- a/docs/sv/request/learn/toc.yml
+++ b/docs/sv/request/learn/toc.yml
@@ -13,6 +13,8 @@ items:
   href: edit-message.md
 - name: Automatisk tilldelning
   href: assign.md
+- name: Markera ärende som skräppost
+  href: spam.md
 - name: Ta över ansvaret för ärende
   href: accept.md
 - name: Be en annan ärendehandläggare om hjälp


### PR DESCRIPTION
## Summary

- New *spam.md* howto page in all 6 languages documenting the Mark as Spam feature released in 12.0
- Added `Can mark requests as Spam` to *functional-rights.md*
- Wired into `index.md` Typical tasks and `toc.yml` — positioned before Accept as a triage action.

## What the page covers

- Functional right requirement (`Can mark requests as Spam`)
- Three entry points: context menu on a list, Task menu on a single request, Task menu on a selection
- Recycle bin behavior and 14-day permanent deletion
- Link to Resolved service requests metric (*crm-suite.md*)

Closes #3004