### PR TITLE
Fix example in EventDataDialogDefinition docs

### DIFF
--- a/docs/en/automation/crmscript/reference/CRMScript.Native.EventDataDialogDefinition.yml
+++ b/docs/en/automation/crmscript/reference/CRMScript.Native.EventDataDialogDefinition.yml
@@ -896,7 +896,7 @@ items:
     return:
       type: CRMScript.Global.Void
   example: 
-  - "\n<pre><code>EventDataDialogDefinition def;\ndef.addText(&quot;textinput&quot;, &quot;My Input&quot;, &quot;Default&quot;, &quot;Type something&quot;, false,&quot;4&quot;,&quot;5&quot;);</code></pre>\n"
+  - "\n<pre><code>EventDataDialogDefinition def;\ndef.addTextarea(&quot;textinput&quot;, &quot;My Input&quot;, &quot;Default&quot;, &quot;Type something&quot;, false, 4, 5);</code></pre>\n"
 - uid: CRMScript.Native.EventDataDialogDefinition.addTime(String,String)
   commentId: M:CRMScript.Native.EventDataDialogDefinition.addTime(String,String)
   id: 'addTime(String,String)'


### PR DESCRIPTION
Update the example in CRMScript.Native.EventDataDialogDefinition YAML: replace addText with addTextarea and use numeric arguments for rows/cols (4, 5) instead of quoted strings. This corrects the sample to match the API signature and intended usage.