### PR TITLE
Add missing .md extension to initial-security-eval links (#3049)

### DIFF
--- a/docs/en/developer-portal/index.yml
+++ b/docs/en/developer-portal/index.yml
@@ -100,7 +100,7 @@ landingContent:
         - text: The SuperOffice app store
           url: standard-app/app-store/index.md
         - text: Initial Telenor Cyberdefense evaluation
-          url: standard-app/certification/initial-security-eval
+          url: standard-app/certification/initial-security-eval.md
       - itemType: list
         typeDesc: how-to-guide
         links:

--- a/docs/en/developer-portal/standard-app/certification/index.md
+++ b/docs/en/developer-portal/standard-app/certification/index.md
@@ -45,4 +45,4 @@ Follow our [step-by-step guide][6], started by sending a request to publish in t
 [5]: ../requirements/index.md
 [6]: certify-app.md
 [7]: initial-security-eval.md#does-it-cost-anything
-[8]: initial-security-eval
+[8]: initial-security-eval.md

--- a/docs/en/developer-portal/standard-app/index.md
+++ b/docs/en/developer-portal/standard-app/index.md
@@ -25,4 +25,4 @@ All applications begin in our [sandbox environment][2]. Standard applications mu
 [1]: ../index.yml
 [2]: ../getting-started/app-envir.md
 [3]: certification/index.md
-[4]: certification/initial-security-eval
+[4]: certification/initial-security-eval.md

--- a/docs/en/developer-portal/standard-app/requirements/security.md
+++ b/docs/en/developer-portal/standard-app/requirements/security.md
@@ -72,7 +72,7 @@ If needed, we may go back in time to see when and by whom an operation was perfo
 <!-- Referenced links -->
 [1]: ../index.md
 [2]: ../certification/certify-app.md
-[3]: ../certification/initial-security-eval
+[3]: ../certification/initial-security-eval.md
 [4]: ../publish.md#beta
 [5]: ../../custom-app/index.md
 [6]: ../../custom-app/validate.md

--- a/docs/en/security/index.yml
+++ b/docs/en/security/index.yml
@@ -126,7 +126,7 @@ conceptualContent:
       - text: Telenor Cyberdefense evaluation
         itemType: explore
         typeDesc: concept
-        url: ../developer-portal/standard-app/certification/initial-security-eval
+        url: ../developer-portal/standard-app/certification/initial-security-eval.md
       - text: Obtain consent to access a customer's tenant
         itemType: list
         typeDesc: how-to-guide


### PR DESCRIPTION
Five reference-style links pointed at initial-security-eval without the file extension, so DocFx couldn't resolve them even though the target file exists.