### PR TITLE
Fix broken links in custom-objects docs (#3050)

### DIFF
--- a/docs/da/custom-objects/admin/create-extra-table.md
+++ b/docs/da/custom-objects/admin/create-extra-table.md
@@ -71,7 +71,7 @@ SuperOffice kan du oprette webpaneler, der kan indeholde tabelinformation. Hvis 
 
 <!-- Referenced links -->
 [1]: create-extra-field.md
-[2]: ../../en/automation/webhook/dev/overview.md
+[2]: ../../../en/automation/webhook/dev/index.md
 
 <!-- Referenced images -->
 [img1]: ../../../media/loc/en/custom-objects/create-extra-tables-and-fields.png

--- a/docs/da/custom-objects/admin/edit-udef.md
+++ b/docs/da/custom-objects/admin/edit-udef.md
@@ -16,7 +16,7 @@ index: true
 
 # Redigering af brugerdefinerede felt
 
-1. [!inkluder[Gå til felter og vælg fane](includes/goto-fields.md)]
+1. [!include[Gå til felter og vælg fane](includes/goto-fields.md)]
 
 1. Dobbeltklik på det nødvendige felt i listen **Felt**.
 

--- a/docs/de/custom-objects/admin/create-extra-table.md
+++ b/docs/de/custom-objects/admin/create-extra-table.md
@@ -71,7 +71,7 @@ In SuperOffice können Sie Web-Bildschirme erstellen, die Tabelleninformationen 
 
 <!-- Referenced links -->
 [1]: create-extra-field.md
-[2]: ../../en/automation/webhook/dev/overview.md
+[2]: ../../../en/automation/webhook/dev/index.md
 
 <!-- Referenced images -->
 [img1]: ../../../media/loc/en/custom-objects/create-extra-tables-and-fields.png

--- a/docs/en/api/overview/index.md
+++ b/docs/en/api/overview/index.md
@@ -313,7 +313,7 @@ Assistance and guidance are available:
 [31]: ../../mobile/index.md
 [32]: netserver.md#domain-level-apis-netserver-core
 [33]: ../config/services.md
-[34]: ../../automation/webhook/dev/overview.md
+[34]: ../../automation/webhook/dev/index.md
 [35]: ../plugins/document/soarc-document-plugin.md
 [36]: ../plugins/sentry/index.md
 [37]: ../tutorials/sem-batch-processing/index.md

--- a/docs/en/custom-objects/admin/create-extra-table.md
+++ b/docs/en/custom-objects/admin/create-extra-table.md
@@ -71,7 +71,7 @@ In SuperOffice you can create web panels that can contain table information. To 
 
 <!-- Referenced links -->
 [1]: create-extra-field.md
-[2]: ../../automation/webhook/dev/overview.md
+[2]: ../../automation/webhook/dev/index.md
 
 <!-- Referenced images -->
 [img1]: ../../../media/loc/en/custom-objects/create-extra-tables-and-fields.png

--- a/docs/nl/custom-objects/admin/create-extra-table.md
+++ b/docs/nl/custom-objects/admin/create-extra-table.md
@@ -71,7 +71,7 @@ In SuperOffice CRM kunt u webvensters maken die tabelinformatie bevatten. Als u 
 
 <!-- Referenced links -->
 [1]: create-extra-field.md
-[2]: ../../en/automation/webhook/dev/overview.md
+[2]: ../../../en/automation/webhook/dev/index.md
 
 <!-- Referenced images -->
 [img1]: ../../../media/loc/en/custom-objects/create-extra-tables-and-fields.png

--- a/docs/no/custom-objects/admin/create-extra-table.md
+++ b/docs/no/custom-objects/admin/create-extra-table.md
@@ -71,7 +71,7 @@ I SuperOffice CRM kan du opprette nettleserfaner som kan inneholde tabellinforma
 
 <!-- Referenced links -->
 [1]: create-extra-field.md
-[2]: ../../../en/automation/webhook/dev/overview.md
+[2]: ../../../en/automation/webhook/dev/index.md
 
 <!-- Referenced images -->
 [img1]: ../../../media/loc/en/custom-objects/create-extra-tables-and-fields.png

--- a/docs/sv/custom-objects/admin/create-extra-table.md
+++ b/docs/sv/custom-objects/admin/create-extra-table.md
@@ -71,7 +71,7 @@ I SuperOffice CRM kan du skapa webbpaneler som kan innehålla tabellinformation.
 
 <!-- Referenced links -->
 [1]: create-extra-field.md
-[2]: ../../en/automation/webhook/dev/overview.md
+[2]: ../../../en/automation/webhook/dev/index.md
 
 <!-- Referenced images -->
 [img1]: ../../../media/loc/en/custom-objects/create-extra-tables-and-fields.png

--- a/docs/sv/custom-objects/admin/edit-udef-layout.md
+++ b/docs/sv/custom-objects/admin/edit-udef-layout.md
@@ -24,7 +24,7 @@ När du [lägger till nya fält][2], placeras de under varandra som standard. Va
 
 ## Var du ska börja
 
-1. [!inkludera[Gå till Fält och välj flik](includes/goto-fields.md)]
+1. [!include[Gå till Fält och välj flik](includes/goto-fields.md)]
 
 **Hur du väljer fält:**
 

--- a/docs/sv/custom-objects/admin/edit-udef.md
+++ b/docs/sv/custom-objects/admin/edit-udef.md
@@ -16,7 +16,7 @@ index: true
 
 # Redigera användardefinierade fält
 
-1. [!inkludera[Gå till Fält och välj flik](includes/goto-fields.md)]
+1. [!include[Gå till Fält och välj flik](includes/goto-fields.md)]
 
 1. Dubbelklicka på det nödvändiga fältet i listan **Fält**.
 


### PR DESCRIPTION
Point automation/webhook/dev/overview.md references at the merged webhook/dev/index.md target (fixing relative-path depth for da/de/nl/sv along the way), and restore the English [!include[...]] DocFx directive keyword in da/sv edit-udef pages where it had been translated, breaking the include.