### PR TITLE
Fix off-by-one relative path errors (#3051)

### DIFF
--- a/docs/da/request/admin/relation-rules.md
+++ b/docs/da/request/admin/relation-rules.md
@@ -117,5 +117,5 @@ Et stort serviceudfald genererer flere individuelle problemrapporter fra berørt
 [3]: ../../customization/screen-designer/admin/index.md
 
 <!-- Referenced images -->
-[img1]: ../../../../media/loc/en/request/relation-rules.png
-[img2]: ../../../../media/loc/en/request/add-relation-rule.png
+[img1]: ../../../media/loc/en/request/relation-rules.png
+[img2]: ../../../media/loc/en/request/add-relation-rule.png

--- a/docs/de/request/admin/relation-rules.md
+++ b/docs/de/request/admin/relation-rules.md
@@ -117,5 +117,5 @@ Ein größerer Dienstausfall generiert mehrere einzelne Problemberichte von betr
 [3]: ../../customization/screen-designer/admin/index.md
 
 <!-- Referenced images -->
-[img1]: ../../../../media/loc/en/request/relation-rules.png
-[img2]: ../../../../media/loc/en/request/add-relation-rule.png
+[img1]: ../../../media/loc/en/request/relation-rules.png
+[img2]: ../../../media/loc/en/request/add-relation-rule.png

--- a/docs/en/request/admin/relation-rules.md
+++ b/docs/en/request/admin/relation-rules.md
@@ -117,5 +117,5 @@ A major service outage generates multiple individual problem reports from affect
 [3]: ../../customization/screen-designer/admin/index.md
 
 <!-- Referenced images -->
-[img1]: ../../../../media/loc/en/request/relation-rules.png
-[img2]: ../../../../media/loc/en/request/add-relation-rule.png
+[img1]: ../../../media/loc/en/request/relation-rules.png
+[img2]: ../../../media/loc/en/request/add-relation-rule.png

--- a/docs/nl/request/admin/relation-rules.md
+++ b/docs/nl/request/admin/relation-rules.md
@@ -117,5 +117,5 @@ Een grote servicestoring genereert meerdere individuele probleemmeldingen van ge
 [3]: ../../customization/screen-designer/admin/index.md
 
 <!-- Referenced images -->
-[img1]: ../../../../media/loc/en/request/relation-rules.png
-[img2]: ../../../../media/loc/en/request/add-relation-rule.png
+[img1]: ../../../media/loc/en/request/relation-rules.png
+[img2]: ../../../media/loc/en/request/add-relation-rule.png

--- a/docs/no/request/admin/relation-rules.md
+++ b/docs/no/request/admin/relation-rules.md
@@ -117,5 +117,5 @@ Et stort serviceavbrudd genererer flere individuelle problemrapporter fra berør
 [3]: ../../customization/screen-designer/admin/index.md
 
 <!-- Referenced images -->
-[img1]: ../../../../media/loc/en/request/relation-rules.png
-[img2]: ../../../../media/loc/en/request/add-relation-rule.png
+[img1]: ../../../media/loc/en/request/relation-rules.png
+[img2]: ../../../media/loc/en/request/add-relation-rule.png

--- a/docs/sv/request/admin/relation-rules.md
+++ b/docs/sv/request/admin/relation-rules.md
@@ -117,5 +117,5 @@ Ett stort serviceavbrott genererar flera enskilda problemrapporter från berörd
 [3]: ../../customization/screen-designer/admin/index.md
 
 <!-- Referenced images -->
-[img1]: ../../../../media/loc/en/request/relation-rules.png
-[img2]: ../../../../media/loc/en/request/add-relation-rule.png
+[img1]: ../../../media/loc/en/request/relation-rules.png
+[img2]: ../../../media/loc/en/request/add-relation-rule.png

--- a/integrations/superoffice-for-teams/ai-summary.md
+++ b/integrations/superoffice-for-teams/ai-summary.md
@@ -29,4 +29,4 @@ Summaries use neutral, professional business language and are returned as a sing
 > If **Generate Summary** is unavailable, AI Labs is not activated for your SuperOffice tenant. Contact your SuperOffice administrator.
 
 <!-- Referenced links -->
-[1]: ../../docs/en/en/ai/learn/index.md
+[1]: ../../docs/en/ai/learn/index.md


### PR DESCRIPTION
Drop the extra "../" in relation-rules.md image references (all 6 locales) so they resolve into docs/media/loc/en/request/ instead of escaping past the docs/ folder, and remove the duplicated "en/" segment in the Teams ai-summary.md link.