### PR TITLE
Fix missing or misrouted includes for CRM Suite packaging (#3048)

### DIFF
--- a/docs/da/includes/req-core-transition-sales.md
+++ b/docs/da/includes/req-core-transition-sales.md
@@ -1,0 +1,3 @@
+<!-- markdownlint-disable-file MD041 -->
+> [!NOTE]
+> Denne funktion kræver en **Sales Premium**-licens eller **Core**-planen.

--- a/docs/de/includes/req-core-transition-sales.md
+++ b/docs/de/includes/req-core-transition-sales.md
@@ -1,0 +1,3 @@
+<!-- markdownlint-disable-file MD041 -->
+> [!NOTE]
+> Für diese Funktion ist eine **Sales Premium**-Lizenz oder der CRM Suite **Core**-Plan erforderlich.

--- a/docs/en/includes/note-req-project-mgt.md
+++ b/docs/en/includes/note-req-project-mgt.md
@@ -3,4 +3,4 @@
 > Project management requires either a **Sales Premium**, **Service Premium**, or **Marketing Essentials** license, or the **Core** plan. For details, see the [list of user plans][1].
 
 <!-- Referenced links -->
-[1]: ../../../../admin/license/user-plans.md
+[1]: ../admin/license/user-plans.md

--- a/docs/nl/includes/req-core-transition-sales.md
+++ b/docs/nl/includes/req-core-transition-sales.md
@@ -1,0 +1,3 @@
+<!-- markdownlint-disable-file MD041 -->
+> [!NOTE]
+> Voor deze functie is een **Sales Premium**-licentie of het CRM Suite **Core**-plan vereist.

--- a/docs/no/includes/req-core-transition-sales.md
+++ b/docs/no/includes/req-core-transition-sales.md
@@ -1,0 +1,3 @@
+<!-- markdownlint-disable-file MD041 -->
+> [!NOTE]
+> Denne funksjonen krever en **Sales Premium**-lisens eller **Core**-planen.

--- a/docs/sv/includes/req-core-transition-sales.md
+++ b/docs/sv/includes/req-core-transition-sales.md
@@ -1,0 +1,3 @@
+<!-- markdownlint-disable-file MD041 -->
+> [!NOTE]
+> Den här funktionen kräver en **Sales Premium**-licens eller **Core**-planen.

--- a/integrations/gmail-link/archive-emails-as-requests.md
+++ b/integrations/gmail-link/archive-emails-as-requests.md
@@ -23,7 +23,7 @@ index: true
 
 # Create request
 
-[!include[Requirement](../../common/includes/req-service-essentials.md)]
+[!include[Requirement](../../docs/en/includes/req-starter-transition-service.md)]
 
 You can create a request in SuperOffice Service based on an email in your Gmail inbox.
 


### PR DESCRIPTION
Add the missing req-core-transition-sales.md translation for da, de, nl, no, and sv, matching each locale's existing req-growth-transition-sales.md wording with Growth swapped for Core. Fix the extra "../" traversal pointing user-plans.md above the repo root in note-req-project-mgt.md. Point the gmail-link requirement note at the existing req-starter-transition-service.md instead of a common/includes file that was never created.