### PR TITLE
Fix singular/plural typo in mail-service link (#3057)

### DIFF
--- a/docs/en/service/index.yml
+++ b/docs/en/service/index.yml
@@ -181,7 +181,7 @@ additionalContent:
       - title: More
         links:
         - text: Service and Marketing mail
-          url: ../online/mail-service/curl/index.md
+          url: ../online/mail-services/curl/index.md
         - text: Service log files
           url: ../onsite/debug/service-log-files.md
   # footer (optional)


### PR DESCRIPTION
The index.yml referenced online/mail-service/curl/index.md, but the actual folder is online/mail-services (plural).