### PR TITLE
Add 12.1.1412 release notes changelog

### DIFF
--- a/release-notes/12/api/12.1/12.1-netserver-update.md
+++ b/release-notes/12/api/12.1/12.1-netserver-update.md
@@ -1,0 +1,20 @@
+---
+uid: news-api-12.1-netserver
+title: NetServer changes in SuperOffice 12.1
+description: NetServer release notes for SuperOffice 12.1
+keywords: API changes, netserver
+author: SuperOffice AS - Product and Engineering
+date: 06.19.2026
+version: 12.1.1412
+content_type: release-note
+category: api
+language: en
+---
+
+# NetServer changes
+
+Generated on 19 juni 2026.
+
+Compared versions: v12.0.342 to v12.1.1412.
+
+[!include[Generated NetServer changelog](../../../api/changes/changes-netserver-12.1.1412.md)]

--- a/release-notes/12/api/12.1/12.1-update.md
+++ b/release-notes/12/api/12.1/12.1-update.md
@@ -1,0 +1,21 @@
+---
+uid: news-api-12.1
+title: What's new in SuperOffice 12.1
+description: Release notes. What's new in SuperOffice 12.1
+keywords: API changes
+author: SuperOffice AS - Product and Engineering
+date: 06.19.2026
+version: 12.1.1412
+content_type: release-note
+category: api
+language: en
+---
+
+# API changes
+
+Generated on 19 juni 2026.
+
+Compared versions: v12.0.342 to v12.1.1412.
+
+* [NetServer update](12.1-netserver-update.md)
+* [WebAPI update](12.1-webapi-update.md)

--- a/release-notes/12/api/12.1/12.1-webapi-update.md
+++ b/release-notes/12/api/12.1/12.1-webapi-update.md
@@ -1,0 +1,20 @@
+---
+uid: news-api-12.1-webapi
+title: WebAPI changes in SuperOffice 12.1
+description: WebAPI release notes for SuperOffice 12.1
+keywords: API changes, webapi
+author: SuperOffice AS - Product and Engineering
+date: 06.19.2026
+version: 12.1.1412
+content_type: release-note
+category: api
+language: en
+---
+
+# WebAPI changes
+
+Generated on 19 juni 2026.
+
+Compared versions: v12.0.342 to v12.1.1412.
+
+[!include[Generated WebAPI changelog](../../../api/changes/changes-webapi-12.1.1412.md)]

--- a/release-notes/12/api/index.md
+++ b/release-notes/12/api/index.md
@@ -17,9 +17,11 @@ Version 12 of the API reference includes changes from the v11.13 release, listed
 
 * [(12.0)][1]
 
-* [(12.2)][2]
+* [(12.1)][2]
+
+* [(12.2)][3]
 
 <!-- Referenced links-->
 [1]: 12.0/12.0-update.md
-[2]: 12.2/12.2-update.md
-
+[2]: 12.1/12.1-update.md
+[3]: 12.2/12.2-update.md

--- a/release-notes/12/toc.yml
+++ b/release-notes/12/toc.yml
@@ -38,6 +38,15 @@ items:
       href: api/12.2/12.2-webapi-update.md
     - name: Database changes 12.2
       href: ../database/changes-12.2.2072.md
+  - name: 12.1 update
+    href: api/12.1/12.1-update.md
+    items:
+    - name: NetServer Changes
+      href: api/12.1/12.1-netserver-update.md
+    - name: SuperOffice WebApi Changes
+      href: api/12.1/12.1-webapi-update.md
+    - name: Database changes 12.1
+      href: ../database/changes-12.1.1412.md
   - name: 12.0 update
     href: api/12.0/12.0-update.md
     items:

--- a/release-notes/api/changes/changes-netserver-12.1.1412.md
+++ b/release-notes/api/changes/changes-netserver-12.1.1412.md
@@ -1,0 +1,1893 @@
+---
+uid: version_12.1.1412_changes
+date: 19.06.2026
+---
+
+Changes from v12.0.342 and v12.1.1412
+
+## Web Services
+
+These changes are observed in both NetServer SOAP and WebAPI (REST) APIs.
+
+### Assembly: SuperOffice.Services
+
+### New Types
+
+* `SuperOffice.CRM.Services.CustomObject`
+* `SuperOffice.CRM.Services.CustomObjectDefinition`
+* `SuperOffice.CRM.Services.CustomObjectField`
+* `SuperOffice.CRM.Services.CustomObjectMetadata`
+* `SuperOffice.CRM.Services.CustomObjectRelation`
+* `SuperOffice.CRM.Services.ICustomObjectAgent`
+
+### Modified Types
+
+#### SuperOffice.CRM.Services.IBLOBAgent is Modified
+
+* Deleted items
+  * Method `GetChatImageWithSizeAsStreamAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetContactImageAsStreamAsync(Int32, CancellationToken)`
+  * Method `GetContactImageWithSizeAsStreamAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetPersonImageAsStreamAsync(Int32, CancellationToken)`
+  * Method `GetPersonImageWithSizeAsStreamAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetProductImageAsStreamAsync(Int32, CancellationToken)`
+  * Method `GetProductThumbnailAsStreamAsync(Int32, CancellationToken)`
+  * Method `GetProjectImageAsStreamAsync(Int32, CancellationToken)`
+  * Method `GetProjectImageWithSizeAsStreamAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetQuoteLineImageAsStreamAsync(Int32, CancellationToken)`
+  * Method `SaveImageStreamAsync(BlobLinkType, Image, String, CancellationToken)`
+  * Method `SaveImageStreamFromStreamAsync(BlobLinkType, Stream, String, CancellationToken)`
+  * Method `SaveProjectImageAsync(String, Image, CancellationToken)`
+  * Method `SaveProjectImageFromStreamAsync(String, Stream, CancellationToken)`
+  * Method `SetContactImageAsync(Int32, Image, CancellationToken)`
+  * Method `SetContactImageFromStreamAsync(Int32, Stream, CancellationToken)`
+  * Method `SetPersonImageAsync(Int32, Image, CancellationToken)`
+  * Method `SetPersonImageFromStreamAsync(Int32, Stream, CancellationToken)`
+  * Method `SetProductImageAsync(Int32, Image, CancellationToken)`
+  * Method `SetProductImageFromStreamAsync(Int32, Stream, CancellationToken)`
+  * Method `SetProductThumbnailAsync(Int32, Image, CancellationToken)`
+  * Method `SetProductThumbnailFromStreamAsync(Int32, Stream, CancellationToken)`
+  * Method `SetProjectImageAsync(Int32, Image, CancellationToken)`
+  * Method `SetProjectImageFromStreamAsync(Int32, Stream, CancellationToken)`
+* Modified items
+  * Method `GetChatImageWithSizeAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetContactImageAsync(Int32, CancellationToken)`
+  * Method `GetContactImageWithSizeAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetPersonImageAsync(Int32, CancellationToken)`
+  * Method `GetPersonImageWithSizeAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetProductImageAsync(Int32, CancellationToken)`
+  * Method `GetProductThumbnailAsync(Int32, CancellationToken)`
+  * Method `GetProjectImageAsync(Int32, CancellationToken)`
+  * Method `GetProjectImageWithSizeAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetQuoteLineImageAsync(Int32, CancellationToken)`
+* New items
+  * Method `SaveImageStreamAsync(BlobLinkType, Stream, String, CancellationToken)`
+  * Method `SaveProjectImageAsync(String, Stream, CancellationToken)`
+  * Method `SetContactImageAsync(Int32, Stream, CancellationToken)`
+  * Method `SetPersonImageAsync(Int32, Stream, CancellationToken)`
+  * Method `SetProductImageAsync(Int32, Stream, CancellationToken)`
+  * Method `SetProductThumbnailAsync(Int32, Stream, CancellationToken)`
+  * Method `SetProjectImageAsync(Int32, Stream, CancellationToken)`
+
+#### SuperOffice.CRM.Services.ICustomerServiceAgent is Modified
+
+* Deleted items
+  * Method `CreateTicketFromMailDataAsync(Int32, String, CancellationToken)`
+* New items
+  * Method `CreateTicketFromMailDataAsync(Int32, String, Int32, CancellationToken)`
+
+#### SuperOffice.CRM.Services.IListAgent is Modified
+
+* New items
+  * Method `GetAllTicketRelationDefinitionEntitiesAsync(CancellationToken)`
+
+#### SuperOffice.CRM.Services.IPersonAgent is Modified
+
+* Deleted items
+  * Method `GetPersonImageAsStreamAsync(Int32, CancellationToken)`
+  * Method `SetPersonImageAsync(Int32, Image, CancellationToken)`
+  * Method `SetPersonImageFromStreamAsync(Int32, Stream, CancellationToken)`
+* Modified items
+  * Method `GetPersonImageAsync(Int32, CancellationToken)`
+* New items
+  * Method `SetPersonImageAsync(Int32, Stream, CancellationToken)`
+
+#### SuperOffice.CRM.Services.IProjectAgent is Modified
+
+* Deleted items
+  * Method `SetProjectImageAsync(Int32, Image, CancellationToken)`
+* Modified items
+  * Method `GetProjectImageAsync(Int32, CancellationToken)`
+* New items
+  * Method `SetProjectImageAsync(Int32, Stream, CancellationToken)`
+
+#### SuperOffice.CRM.Services.PreviewFaqEntry is Modified
+
+* New items
+  * Property `AccessLevel`
+
+### Assembly: SuperOffice.Services.Implementation
+
+### Deleted Types
+
+* `SuperOffice.CRM.Services.Implementation.BL.CustomObjectEntityImplementation`
+* `SuperOffice.CRM.Services.Implementation.BL.CustomObjectMetadata`
+* `SuperOffice.CRM.Services.Implementation.BL.Relation`
+
+### New Types
+
+* `SuperOffice.CRM.Services.CustomObjectAgent`
+* `SuperOffice.CRM.Services.Implementation.BL.Contracts.ICustomObjectDefinitionImplementation`
+* `SuperOffice.CRM.Services.Implementation.BL.Contracts.ICustomObjectImplementation`
+* `SuperOffice.CRM.Services.Implementation.BL.CustomObjectDefinitionImplementation`
+* `SuperOffice.CRM.Services.Implementation.BL.CustomObjectImplementation`
+
+### Modified Types
+
+#### SuperOffice.CRM.Services.AIAgent is Modified
+
+* Deleted items
+  * Method `AIAgent(ITextServicesImplementation, IBizCardImplementation, ICategorizationStatusResponseImplementation, ICategoryGuessImplementation, IChatbotTurnImplementation, ICopilotDataSourceEntityImplementation, ICopilotEntityImplementation, IFormDesignCarrierImplementation, IFormDesignCssImplementation, ISentimentImplementation, INaturalLanguageSearchImplementation, ICreatePhotoBackgroundImplementation, IRagAnswerImplementation, IRagResultImplementation, IRagStatusImplementation, ISummarizerImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `AIAgent(ITextServicesImplementation, IBizCardImplementation, ICategorizationStatusResponseImplementation, ICategoryGuessImplementation, IChatbotTurnImplementation, ICopilotDataSourceEntityImplementation, ICopilotEntityImplementation, IFormDesignCarrierImplementation, IFormDesignCssImplementation, ISentimentImplementation, INaturalLanguageSearchImplementation, ICreatePhotoBackgroundImplementation, IRagAnswerImplementation, IRagResultImplementation, IRagStatusImplementation, ISummarizerImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.AppointmentAgent is Modified
+
+* Deleted items
+  * Method `AppointmentAgent(IAppointmentImplementation, IAppointmentEntityImplementation, IAppointmentListImplementation, IAppointmentSyncDataImplementation, IDayInformationListImplementation, IMultiAlarmDataImplementation, INextAvailableTimeListImplementation, ISalesActivityImplementation, ISuggestedAppointmentImplementation, ISuggestedAppointmentEntityImplementation, ITaskListItemImplementation, IVideoMeetingReservationImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `AppointmentAgent(IAppointmentImplementation, IAppointmentEntityImplementation, IAppointmentListImplementation, IAppointmentSyncDataImplementation, IDayInformationListImplementation, IMultiAlarmDataImplementation, INextAvailableTimeListImplementation, ISalesActivityImplementation, ISuggestedAppointmentImplementation, ISuggestedAppointmentEntityImplementation, ITaskListItemImplementation, IVideoMeetingReservationImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.ArchiveAgent is Modified
+
+* Deleted items
+  * Method `ArchiveAgent(IActivityFilterImplementation, IArchiveConfigurationImplementation, IArchiveListImplementation, IArchiveListResultImplementation, IRelatedDataImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `ArchiveAgent(IActivityFilterImplementation, IArchiveConfigurationImplementation, IArchiveListImplementation, IArchiveListResultImplementation, IRelatedDataImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.AssociateAgent is Modified
+
+* Deleted items
+  * Method `AssociateAgent(IAssociateImplementation, IAssociateListImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `AssociateAgent(IAssociateImplementation, IAssociateListImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.BatchAgent is Modified
+
+* Deleted items
+  * Method `BatchAgent(IBatchImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `BatchAgent(IBatchImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.BLOBAgent is Modified
+
+* Deleted items
+  * Method `BLOBAgent(IBlobEntityImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+  * Method `GetChatImageWithSizeAsStreamAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetContactImageAsStreamAsync(Int32, CancellationToken)`
+  * Method `GetContactImageWithSizeAsStreamAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetPersonImageAsStreamAsync(Int32, CancellationToken)`
+  * Method `GetPersonImageWithSizeAsStreamAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetProductImageAsStreamAsync(Int32, CancellationToken)`
+  * Method `GetProductThumbnailAsStreamAsync(Int32, CancellationToken)`
+  * Method `GetProjectImageAsStreamAsync(Int32, CancellationToken)`
+  * Method `GetProjectImageWithSizeAsStreamAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetQuoteLineImageAsStreamAsync(Int32, CancellationToken)`
+  * Method `SaveImageStreamAsync(BlobLinkType, Image, String, CancellationToken)`
+  * Method `SaveImageStreamFromStreamAsync(BlobLinkType, Stream, String, CancellationToken)`
+  * Method `SaveProjectImageAsync(String, Image, CancellationToken)`
+  * Method `SaveProjectImageFromStreamAsync(String, Stream, CancellationToken)`
+  * Method `SetContactImageAsync(Int32, Image, CancellationToken)`
+  * Method `SetContactImageFromStreamAsync(Int32, Stream, CancellationToken)`
+  * Method `SetPersonImageAsync(Int32, Image, CancellationToken)`
+  * Method `SetPersonImageFromStreamAsync(Int32, Stream, CancellationToken)`
+  * Method `SetProductImageAsync(Int32, Image, CancellationToken)`
+  * Method `SetProductImageFromStreamAsync(Int32, Stream, CancellationToken)`
+  * Method `SetProductThumbnailAsync(Int32, Image, CancellationToken)`
+  * Method `SetProductThumbnailFromStreamAsync(Int32, Stream, CancellationToken)`
+  * Method `SetProjectImageAsync(Int32, Image, CancellationToken)`
+  * Method `SetProjectImageFromStreamAsync(Int32, Stream, CancellationToken)`
+* Modified items
+  * Method `GetChatImageWithSizeAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetContactImageAsync(Int32, CancellationToken)`
+  * Method `GetContactImageWithSizeAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetPersonImageAsync(Int32, CancellationToken)`
+  * Method `GetPersonImageWithSizeAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetProductImageAsync(Int32, CancellationToken)`
+  * Method `GetProductThumbnailAsync(Int32, CancellationToken)`
+  * Method `GetProjectImageAsync(Int32, CancellationToken)`
+  * Method `GetProjectImageWithSizeAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetQuoteLineImageAsync(Int32, CancellationToken)`
+* New items
+  * Method `BLOBAgent(IBlobEntityImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+  * Method `SaveImageStreamAsync(BlobLinkType, Stream, String, CancellationToken)`
+  * Method `SaveProjectImageAsync(String, Stream, CancellationToken)`
+  * Method `SetContactImageAsync(Int32, Stream, CancellationToken)`
+  * Method `SetPersonImageAsync(Int32, Stream, CancellationToken)`
+  * Method `SetProductImageAsync(Int32, Stream, CancellationToken)`
+  * Method `SetProductThumbnailAsync(Int32, Stream, CancellationToken)`
+  * Method `SetProjectImageAsync(Int32, Stream, CancellationToken)`
+
+#### SuperOffice.CRM.Services.BulkUpdateAgent is Modified
+
+* Deleted items
+  * Method `BulkUpdateAgent(IFieldValueInfoImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `BulkUpdateAgent(IFieldValueInfoImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.ChatAgent is Modified
+
+* Deleted items
+  * Method `ChatAgent(IChatPresenceImplementation, IChatSessionEntityImplementation, IChatTopicAgentImplementation, IChatTopicEntityImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `ChatAgent(IChatPresenceImplementation, IChatSessionEntityImplementation, IChatTopicAgentImplementation, IChatTopicEntityImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.ContactAgent is Modified
+
+* Deleted items
+  * Method `ContactAgent(IContactImplementation, IContactActivityListImplementation, IContactEntityImplementation, IContactListImplementation, IPreviewContactImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `ContactAgent(IContactImplementation, IContactActivityListImplementation, IContactEntityImplementation, IContactListImplementation, IPreviewContactImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.CRMScriptAgent is Modified
+
+* Deleted items
+  * Method `CRMScriptAgent(IScriptImplementation, ICRMScriptEntityImplementation, ITriggerScriptEntityImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `CRMScriptAgent(IScriptImplementation, ICRMScriptEntityImplementation, ITriggerScriptEntityImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.CustomerServiceAgent is Modified
+
+* Deleted items
+  * Method `CustomerServiceAgent(IChatSessionImplementation, ICsFeatureToggleImplementation, ICsSessionKeyImplementation, ICustomerCenterConfigImplementation, ICustomerServiceConfigImplementation, ICustomerServiceStartupImplementation, IEventDataImplementation, IMailboxImplementation, IMailboxEntityImplementation, IPreviewFaqEntryImplementation, IPreviewQuickReplyImplementation, IPreviewReplyTemplateImplementation, IReplyTemplateParsedImplementation, ISmsConfigImplementation, ISmtpTestResultImplementation, IStatisticsDataSetImplementation, ISystemTemplateSettingsImplementation, ITicketInfoImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+  * Method `CreateTicketFromMailDataAsync(Int32, String, CancellationToken)`
+* New items
+  * Method `CustomerServiceAgent(IChatSessionImplementation, ICsFeatureToggleImplementation, ICsSessionKeyImplementation, ICustomerCenterConfigImplementation, ICustomerServiceConfigImplementation, ICustomerServiceStartupImplementation, IEventDataImplementation, IMailboxImplementation, IMailboxEntityImplementation, IPreviewFaqEntryImplementation, IPreviewQuickReplyImplementation, IPreviewReplyTemplateImplementation, IReplyTemplateParsedImplementation, ISmsConfigImplementation, ISmtpTestResultImplementation, IStatisticsDataSetImplementation, ISystemTemplateSettingsImplementation, ITicketInfoImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+  * Method `CreateTicketFromMailDataAsync(Int32, String, Int32, CancellationToken)`
+
+#### SuperOffice.CRM.Services.DashAgent is Modified
+
+* Deleted items
+  * Method `DashAgent(IDashImplementation, IDashCollectionImplementation, IDashThemeImplementation, IDashTileImplementation, IDashTileDefinitionImplementation, IDashTileHtmlImplementation, IPreviewDashImplementation, IPreviewDashTileImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `DashAgent(IDashImplementation, IDashCollectionImplementation, IDashThemeImplementation, IDashTileImplementation, IDashTileDefinitionImplementation, IDashTileHtmlImplementation, IPreviewDashImplementation, IPreviewDashTileImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.DatabaseAgent is Modified
+
+* Deleted items
+  * Method `DatabaseAgent(IDictionaryStepInformationImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `DatabaseAgent(IDictionaryStepInformationImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.DatabaseTableAgent is Modified
+
+* Deleted items
+  * Method `DatabaseTableAgent(ITableRecordImplementation, IMassOperationResultImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `DatabaseTableAgent(ITableRecordImplementation, IMassOperationResultImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.DiagnosticsAgent is Modified
+
+* Deleted items
+  * Method `DiagnosticsAgent(IAnalyticsDataImplementation, ICacheImplementation, ICacheInvalidationImplementation, IEntityCountsImplementation, ILoggingImplementation, IUsageStatsImplementation, ISystemMessageListImplementation, ITableManagerImplementation, IInstallationImplementation, ITicketUsageImplementation, IWebAppUsageImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `DiagnosticsAgent(IAnalyticsDataImplementation, ICacheImplementation, ICacheInvalidationImplementation, IEntityCountsImplementation, ILoggingImplementation, IUsageStatsImplementation, ISystemMessageListImplementation, ITableManagerImplementation, IInstallationImplementation, ITicketUsageImplementation, IWebAppUsageImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.DocumentAgent is Modified
+
+* Deleted items
+  * Method `DocumentAgent(IDocumentImplementation, IDocumentEntityImplementation, IDocumentListImplementation, IDocumentPreviewImplementation, ISuggestedDocumentEntityImplementation, ITemplateVariablesParametersImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `DocumentAgent(IDocumentImplementation, IDocumentEntityImplementation, IDocumentListImplementation, IDocumentPreviewImplementation, ISuggestedDocumentEntityImplementation, ITemplateVariablesParametersImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.DocumentMigrationAgent is Modified
+
+* Deleted items
+  * Method `DocumentMigrationAgent(IDocumentMigrationItemListImplementation, IDocumentTemplateMigrationListImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `DocumentMigrationAgent(IDocumentMigrationItemListImplementation, IDocumentTemplateMigrationListImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.EMailAgent is Modified
+
+* Deleted items
+  * Method `EMailAgent(IEMailAccountImplementation, IEMailAddressImplementation, IEMailAppointmentImplementation, IEMailAttachmentImplementation, IEMailConnectionInfoImplementation, IEMailConnectionInfoExtendedImplementation, IEMailCustomHeaderImplementation, IEMailEntityImplementation, IEMailEnvelopeImplementation, IEMailFolderImplementation, IEMailSOInfoImplementation, ISyncUserAccountImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `EMailAgent(IEMailAccountImplementation, IEMailAddressImplementation, IEMailAppointmentImplementation, IEMailAttachmentImplementation, IEMailConnectionInfoImplementation, IEMailConnectionInfoExtendedImplementation, IEMailCustomHeaderImplementation, IEMailEntityImplementation, IEMailEnvelopeImplementation, IEMailFolderImplementation, IEMailSOInfoImplementation, ISyncUserAccountImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.ErpSyncAgent is Modified
+
+* Deleted items
+  * Method `ErpSyncAgent(IErpConnectionImplementation, IErpConnectionDataImplementation, IErpConnectionListMappingContainerImplementation, IErpSyncFieldValueImplementation, IErpSyncActorTypeMappingImplementation, IErpSyncConnectionSummaryImplementation, IErpSyncConnectorEntityImplementation, IErpSyncDefaultValueImplementation, IErpSyncEngineImplementation, IErpSyncEngineStatusImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `ErpSyncAgent(IErpConnectionImplementation, IErpConnectionDataImplementation, IErpConnectionListMappingContainerImplementation, IErpSyncFieldValueImplementation, IErpSyncActorTypeMappingImplementation, IErpSyncConnectionSummaryImplementation, IErpSyncConnectorEntityImplementation, IErpSyncDefaultValueImplementation, IErpSyncEngineImplementation, IErpSyncEngineStatusImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.FavouriteAgent is Modified
+
+* Deleted items
+  * Method `FavouriteAgent(IFavouriteImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `FavouriteAgent(IFavouriteImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.FindAgent is Modified
+
+* Deleted items
+  * Method `FindAgent(IFindImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `FindAgent(IFindImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.ForeignSystemAgent is Modified
+
+* Deleted items
+  * Method `ForeignSystemAgent(IForeignAppEntityImplementation, IForeignDeviceImplementation, IForeignKeyImplementation, IForeignKeyListImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `ForeignSystemAgent(IForeignAppEntityImplementation, IForeignDeviceImplementation, IForeignKeyImplementation, IForeignKeyListImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.FreeTextAgent is Modified
+
+* Deleted items
+  * Method `FreeTextAgent(IFreeTextImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `FreeTextAgent(IFreeTextImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.Implementation.BL.Contracts.IBlobEntityImplementation is Modified
+
+* Deleted items
+  * Method `GetChatImageWithSizeAsStreamAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetContactImageAsStreamAsync(Int32, CancellationToken)`
+  * Method `GetContactImageWithSizeAsStreamAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetPersonImageAsStreamAsync(Int32, CancellationToken)`
+  * Method `GetPersonImageWithSizeAsStreamAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetProductImageAsStreamAsync(Int32, CancellationToken)`
+  * Method `GetProductThumbnailAsStreamAsync(Int32, CancellationToken)`
+  * Method `GetProjectImageAsStreamAsync(Int32, CancellationToken)`
+  * Method `GetProjectImageWithSizeAsStreamAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetQuoteLineImageAsStreamAsync(Int32, CancellationToken)`
+  * Method `SaveImageStreamAsync(BlobLinkType, Image, String, CancellationToken)`
+  * Method `SaveImageStreamFromStreamAsync(BlobLinkType, Stream, String, CancellationToken)`
+  * Method `SaveProjectImageAsync(String, Image, CancellationToken)`
+  * Method `SaveProjectImageFromStreamAsync(String, Stream, CancellationToken)`
+  * Method `SetContactImageAsync(Int32, Image, CancellationToken)`
+  * Method `SetContactImageFromStreamAsync(Int32, Stream, CancellationToken)`
+  * Method `SetPersonImageAsync(Int32, Image, CancellationToken)`
+  * Method `SetPersonImageFromStreamAsync(Int32, Stream, CancellationToken)`
+  * Method `SetProductImageAsync(Int32, Image, CancellationToken)`
+  * Method `SetProductImageFromStreamAsync(Int32, Stream, CancellationToken)`
+  * Method `SetProductThumbnailAsync(Int32, Image, CancellationToken)`
+  * Method `SetProductThumbnailFromStreamAsync(Int32, Stream, CancellationToken)`
+  * Method `SetProjectImageAsync(Int32, Image, CancellationToken)`
+  * Method `SetProjectImageFromStreamAsync(Int32, Stream, CancellationToken)`
+* Modified items
+  * Method `GetChatImageWithSizeAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetContactImageAsync(Int32, CancellationToken)`
+  * Method `GetContactImageWithSizeAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetPersonImageAsync(Int32, CancellationToken)`
+  * Method `GetPersonImageWithSizeAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetProductImageAsync(Int32, CancellationToken)`
+  * Method `GetProductThumbnailAsync(Int32, CancellationToken)`
+  * Method `GetProjectImageAsync(Int32, CancellationToken)`
+  * Method `GetProjectImageWithSizeAsync(Int32, Int32, Int32, CancellationToken)`
+  * Method `GetQuoteLineImageAsync(Int32, CancellationToken)`
+* New items
+  * Method `SaveImageStreamAsync(BlobLinkType, Stream, String, CancellationToken)`
+  * Method `SaveProjectImageAsync(String, Stream, CancellationToken)`
+  * Method `SetContactImageAsync(Int32, Stream, CancellationToken)`
+  * Method `SetPersonImageAsync(Int32, Stream, CancellationToken)`
+  * Method `SetProductImageAsync(Int32, Stream, CancellationToken)`
+  * Method `SetProductThumbnailAsync(Int32, Stream, CancellationToken)`
+  * Method `SetProjectImageAsync(Int32, Stream, CancellationToken)`
+
+#### SuperOffice.CRM.Services.Implementation.BL.Contracts.IPersonEntityImplementation is Modified
+
+* Deleted items
+  * Method `GetPersonImageAsStreamAsync(Int32, CancellationToken)`
+  * Method `SetPersonImageAsync(Int32, Image, CancellationToken)`
+  * Method `SetPersonImageFromStreamAsync(Int32, Stream, CancellationToken)`
+* Modified items
+  * Method `GetPersonImageAsync(Int32, CancellationToken)`
+* New items
+  * Method `SetPersonImageAsync(Int32, Stream, CancellationToken)`
+
+#### SuperOffice.CRM.Services.Implementation.BL.Contracts.IProjectEntityImplementation is Modified
+
+* Deleted items
+  * Method `SetProjectImageAsync(Int32, Image, CancellationToken)`
+* Modified items
+  * Method `GetProjectImageAsync(Int32, CancellationToken)`
+* New items
+  * Method `SetProjectImageAsync(Int32, Stream, CancellationToken)`
+
+#### SuperOffice.CRM.Services.Implementation.BL.Contracts.ITicketInfoImplementation is Modified
+
+* Deleted items
+  * Method `CreateTicketFromMailDataAsync(Int32, String, CancellationToken)`
+* New items
+  * Method `CreateTicketFromMailDataAsync(Int32, String, Int32, CancellationToken)`
+
+#### SuperOffice.CRM.Services.Implementation.BL.Contracts.ITicketRelationDefinitionEntityImplementation is Modified
+
+* New items
+  * Method `GetAllTicketRelationDefinitionEntitiesAsync(CancellationToken)`
+
+#### SuperOffice.CRM.Services.Implementation.BL.IncomingMessageImplementation is Modified
+
+* Deleted items
+  * Method `IncomingMessageImplementation()`
+* New items
+  * Method `IncomingMessageImplementation(MessagingManager)`
+
+#### SuperOffice.CRM.Services.Implementation.BL.MessageDeliveryStatusImplementation is Modified
+
+* Deleted items
+  * Method `MessageDeliveryStatusImplementation()`
+* New items
+  * Method `MessageDeliveryStatusImplementation(MessagingManager)`
+
+#### SuperOffice.CRM.Services.Implementation.BL.OutgoingMessageImplementation is Modified
+
+* Deleted items
+  * Method `OutgoingMessageImplementation()`
+* New items
+  * Method `OutgoingMessageImplementation(MessagingManager)`
+
+#### SuperOffice.CRM.Services.Implementation.BL.ProviderInfoImplementation is Modified
+
+* Deleted items
+  * Method `ProviderInfoImplementation()`
+* Modified items
+  * Method `GetPluginsAsync(CancellationToken)`
+* New items
+  * Method `ProviderInfoImplementation(MessagingManager)`
+
+#### SuperOffice.CRM.Services.Implementation.BL.TicketInfoImplementation is Modified
+
+* Deleted items
+  * Method `CreateTicketFromMailDataAsync(Int32, String, CancellationToken)`
+* New items
+  * Method `CreateTicketFromMailDataAsync(Int32, String, Int32, CancellationToken)`
+
+#### SuperOffice.CRM.Services.ImportAgent is Modified
+
+* Deleted items
+  * Method `ImportAgent(IImportLineImplementation, IImportErpDataImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `ImportAgent(IImportLineImplementation, IImportErpDataImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.LicenseAgent is Modified
+
+* Deleted items
+  * Method `LicenseAgent(ILicenseImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `LicenseAgent(ILicenseImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.ListAgent is Modified
+
+* Deleted items
+  * Method `ListAgent(IAmountClassEntityImplementation, IAutomatedCategoryUpdateImplementation, IBusinessImplementation, IBusinessListImplementation, ICategoryImplementation, ICategoryEntityImplementation, ICategoryListImplementation, ICompetitorImplementation, ICompetitorListImplementation, ITaskMenuImplementation, IConsentPurposeImplementation, IConsentPurposeListImplementation, IConsentSourceImplementation, IConsentSourceListImplementation, ICountryImplementation, ICountryListImplementation, ICreditedImplementation, ICreditedListImplementation, ICurrencyImplementation, ICurrencyEntityImplementation, ICurrencyListImplementation, ICustomerLanguageImplementation, ICustomerLanguageListImplementation, IDeliveryTermImplementation, IDeliveryTermsListImplementation, IDeliveryTypeImplementation, IDeliveryTypeListImplementation, IDepartmentImplementation, IDepartmentListImplementation, IDocumentTemplateImplementation, IDocumentTemplateEntityImplementation, IDocumentTemplateListImplementation, IExtAppEntityImplementation, IHeadingEntityImplementation, IHierarchyEntityImplementation, ILanguageInfoImplementation, ILanguageInfoListImplementation, ILegalBaseImplementation, ILegalBaseListImplementation, ILinkImplementation, ILinkListImplementation, IListEntityImplementation, IListItemEntityImplementation, ILocalizedTextImplementation, ILocalizedTextListImplementation, IMrMrsImplementation, IMrMrsListImplementation, IPaymentTermImplementation, IPaymentTermsListImplementation, IPaymentTypeImplementation, IPaymentTypeListImplementation, IPositionImplementation, IPositionListImplementation, IPriorityImplementation, IPriorityListImplementation, IProductCategoryImplementation, IProductCategoryListImplementation, IProductFamilyImplementation, IProductFamilyListImplementation, IProductTypeImplementation, IProductTypeListImplementation, IProjectStatusImplementation, IProjectStatusListImplementation, IProjectTypeImplementation, IProjectTypeEntityImplementation, IProjectTypeListImplementation, IQuickReplyImplementation, IRatingImplementation, IRatingListImplementation, IReasonImplementation, IReasonListImplementation, IQuoteApproveReasonImplementation, IQuoteApproveReasonListImplementation, IQuoteDenyReasonImplementation, IQuoteDenyReasonListImplementation, IReasonSoldImplementation, IReasonSoldListImplementation, IReasonStalledImplementation, IReasonStalledListImplementation, IRelationDefinitionEntityImplementation, IResourceEntityImplementation, ISaleStageEntityImplementation, ISaleTypeImplementation, ISaleTypeEntityImplementation, ISaleTypeListImplementation, ISelectionCategoryImplementation, ISelectionCategoryListImplementation, ISourceImplementation, ISourceListImplementation, ISoTaskImplementation, ITaskListImplementation, ITicketCategoryImplementation, ITicketCategoryEntityImplementation, ITicketCategoryListImplementation, ITicketCategoryMembershipEntityImplementation, ITicketPriorityImplementation, ITicketPriorityEntityImplementation, ITicketPriorityListImplementation, ITicketRelationDefinitionEntityImplementation, ITicketStatusEntityImplementation, ITicketStatusListImplementation, ITicketTypeEntityImplementation, ITicketTypeListImplementation, IWebPanelEntityImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `ListAgent(IAmountClassEntityImplementation, IAutomatedCategoryUpdateImplementation, IBusinessImplementation, IBusinessListImplementation, ICategoryImplementation, ICategoryEntityImplementation, ICategoryListImplementation, ICompetitorImplementation, ICompetitorListImplementation, ITaskMenuImplementation, IConsentPurposeImplementation, IConsentPurposeListImplementation, IConsentSourceImplementation, IConsentSourceListImplementation, ICountryImplementation, ICountryListImplementation, ICreditedImplementation, ICreditedListImplementation, ICurrencyImplementation, ICurrencyEntityImplementation, ICurrencyListImplementation, ICustomerLanguageImplementation, ICustomerLanguageListImplementation, IDeliveryTermImplementation, IDeliveryTermsListImplementation, IDeliveryTypeImplementation, IDeliveryTypeListImplementation, IDepartmentImplementation, IDepartmentListImplementation, IDocumentTemplateImplementation, IDocumentTemplateEntityImplementation, IDocumentTemplateListImplementation, IExtAppEntityImplementation, IHeadingEntityImplementation, IHierarchyEntityImplementation, ILanguageInfoImplementation, ILanguageInfoListImplementation, ILegalBaseImplementation, ILegalBaseListImplementation, ILinkImplementation, ILinkListImplementation, IListEntityImplementation, IListItemEntityImplementation, ILocalizedTextImplementation, ILocalizedTextListImplementation, IMrMrsImplementation, IMrMrsListImplementation, IPaymentTermImplementation, IPaymentTermsListImplementation, IPaymentTypeImplementation, IPaymentTypeListImplementation, IPositionImplementation, IPositionListImplementation, IPriorityImplementation, IPriorityListImplementation, IProductCategoryImplementation, IProductCategoryListImplementation, IProductFamilyImplementation, IProductFamilyListImplementation, IProductTypeImplementation, IProductTypeListImplementation, IProjectStatusImplementation, IProjectStatusListImplementation, IProjectTypeImplementation, IProjectTypeEntityImplementation, IProjectTypeListImplementation, IQuickReplyImplementation, IRatingImplementation, IRatingListImplementation, IReasonImplementation, IReasonListImplementation, IQuoteApproveReasonImplementation, IQuoteApproveReasonListImplementation, IQuoteDenyReasonImplementation, IQuoteDenyReasonListImplementation, IReasonSoldImplementation, IReasonSoldListImplementation, IReasonStalledImplementation, IReasonStalledListImplementation, IRelationDefinitionEntityImplementation, IResourceEntityImplementation, ISaleStageEntityImplementation, ISaleTypeImplementation, ISaleTypeEntityImplementation, ISaleTypeListImplementation, ISelectionCategoryImplementation, ISelectionCategoryListImplementation, ISourceImplementation, ISourceListImplementation, ISoTaskImplementation, ITaskListImplementation, ITicketCategoryImplementation, ITicketCategoryEntityImplementation, ITicketCategoryListImplementation, ITicketCategoryMembershipEntityImplementation, ITicketPriorityImplementation, ITicketPriorityEntityImplementation, ITicketPriorityListImplementation, ITicketRelationDefinitionEntityImplementation, ITicketStatusEntityImplementation, ITicketStatusListImplementation, ITicketTypeEntityImplementation, ITicketTypeListImplementation, IWebPanelEntityImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+  * Method `GetAllTicketRelationDefinitionEntitiesAsync(CancellationToken)`
+
+#### SuperOffice.CRM.Services.MarketingAgent is Modified
+
+* Deleted items
+  * Method `MarketingAgent(IAvailableFontImplementation, IFormEntityImplementation, IFormFieldRestrictionImplementation, IFormSubmissionEntityImplementation, IMailingStatisticsImplementation, IPreviewMailingImplementation, IPreviewMailingHeaderImplementation, IShipmentMessageBlockEntityImplementation, IShipmentMessageEntityImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `MarketingAgent(IAvailableFontImplementation, IFormEntityImplementation, IFormFieldRestrictionImplementation, IFormSubmissionEntityImplementation, IMailingStatisticsImplementation, IPreviewMailingImplementation, IPreviewMailingHeaderImplementation, IShipmentMessageBlockEntityImplementation, IShipmentMessageEntityImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.MDOAgent is Modified
+
+* Deleted items
+  * Method `MDOAgent(IMDOListImplementation, ISelectableMDOListImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `MDOAgent(IMDOListImplementation, ISelectableMDOListImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.MessagingAgent is Modified
+
+* Deleted items
+  * Method `MessagingAgent(IIncomingMessageImplementation, IMessageDeliveryStatusImplementation, IOutgoingMessageImplementation, IProviderInfoImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `MessagingAgent(IIncomingMessageImplementation, IMessageDeliveryStatusImplementation, IOutgoingMessageImplementation, IProviderInfoImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.NumberAllocationAgent is Modified
+
+* Deleted items
+  * Method `NumberAllocationAgent(IRefCountEntityImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `NumberAllocationAgent(IRefCountEntityImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.PersonAgent is Modified
+
+* Deleted items
+  * Method `PersonAgent(IConsentPersonImplementation, IPersonImplementation, IPersonEntityImplementation, IPersonImageImplementation, IPersonListImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+  * Method `GetPersonImageAsStreamAsync(Int32, CancellationToken)`
+  * Method `SetPersonImageAsync(Int32, Image, CancellationToken)`
+  * Method `SetPersonImageFromStreamAsync(Int32, Stream, CancellationToken)`
+* Modified items
+  * Method `GetPersonImageAsync(Int32, CancellationToken)`
+* New items
+  * Method `PersonAgent(IConsentPersonImplementation, IPersonImplementation, IPersonEntityImplementation, IPersonImageImplementation, IPersonListImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+  * Method `SetPersonImageAsync(Int32, Stream, CancellationToken)`
+
+#### SuperOffice.CRM.Services.PhoneListAgent is Modified
+
+* Deleted items
+  * Method `PhoneListAgent(IPhoneListImplementation, IPhoneListPreferencesImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `PhoneListAgent(IPhoneListImplementation, IPhoneListPreferencesImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.PocketAgent is Modified
+
+* Deleted items
+  * Method `PocketAgent(ICallerIDImplementation, IPocketStartupDataImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `PocketAgent(ICallerIDImplementation, IPocketStartupDataImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.PreferenceAgent is Modified
+
+* Deleted items
+  * Method `PreferenceAgent(IPreferenceImplementation, IPreferenceDescriptionImplementation, IPreferenceDescriptionLineImplementation, IPreferenceListImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `PreferenceAgent(IPreferenceImplementation, IPreferenceDescriptionImplementation, IPreferenceDescriptionLineImplementation, IPreferenceListImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.ProjectAgent is Modified
+
+* Deleted items
+  * Method `ProjectAgent(IProjectImplementation, IProjectEntityImplementation, IProjectEventImplementation, IProjectEventEntityImplementation, IProjectEventListImplementation, IProjectListImplementation, IProjectMemberImplementation, IProjectMemberListImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+  * Method `SetProjectImageAsync(Int32, Image, CancellationToken)`
+* Modified items
+  * Method `GetProjectImageAsync(Int32, CancellationToken)`
+* New items
+  * Method `ProjectAgent(IProjectImplementation, IProjectEntityImplementation, IProjectEventImplementation, IProjectEventEntityImplementation, IProjectEventListImplementation, IProjectListImplementation, IProjectMemberImplementation, IProjectMemberListImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+  * Method `SetProjectImageAsync(Int32, Stream, CancellationToken)`
+
+#### SuperOffice.CRM.Services.QuoteAgent is Modified
+
+* Deleted items
+  * Method `QuoteAgent(IFieldMetadataImplementation, IPriceListImplementation, IProductImplementation, IQuoteImplementation, IQuoteAlternativeImplementation, IQuoteConnectionImplementation, IQuoteEntityImplementation, IQuoteLineImplementation, IQuoteLineConfigurationImplementation, IQuoteVersionImplementation, IQuoteVersionAttachmentImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `QuoteAgent(IFieldMetadataImplementation, IPriceListImplementation, IProductImplementation, IQuoteImplementation, IQuoteAlternativeImplementation, IQuoteConnectionImplementation, IQuoteEntityImplementation, IQuoteLineImplementation, IQuoteLineConfigurationImplementation, IQuoteVersionImplementation, IQuoteVersionAttachmentImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.RelationAgent is Modified
+
+* Deleted items
+  * Method `RelationAgent(IContactRelationEntityImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `RelationAgent(IContactRelationEntityImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.ReportAgent is Modified
+
+* Deleted items
+  * Method `ReportAgent(IReportLabelLayoutEntityImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `ReportAgent(IReportLabelLayoutEntityImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.ResourceAgent is Modified
+
+* Deleted items
+  * Method `ResourceAgent(IResourceOverrideImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `ResourceAgent(IResourceOverrideImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.SaintAgent is Modified
+
+* Deleted items
+  * Method `SaintAgent(ISaintConfigurationImplementation, IStatusMonitorImplementation, IStatusMonitorPeriodsImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `SaintAgent(ISaintConfigurationImplementation, IStatusMonitorImplementation, IStatusMonitorPeriodsImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.SaleAgent is Modified
+
+* Deleted items
+  * Method `SaleAgent(ISaleImplementation, ISaleEntityImplementation, ISaleListImplementation, ISaleStakeholderImplementation, ISaleStakeholderListImplementation, ISaleSummaryImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `SaleAgent(ISaleImplementation, ISaleEntityImplementation, ISaleListImplementation, ISaleStakeholderImplementation, ISaleStakeholderListImplementation, ISaleSummaryImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.SelectionAgent is Modified
+
+* Deleted items
+  * Method `SelectionAgent(IBoardViewSettingsBaseImplementation, ISelectionEntityImplementation, ISelectionForFindImplementation, ISelectionSummaryItemImplementation, ITypicalSearchesImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `SelectionAgent(IBoardViewSettingsBaseImplementation, ISelectionEntityImplementation, ISelectionForFindImplementation, ISelectionSummaryItemImplementation, ITypicalSearchesImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.SentryAgent is Modified
+
+* Deleted items
+  * Method `SentryAgent(ISentryImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `SentryAgent(ISentryImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.TargetsAgent is Modified
+
+* Deleted items
+  * Method `TargetsAgent(ITargetAssignmentImplementation, ITargetDimensionImplementation, ITargetGroupImplementation, ITargetRevisionImplementation, ITargetRevisionHistoryImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `TargetsAgent(ITargetAssignmentImplementation, ITargetDimensionImplementation, ITargetGroupImplementation, ITargetRevisionImplementation, ITargetRevisionHistoryImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.TicketAgent is Modified
+
+* Deleted items
+  * Method `TicketAgent(IAttachmentEntityImplementation, ITicketImplementation, ITicketEntityImplementation, ITicketMessageImplementation, ITicketMessageEntityImplementation, ITicketRelationEntityImplementation, ITicketSummaryItemImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `TicketAgent(IAttachmentEntityImplementation, ITicketImplementation, ITicketEntityImplementation, ITicketMessageImplementation, ITicketMessageEntityImplementation, ITicketRelationEntityImplementation, ITicketSummaryItemImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.TimeZoneAgent is Modified
+
+* Deleted items
+  * Method `TimeZoneAgent(IPreferredTimeZoneImplementation, IRemoteTimeZoneMethodsImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `TimeZoneAgent(IPreferredTimeZoneImplementation, IRemoteTimeZoneMethodsImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.UserAgent is Modified
+
+* Deleted items
+  * Method `UserAgent(IAccessGatewayInfoImplementation, ICredentialImplementation, IRoleImplementation, IRoleEntityImplementation, IServiceAuthImplementation, ITokenManagementInfoImplementation, IUntrustedCredentialsImplementation, IUserImplementation, IUserGroupImplementation, IUserGroupListImplementation, IUserInfoImplementation, IUserInfoListImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `UserAgent(IAccessGatewayInfoImplementation, ICredentialImplementation, IRoleImplementation, IRoleEntityImplementation, IServiceAuthImplementation, ITokenManagementInfoImplementation, IUntrustedCredentialsImplementation, IUserImplementation, IUserGroupImplementation, IUserGroupListImplementation, IUserInfoImplementation, IUserInfoListImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.UserDefinedFieldInfoAgent is Modified
+
+* Deleted items
+  * Method `UserDefinedFieldInfoAgent(IFieldInfoBaseImplementation, IUserDefinedFieldInfoImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `UserDefinedFieldInfoAgent(IFieldInfoBaseImplementation, IUserDefinedFieldInfoImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.ViewStateAgent is Modified
+
+* Deleted items
+  * Method `ViewStateAgent(ILiveUiConfigImplementation, IHistoryImplementation, IHistoryListImplementation, IUiEventImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `ViewStateAgent(ILiveUiConfigImplementation, IHistoryImplementation, IHistoryListImplementation, IUiEventImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.WebhookAgent is Modified
+
+* Deleted items
+  * Method `WebhookAgent(IWebhookImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `WebhookAgent(IWebhookImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+#### SuperOffice.CRM.Services.WorkflowAgent is Modified
+
+* Deleted items
+  * Method `WorkflowAgent(IEmailFlowImplementation, IWorkflowEventImplementation, IWorkflowEventResultImplementation, IWorkflowFilterImplementation, IWorkflowGoalImplementation, IWorkflowStepBaseImplementation, IWorkflowStepOptionBaseImplementation, IWorkflowTriggerImplementation, IWorkflowWaitForActionImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository, IScriptingConfiguration, IOnlineConfiguration)`
+* New items
+  * Method `WorkflowAgent(IEmailFlowImplementation, IWorkflowEventImplementation, IWorkflowEventResultImplementation, IWorkflowFilterImplementation, IWorkflowGoalImplementation, IWorkflowStepBaseImplementation, IWorkflowStepOptionBaseImplementation, IWorkflowTriggerImplementation, IWorkflowWaitForActionImplementation, ISoRequestItemsAccessor, IDebugUser, IServiceCallsRepository)`
+
+## NetServer Core
+
+The following represent changes to assemblies SoCore, SoDatabase, SoLicense and SuperOffice.Plugins.
+
+### Assembly: SoCore
+
+### Deleted Types
+
+* `SuperOffice.Events.SoEventManager`
+* `SuperOffice.Events.SoGlobalFlush`
+* `SuperOffice.Security.Principal.CurrentWindowsIdentitySupplier`
+
+### New Types
+
+* `SuperOffice.Util.IStructurePatchingHelper`
+* `SuperOffice.Util.StructurePatchingTypeCache`
+* `SuperOffice.Util.TypeAction`
+
+### Modified Types
+
+#### Microsoft.Extensions.DependencyInjection.NetServerCoreOptionsBuilder is Modified
+
+* Deleted items
+  * Method `UseOnPremAD()`
+
+#### SuperOffice.Configuration.ConfigFile is Modified
+
+* Deleted items
+
+##### SuperOffice.Configuration.ConfigFile.CssSprite is Deleted
+
+##### SuperOffice.Configuration.ConfigFile.Factory is Deleted
+
+##### SuperOffice.Configuration.ConfigFile.ICssSpriteConfiguration is Deleted
+
+##### SuperOffice.Configuration.ConfigFile.IDataSessionConfiguration is Deleted
+
+##### SuperOffice.Configuration.ConfigFile.IFactoryConfiguration is Deleted
+
+##### SuperOffice.Configuration.ConfigFile.IInfrastructureConfiguration is Deleted
+
+##### SuperOffice.Configuration.ConfigFile.IIntellisyncConnectorConfiguration is Deleted
+
+##### SuperOffice.Configuration.ConfigFile.Infrastructure is Deleted
+
+##### SuperOffice.Configuration.ConfigFile.IntellisyncConnector is Deleted
+
+##### SuperOffice.Configuration.ConfigFile.IScriptingConfiguration is Deleted
+
+##### SuperOffice.Configuration.ConfigFile.ISecurityActiveDirectoryCredentialPluginConfiguration is Deleted
+
+##### SuperOffice.Configuration.ConfigFile.ISecuritySentryConfiguration is Deleted
+
+##### SuperOffice.Configuration.ConfigFile.ISyncConfiguration is Deleted
+
+##### SuperOffice.Configuration.ConfigFile.IThreadingConfiguration is Deleted
+
+##### SuperOffice.Configuration.ConfigFile.Scripting is Deleted
+
+##### SuperOffice.Configuration.ConfigFile.Sync is Deleted
+
+##### SuperOffice.Configuration.ConfigFile.Threading is Deleted
+
+* Modified items
+
+##### SuperOffice.Configuration.ConfigFile.Data is Modified
+
+* Deleted items
+
+##### .Data.Session is Deleted
+
+##### SuperOffice.Configuration.ConfigFile.Security is Modified
+
+* Deleted items
+
+##### .Security.ActiveDirectoryCredentialPlugin is Deleted
+
+##### .Security.Sentry is Deleted
+
+#### SuperOffice.CRM.UserPreferenceStrings is Modified
+
+* Deleted items
+
+##### SuperOffice.CRM.UserPreferenceStrings.Phone is Deleted
+
+##### SuperOffice.CRM.UserPreferenceStrings.SentryAddonNames is Deleted
+
+* Modified items
+
+##### SuperOffice.CRM.UserPreferenceStrings.Mail is Modified
+
+* New items
+  * Field `.MailShowMyEmails`
+
+* New items
+
+##### SuperOffice.CRM.UserPreferenceStrings.License is New
+
+#### SuperOffice.Data.TicketLogAction is Modified
+
+* New items
+  * Field `Message_DeleteMessage`
+
+#### SuperOffice.Globalization.RC is Modified
+
+* New items
+  * Field `SR_ADMIN_WEBHOOKS_CRMSCRIPT_DISABLED_TOOLTIP`
+  * Field `SR_FDLG_ADDPERIOD`
+  * Field `SR_FENCING_PROJECT_MAX_GENERAL`
+  * Field `SR_FORMS_NOT_SELECTED`
+  * Field `SR_MM_TO`
+  * Field `SR_PD_Functions_JoinPilotForStartPage_DESC`
+  * Field `SR_PD_Functions_JoinPilotForStartPage_NAME`
+  * Field `SR_PROJECT_COMPLETED_DISABLED`
+  * Field `SR_TICKET_ARCHIVE_SPAM_SELECTED_REQUEST_CONFIRMATION`
+  * Field `SR_TICKET_DRAFT_HAS_INVISIBLE_CHANGES`
+  * Field `SR_TICKET_OPEN_FULL_VIEW`
+  * Field `SR_TICKET_OPEN_IN_DIALOG`
+  * Field `SR_TICKET_RESTRICTED_FAQ`
+  * Field `SR_WEBHOOK_SEE_DETAILS`
+
+#### SuperOffice.Security.Principal.INSAuthenticator is Modified
+
+* New items
+  * Method `AuthenticateAsync(IEnumerable<ClaimsIdentity>, CancellationToken)`
+
+#### SuperOffice.SoSession is Modified
+
+* New items
+  * Method `AuthenticateAsync(ClaimsIdentity, CancellationToken, Claim[])`
+  * Method `SignInToCurrentContext()`
+
+#### SuperOffice.Threading.AsyncQueue<TItem> is Modified
+
+* New items
+  * Property `Count`
+  * Method `DrainQueue()`
+
+#### SuperOffice.Threading.AsyncQueueBase<TItem> is Modified
+
+* New items
+  * Property `Count`
+  * Method `DrainQueue()`
+
+#### SuperOffice.Threading.IAsyncQueueBase<TItem> is Modified
+
+* New items
+  * Property `Count`
+  * Method `DrainQueue()`
+
+#### SuperOffice.Util.ImageStreamUtils is Modified
+
+* New items
+  * Method `FitToPng(Stream, Int32, Int32)`
+  * Method `FitToPngBytes(Stream, Int32, Int32)`
+  * Method `GetNoPhotoPng()`
+  * Method `GetTransparentPixelPng()`
+
+#### SuperOffice.Util.StructurePatchingHelper is Modified
+
+* Deleted items
+  * Method `ApplyActions(Object, Attribute[], String, Dictionary<Type, TypeAction>, Action<Object>)`
+  * Method `ApplyActions(Object, Dictionary<Type, TypeAction>, Action<Object>)`
+
+##### SuperOffice.Util.StructurePatchingHelper.TypeAction is Deleted
+
+* New items
+  * Method `StructurePatchingHelper(StructurePatchingTypeCache)`
+  * Method `ApplyActions(Object, Attribute[], String, Dictionary<Type, TypeAction>, Action<Object>)`
+  * Method `ApplyActions(Object, Dictionary<Type, TypeAction>, Action<Object>)`
+
+### Assembly: SoDatabase
+
+### Deleted Types
+
+* `SuperOffice.CRM.Security.ISentryPlugin`
+* `SuperOffice.CRM.Security.ISentryPluginQueryTableUpdater`
+* `SuperOffice.CRM.Security.SentryPluginAttribute`
+* `SuperOffice.CRM.Security.SentryPluginQueryTableUpdaterAttribute`
+
+### New Types
+
+* `SuperOffice.CRM.Webhooks.WebhookBannerNotification`
+* `SuperOffice.CRM.Webhooks.WebhookBannerQueue`
+* `SuperOffice.Data.SQL.ArgumentField`
+* `SuperOffice.Data.SQL.Concat`
+
+### Modified Types
+
+#### SuperOffice.CRM.Cache.AssociateCache is Modified
+
+* Deleted items
+  * Method `GetAssociateImageAsync(Int32, Int32, Int32)`
+* Modified items
+  * Method `GetPersonImageAsync(Int32)`
+
+#### SuperOffice.CRM.Cache.MDOPreferenceCache is Modified
+
+* New items
+  * Method `IsGroupingAllowed(String, String)`
+
+#### SuperOffice.CRM.Security.ProjectFencingCache is Modified
+
+* New items
+  * Method `IsCacheInvalidatedAsync(String, Int32, PrivateSave, CancellationToken)`
+
+#### SuperOffice.CRM.Security.RelationsSentry is Modified
+
+* New items
+  * Method `GetMainRight()`
+
+#### SuperOffice.CRM.Security.Sentry is Modified
+
+* Deleted items
+  * Method `DemandPlugins()`
+
+#### SuperOffice.CRM.Ticket.RelatedTicketInfo is Modified
+
+* New items
+  * Field `BaseStatus`
+  * Field `RelationComment`
+  * Field `RelationCreatedAt`
+  * Field `TicketCreatedAt`
+  * Field `TicketStatus`
+  * Field `TicketStatusDisplayValue`
+
+#### SuperOffice.CRM.Ticket.TicketRelationHelper is Modified
+
+* Deleted items
+  * Method `GetTicketRelationsInfoAsync(Int32, Int32, Int32, Int32, CancellationToken)`
+* New items
+  * Method `GetTicketRelationsInfoAsync(Int32, CancellationToken)`
+
+#### SuperOffice.CRM.Webhooks.ISystemWebhookPlugin is Modified
+
+* Deleted items
+  * Method `SaveWebhookAsync(Webhook)`
+* New items
+  * Method `SaveWebhookAsync(Webhook, Boolean)`
+
+#### SuperOffice.CRM.Webhooks.IWebhookManager is Modified
+
+* Deleted items
+  * Method `SaveWebhookAsync(Webhook)`
+* New items
+  * Method `SaveWebhookAsync(Webhook, Boolean)`
+
+#### SuperOffice.Data.Cache.CacheBlockLogger is Modified
+
+* New items
+  * Method `KeepAll()`
+
+#### SuperOffice.Data.DatabaseStepAttribute is Modified
+
+* Deleted items
+  * Method `DatabaseStepAttribute(String, Int32, ReleaseState)`
+* New items
+  * Method `DatabaseStepAttribute(String, Int32)`
+
+#### SuperOffice.Data.Dialect.Dialect is Modified
+
+* Deleted items
+  * Method `GenerateCaseInsensitivity(FieldInfo, Parameter, String)`
+* New items
+  * Method `QuoteAliasIfNeeded(String)`
+  * Method `ToSql(ArgumentField)`
+  * Method `ToSql(Concat)`
+
+#### SuperOffice.Data.Dictionary.SoField is Modified
+
+* New items
+  * Method `ConvertFieldDataTypeToDictFieldType(FieldDataType)`
+
+#### SuperOffice.Data.S is Modified
+
+* Modified items
+
+##### SuperOffice.Data.S.FieldExpression is Modified
+
+* New items
+  * Method `.FieldExpressionConcat(Argument[])`
+
+#### SuperOffice.Data.SoConnection is Modified
+
+* New items
+  * Method `OpenAsync(CancellationToken)`
+
+#### SuperOffice.Data.SoDatabase is Modified
+
+* Deleted items
+  * Property `IgnoreADUsernameAuthentication`
+
+#### SuperOffice.Data.SQL.Aggregation is Modified
+
+* New items
+  * Method `GetReferencedFields()`
+
+#### SuperOffice.Data.SQL.Argument is Modified
+
+* Modified items
+  * Method `Between(Argument, Argument)`
+  * Method `Equal(Argument)`
+  * Method `GreaterThan(Argument)`
+  * Method `GreaterThanOrEqual(Argument)`
+  * Method `HasAll(Argument[])`
+  * Method `HasAny(Argument[])`
+  * Method `HasFlag(Argument)`
+  * Method `HasNoFlag(Argument)`
+  * Method `In(Argument[])`
+  * Method `IsNotNull()`
+  * Method `IsNull()`
+  * Method `LessThan(Argument)`
+  * Method `LessThanOrEqual(Argument)`
+  * Method `Like(Argument)`
+  * Method `Like(String)`
+  * Method `MissingAll(Argument[])`
+  * Method `MissingAny(Argument[])`
+  * Method `NotBetween(Argument, Argument)`
+  * Method `NotIn(Argument[])`
+  * Method `NotLike(Argument)`
+  * Method `UnEqual(Argument)`
+* New items
+  * Method `GetReferencedFields()`
+
+#### SuperOffice.Data.SQL.ArgumentFunction is Modified
+
+* New items
+  * Method `GetReferencedFields()`
+
+#### SuperOffice.Data.SQL.Case is Modified
+
+* New items
+  * Method `GetReferencedFields()`
+
+#### SuperOffice.Data.SQL.FieldInfo is Modified
+
+* New items
+  * Method `GetReferencedFields()`
+
+#### SuperOffice.Data.SQL.MathematicalExpression is Modified
+
+* New items
+  * Method `GetReferencedFields()`
+
+#### SuperOffice.Data.SQL.TableInfo is Modified
+
+* Deleted items
+  * Property `IsDictionaryTable`
+  * Property `ProtAll`
+
+#### SuperOffice.Data.TablesInfo is Modified
+
+#### SuperOffice.Util.IAppointmentUtility is Modified
+
+* Modified items
+  * Method `GetConnectionInfoAsync()`
+
+### Assembly: SoDatabase.BusinessLogic
+
+### Deleted Types
+
+* `SuperOffice.CRM.ArchiveLists.IRestrictionStorage`
+* `SuperOffice.CRM.ArchiveLists.IRestrictionStorageMappingConfiguration`
+* `SuperOffice.CRM.ArchiveLists.RestrictionStorageFactory`
+* `SuperOffice.CRM.ArchiveLists.RestrictionStoragePluginAttribute`
+* `SuperOffice.Data.Dialect.Oracle12`
+* `SuperOffice.Data.Dialect.OracleCommon`
+* `SuperOffice.Data.Dialect.OracleMassOperations`
+* `SuperOffice.Data.Dialect.OracleOperations`
+
+### Modified Types
+
+#### SuperOffice.CRM.ArchiveLists.AppointmentExtenderBase is Modified
+
+* Deleted items
+  * Method `ModifyQuery()`
+  * Method `ProcessOrderBy()`
+
+#### SuperOffice.CRM.ArchiveLists.ContactExtenderBase is Modified
+
+* Deleted items
+  * Method `StandardNameDept()`
+
+#### SuperOffice.CRM.ArchiveLists.ExtensibleColumnsBase is Modified
+
+* Modified items
+  * Method `MapSimpleCustomField(FieldInfo, ArchiveColumnInfo[])`
+  * Method `WantColumnForAnything(ArchiveColumnInfo[])`
+  * Method `WantColumnForAnything(String[])`
+  * Method `WantColumnForOrderBy(ArchiveColumnInfo[])`
+  * Method `WantColumnForOrderBy(String[])`
+  * Method `WantColumnForOutput(ArchiveColumnInfo[])`
+  * Method `WantColumnForOutput(List<ArchiveColumnInfo>)`
+  * Method `WantColumnForOutput(String[])`
+  * Method `WantColumnForRestriction(ArchiveColumnInfo[])`
+  * Method `WantColumnForRestriction(String[])`
+
+#### SuperOffice.CRM.ArchiveLists.Joiners.AppointmentTextConversionExtender is Modified
+
+* Deleted items
+  * Method `GetDescription(SoDataReader)`
+  * Method `RequestDescription()`
+  * Method `RequestDescriptionForRestriction()`
+
+#### SuperOffice.CRM.ArchiveLists.PersonContactExtenderHelper is Modified
+
+* Deleted items
+  * Method `GetNameAndDepartment(SoDataReader, ContactTableInfo, Boolean)`
+* New items
+  * Field `C_NameDepartmentColumnBaseName`
+  * Method `CreateNameAndDepartmentArgumentField(ArchiveSelect, ArchiveColumnInfo)`
+  * Method `GetNameAndDepartment(SoDataReader, Boolean, ArchiveColumnInfo)`
+  * Method `PopulateNameAndDepartmentFromReader(SoDataReader, ArchiveRow, Boolean, ArchiveColumnInfo)`
+  * Method `SetContactTableInfo(ContactTableInfo)`
+  * Method `StandardNameDepartmentColumn()`
+
+#### SuperOffice.CRM.ArchiveLists.RestrictionCriteriaStorage is Modified
+
+* New items
+  * Method `GetProvider(String)`
+  * Method `GetProvider(String, String)`
+  * Method `GetRestrictionFromAllGroupsViaStorage(ArchiveRestrictionInfo[], String, String, String, String)`
+  * Method `GetRestrictionFromAllGroupsViaStorage(ArchiveRestrictionInfo[], String, String, String, String, String)`
+  * Method `GetRestrictionViaStorage(ArchiveRestrictionInfo[], String, String, String, String)`
+  * Method `GetRestrictionViaStorage(ArchiveRestrictionInfo[], String, String, String, String, String)`
+
+#### SuperOffice.CRM.ArchiveLists.RestrictionStorageBase is Modified
+
+* Modified items
+  * Property `Context`
+
+#### SuperOffice.CRM.CustomObject.CustomObjectHelper is Modified
+
+* New items
+  * Method `CurrentUserHasAtLeastReadOnExtraTable(Int32)`
+  * Method `CurrentUserHasAtLeastReadOnExtraTable(String)`
+
+#### SuperOffice.CRM.Entities.AppointmentMatrix is Modified
+
+* Modified items
+
+##### SuperOffice.CRM.Entities.AppointmentMatrix.SendMails is Modified
+
+* Deleted items
+  * Method `.SendMailsBeginInvoke(String, String, String, Boolean, String, String, String, Boolean, String, MailItem[], AsyncCallback, Object)`
+  * Method `.SendMailsInvoke(String, String, String, Boolean, String, String, String, Boolean, String, MailItem[])`
+* New items
+  * Method `.SendMailsBeginInvoke(String, String, String, Boolean, String, String, String, Boolean, String, Boolean, MailItem[], AsyncCallback, Object)`
+  * Method `.SendMailsInvoke(String, String, String, Boolean, String, String, String, Boolean, String, Boolean, MailItem[])`
+
+* New items
+  * Method `SetSendMailToParticipants(Boolean, String, String, String, Boolean, String, String, String, Boolean, Boolean, String)`
+
+#### SuperOffice.CRM.Entities.IAppointmentMatrix is Modified
+
+* New items
+  * Method `SetSendMailToParticipants(Boolean, String, String, String, Boolean, String, String, String, Boolean, Boolean, String)`
+
+#### SuperOffice.CRM.Mail.EMailHelper is Modified
+
+* Deleted items
+  * Method `ResolveAddressAsync(String, CancellationToken, Boolean)`
+* New items
+  * Method `ResolveAddressAsync(String, Boolean, CancellationToken)`
+
+#### SuperOffice.CRM.Mail.SendMailQueue is Modified
+
+* New items
+  * Method `SendMail(String, String, String, Boolean, String, String, String, Boolean, String, Boolean, MailItem[])`
+
+#### SuperOffice.CRM.Mail.SendMailQueueArgument is Modified
+
+* New items
+  * Property `UseGraphApi`
+  * Method `SendMailQueueArgument(String, String, String, Boolean, String, String, String, Boolean, String, Boolean, MailItem[])`
+
+#### SuperOffice.CRM.Mail.SoMail is Modified
+
+* New items
+  * Method `BeginSend(String, String, String, Boolean, Boolean)`
+
+#### SuperOffice.CRM.TicketMessage.TicketMessageHelper is Modified
+
+* Deleted items
+  * Method `GetQuotedMessageContentAsync(Int32, Int32, CancellationToken)`
+* New items
+  * Method `BuildQuotedMessageAsync(IEnumerable<KeyValuePair<String, String>>, DateTime, String, String, String, String, TicketMessageType, String, CancellationToken)`
+
+#### SuperOffice.CRM.Webhooks.DefaultWebhookPlugin is Modified
+
+* Deleted items
+  * Method `GetAssociateEjUserIds(Int32[])`
+  * Method `QueueInAppNotificationAsync(Int32, String, String, CancellationToken)`
+  * Method `SaveWebhookAsync(Webhook)`
+* New items
+  * Method `ResetWebhookUsageAsync(Int32, CancellationToken)`
+  * Method `SaveWebhookAsync(Webhook, Boolean)`
+
+#### SuperOffice.CRM.Webhooks.WebhookManager is Modified
+
+* Deleted items
+  * Method `SaveWebhookAsync(Webhook)`
+* New items
+  * Method `AbandonPendingWebhooks()`
+  * Method `SaveWebhookAsync(Webhook, Boolean)`
+
+#### SuperOffice.Data.Dialect.DatabaseOperations is Modified
+
+* Modified items
+  * Method `WipeAndImportTableAsync(SoTable, IEnumerable<Object[]>, CancellationToken)`
+* New items
+  * Method `UpdateStatisticsAsync(SoTable, CancellationToken)`
+
+#### SuperOffice.Data.Dialect.SqlServerOperations is Modified
+
+* Deleted items
+  * Property `NumShipoutThreads`
+* Modified items
+  * Method `InnerTruncateTableAsync(SoTable, TruncateOptions)`
+* New items
+  * Method `UpdateStatisticsAsync(SoTable, CancellationToken)`
+
+#### SuperOffice.Util.AppointmentUtility is Modified
+
+* Modified items
+  * Method `GetConnectionInfoAsync()`
+
+### Assembly: SuperOffice.Plugins
+
+### Deleted Types
+
+* `SuperOffice.Events.EventEnginePluginAttribute`
+* `SuperOffice.Events.IEventEngine`
+* `SuperOffice.Events.SendEventArguments`
+
+## Continuous Database
+
+The following represent changes to SuperOffice database schema.
+
+### Assembly: SuperOffice.CD.DSL.Database
+
+### Modified Types
+
+#### .Optimization_01_TtlForeignKeyIndexes is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.Database.SuperOffice80 is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.Database.TicketLogAction is Modified
+
+* New items
+  * Field `Message_DeleteMessage`
+
+#### SuperOffice.CD.DSL.Database.AiStep1 is Modified
+
+#### SuperOffice.CD.DSL.Database.ChatStep1 is Modified
+
+#### SuperOffice.CD.DSL.Database.ChatStep15_LunchHours is Modified
+
+#### SuperOffice.CD.DSL.Database.ChatStep16_WidgetSettings is Modified
+
+#### SuperOffice.CD.DSL.Database.ChatStep17_Country is Modified
+
+#### SuperOffice.CD.DSL.Database.ChatStep18_MessageNotification is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.ChatStep19_OfflineFromQueue is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.ChatStep20_Rating is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.ChatStep21_ChatTopicWidgetBadgeColor is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.ChatStep22_ChatTopicWidgetBadgeColor is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.ChatStep3 is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.ChatStep4 is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.ChatStep5 is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.ChatStep6 is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.ChatStep7_OpeningHours is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.ChatStep8_CustomQueue is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.ChatStep9_CSLanguage is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.ConsentManagementStep09_MigrationFromNomailing is Modified
+
+#### SuperOffice.CD.DSL.Database.ConsentManagementStep1 is Modified
+
+#### SuperOffice.CD.DSL.Database.ConsentManagementStep10_Indexes is Modified
+
+#### SuperOffice.CD.DSL.Database.ConsentManagementStep11_Travel is Modified
+
+#### SuperOffice.CD.DSL.Database.ConsentManagementStep12_Erp is Modified
+
+#### SuperOffice.CD.DSL.Database.ConsentManagementStep13_Erp is Modified
+
+#### SuperOffice.CD.DSL.Database.CRMScriptStep01_Tracing is Modified
+
+#### SuperOffice.CD.DSL.Database.CRMScriptStep02_ExtraMenusId is Modified
+
+#### SuperOffice.CD.DSL.Database.CRMScriptStep03_UniqueIdentifier is Modified
+
+#### SuperOffice.CD.DSL.Database.CRMScriptStep04_PopulateGuid is Modified
+
+#### SuperOffice.CD.DSL.Database.CRMScriptStep05_GuidUnique is Modified
+
+#### SuperOffice.CD.DSL.Database.CRMScriptStep05_ScreenDefAutoSave is Modified
+
+#### SuperOffice.CD.DSL.Database.CRMScriptStep07_ObsoleteTrigger is Modified
+
+#### SuperOffice.CD.DSL.Database.CRMScriptStep08_ScriptType is Modified
+
+#### SuperOffice.CD.DSL.Database.CRMScriptStep09_ScriptTraceRunFrames is Modified
+
+#### SuperOffice.CD.DSL.Database.CRMScriptStep10_ScriptTraceEmail is Modified
+
+#### SuperOffice.CD.DSL.Database.CRMScriptStep11_ScreenChooserFK is Modified
+
+#### SuperOffice.CD.DSL.Database.CS_07_TicketMessageImportance is Modified
+
+#### SuperOffice.CD.DSL.Database.CS_27_Registry288 is Modified
+
+#### SuperOffice.CD.DSL.Database.CS_40_ListClean_RequestTypes is Modified
+
+#### SuperOffice.CD.DSL.Database.CS_41_Reorg_RequestTypes is Modified
+
+#### SuperOffice.CD.DSL.Database.CS_42_Recreate_TicketType is Modified
+
+#### SuperOffice.CD.DSL.Database.CS_43_Adjust_TicketType is Modified
+
+#### SuperOffice.CD.DSL.Database.CS_45_TicketType_Mirroring is Modified
+
+#### SuperOffice.CD.DSL.Database.CSStep1 is Modified
+
+#### SuperOffice.CD.DSL.Database.CSStep2 is Modified
+
+#### SuperOffice.CD.DSL.Database.CSStep3_SMessageLongDescription is Modified
+
+#### SuperOffice.CD.DSL.Database.ExternalOwnerStep1 is Modified
+
+#### SuperOffice.CD.DSL.Database.InboxStep1 is Modified
+
+#### SuperOffice.CD.DSL.Database.Mailing_01_SortingTypes is Modified
+
+#### SuperOffice.CD.DSL.Database.Optimization_02_UserPreferences is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.PocketStep01 is Modified
+
+#### SuperOffice.CD.DSL.Database.PocketStep04 is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.Steps_Chat.ChatStep11_ChatTopicEnumTypes is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Chat.ChatStep12_ChatSessionEnumTypes is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Chat.ChatStep13_ChatBotFields is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Chat.ChatStep14_ChatBotFields is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_ConfigurableScreen.ConfigurableScreen_01_TableAndEnum is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_ConfigurableScreen.ConfigurableScreen_02_StateEnum is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_ConfigurableScreen.ConfigurableScreen_05_AppliesTo is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_ConfigurableScreen.ConfigurableScreen_06_TaskListItemTable is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_ConfigurableScreen.ConfigurableScreen_07_TaskMenuEncoding is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_ConfigurableScreen.ConfigurableScreen_08_TaskMenuPriming is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_ConfigurableScreen.ConfigurableScreen_09_TicketTabPanesIdUpdate is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_ConfigurableScreen.ConfigurableScreen_10_Remove_FT_NSTicketType is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_ConfigurableScreen.ConfigurableScreen_11_CustomMdoComponent2ForTicketStatus is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_ConfigurableScreen.Mailing_10_DomainList is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_ConsentManagement.ConsentManagementStep14_SetStore is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_ConsentManagement.ConsentManagementStep15_NameChange is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_ConsentManagement.ConsentManagementStep16_SetGdprPref is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_ConsentManagement.ConsentManagementStep17_RemoveHashFromKeys is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_ConsentManagement.ConsentManagementStep18_MoreNameChange is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_ConsentManagement.ConsentManagementStep19_MoreNameChange is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_ConsentManagement.ConsentManagementStep20_Translations is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_ConsentManagement.ConsentManagementStep21_Translations is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_ConsentManagement.ConsentManagementStep22_ClearInvalidMailItemIds is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Copilot.Copilot_01_Tables is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Copilot.Copilot_02_PrimingData is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_04_EnumTypes is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_05_TicketEnumTypes is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_06_TicketMessageEnumTypes is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_08_Tags is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_10_ContactId_AssociateId is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_11_SListElement_Flags is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_12_attachment_location is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_13_PasswordRules is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_14_MailInFilter_Dsn is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_15_TicketSentiment is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_16_MoveSuggestedCategory is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_17_TicketLogAction_details is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_18_MailboxEnumTypes is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_22_MailInFilter_AI is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_23_NotifyExpiry is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_24_MsFilterTags is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_25_CustomNotifyUrl is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_26_InboxUidlLength is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_28_ReplyTemplateBodyFlags is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_33_EjMessageMessageIdLength is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_34_TicketLogActionEnum is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_35_EjMessageBadge is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_36_NotifyRegistered is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_38_TicketTimeSpent is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_39_RequestType is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_44_TicketTimeSpan is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_46_TicketTypeIsDefault is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_47_TicketType_MailboxAndFilter is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_48_TicketTypeIcon is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_49_TicketTypeIcon is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_50_TicketTypeTooltip is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_51_CreatedBy_AssocToEjUser is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_52_LastExecutedByHttp is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_53_ExtraTablesIconId is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_54_TicketTypeNewColumns is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_55_TicketTypeUserGroups is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_56_TicketType_reply_forward_no_signature is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_57_Ejscript_SourceCode is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_58_Ejscript_SourceCode is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_59_TicketType_reply_external_as_default is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_60_Ejscript_SourceMap is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_61_EjscriptVerb is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_62_ExtraTables_TableNum is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_63_ExtraTables_TableNumValue is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_64_Model_NextTableNumber is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_65_Model_NextTableNumberFix is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_66_CustomObjects_DataRight_Priming is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_67_UpdateCustomObjectSelection_TableNumber is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_68_TicketRelation is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_69_TicketRelation2 is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_70_TicketRelationDef is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.CS_72_TicketStatusSpam is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.Mailing_04_ShipmentStatus is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.Mailing_05_FormSubmissionId is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_CS.Mailing_06_BounceCode is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Dashboard.DashboardStep01_Initial is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Dashboard.DashboardStep13_CurrencyCode is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Dashboard.DashboardStep14_Sentry is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Dashboard.DashboardStep21_ThemeData is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Dashboard.DashboardStep22_QuickFilterInfo is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Dashboard.DashboardStep23_DefaultDashboardNoOwner is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Dashboard.DashboardStep24_DefaultDashboardNoOwner is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_FollowUpDialog.FollowUpDialog_01_Text_Table_Modifications_And_New_Fields is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_FollowUpDialog.FollowUpDialog_02_AppointmentTable_SendEmail_Field is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_FollowUpDialog.FollowUpDialog_03_AddIndexOnAppointmentAgenda is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_FollowUpDialog.FollowUpDialog_04_Add_Sentry_To_Html_Text is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_LandingPage.LandingPage_01_Initial is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Mailing.Mailing_02_SMessageDesign is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Mailing.Mailing_03RemoveSOEditorTemplates is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Mailing.Mailing_07_StatisticsCalculation is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Mailing.Mailing_08_StatisticsDefaultDirty_Remove is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Mailing.Mailing_09_StatisticsDefaultDirty_Readd is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Mailing.Mailing_11_StatisticsSentNum is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Mailing.Mailing_12_LocalLinks is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Mailing.Mailing_13_LinkLength is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Mailing.Mailing_14_LinkRedirectKind is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Mailing.Mailing_15_RemoveRedirectIsUrl is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Mailing.Mailing_16_LinkRedirectFormId is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Metering.Metering_01_MeteringLogTable is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Notifications.Notifications_01_ModifiedAppointmentFields is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Notifications.Notifications_02_AppointmentIndex is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_R_Service.R_Service_03_EjUserId_1 is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_R_Service.R_Service_1 is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_R_Service.R_Service_2 is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_101_Conflict_detector_appointment_index is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_102_Udef_Freetext is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_112_EjUser_Flags22 is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_113_Message is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_114_FunctionalRights is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_115_Document_ContentSetCount is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_116_PrepareRemoveReporter is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_117_Expanded_Messages is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_118_SearchCritIndexes is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_119_Appointment_OwnedExternally is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_120_CopyLabelSubstitutions is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_121_PrimingDataUpdateRLDaysDA is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_122_AssignmentNotification is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_123_UTMParameters is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_124_CategoryGroups is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_128_FixIncorrectUniqueIndexes is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_129_ClearServiceAssociateHistory is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_130_Sale_StageWhenClosed is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_138_Appointment_ExternalParticipants is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_148_MarkAsSpam_FunctionalRight is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_149_MarkAsSpam_FunctionalRight_LocaleText is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_19_SoftDelete is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_20_Saint2 is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_23_SuperId is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_28_Tags is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_70_BatchTask_AddFileName is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_82_Extrafield_IndexNames is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_88_TargetsAdministrator_FunctionalRight is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.Steps_SuperOffice.SuperOffice_99_PersonAssocId is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Targets.TargetsStep01_Initial is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Targets.TargetsStep02_Normalize is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Targets.TargetsStep04_RevisionHistory is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Targets.TargetsStep05_LargeValueSupportAndMoreRevisionHistory is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Targets.TargetsStep06_RemoveOldValueFields is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Targets.TargetsStep07_NewDimensions is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Targets.TargetsStep08_ListField is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_UserPreference.UserPreference_01_Num_Expanded_Messages is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_UserPreference.UserPreference_02_EjUser_Simple_Fields_Migration is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_UserPreference.UserPreference_03_Flags_Migration is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_UserPreference.UserPreference_04_NotifyFields_Migration is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Webhooks.Webhooks_01_CreateTables is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.Steps_Webhooks.Webhooks_02_UsageTable is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.Steps_Webhooks.Webhooks_03_RemoveOldUsage is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.Steps_Webhooks.Webhooks_04_Add_ErrorEmail is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.Steps_Webhooks.Webhooks_05_NotifyTable is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep01_Initial is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep02_Rank is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep03_Hierarchy is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep04_EmailSettings is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep05_WorkflowSettings is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep06_WorkflowBlockList is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep07_WorkflowStepOptions is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep08_EmailFlowContent is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep09_NoConversionUtcDateAndTime is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep10_Locking is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep11_ParticipantFields is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep12_SShipmentAddrForeignKeysToFlow is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep13_SShipmentAddrForeignKeyIndexing is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep14_WorkflowStepOptionKeyToInt is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep15_FlowExitSettings is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep16_WorkflowFunctionalRights is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep16_WorkflowWaitForAction is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep18_EmailFlowContentFormsAndLinks is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep19_WorkflowSchemaOptimization_part1 is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep20_WorkflowSchemaOptimization_part2 is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep21_FormFields is Modified
+
+#### SuperOffice.CD.DSL.Database.Steps_Workflows.WorkflowStep22_FlowReferences is Modified
+
+#### SuperOffice.CD.DSL.Database.SubscriptionMgmtStep1 is Modified
+
+#### SuperOffice.CD.DSL.Database.SubscriptionMgmtStep2 is Modified
+
+#### SuperOffice.CD.DSL.Database.SubscriptionMgmtStep3 is Modified
+
+#### SuperOffice.CD.DSL.Database.SubscriptionMgmtStep4 is Modified
+
+#### SuperOffice.CD.DSL.Database.SubscriptionMgmtStep5_RenameTables is Modified
+
+#### SuperOffice.CD.DSL.Database.SubscriptionMgmtStep6_Indexes is Modified
+
+#### SuperOffice.CD.DSL.Database.SubscriptionMgmtStep7_Translations is Modified
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_100_SOCompany is Modified
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_104_Freetext_SequenceIds is Modified
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_11_PrimingData is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_111_UnsafeFileTypes_On_Group_Level is Modified
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_12_PrimingData is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_13_PrimingData is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_132_AutoUpdate is Modified
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_133_AutoUpdateAddLeadstatus is Modified
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_134_ShipmentAddrAddOwnerLock is Modified
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_135_PrimaryKeys is Modified
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_136_AvailableFonts is Modified
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_139_AvailableFontsSoftDelete is Modified
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_14_Indexes is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_15_PrimingData is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_16_PrimingData is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_17_PrimingData is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_18_DeleteOrphans is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_21_PrimingData is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_22_PrimingData is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_24_PrimingData is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_25_PrimingData is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_26_PrimingData is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_27_R_PreferenceMappings is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_5_PrimingData is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_56_PrunePreferences is Modified
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_58_SOCompany is Modified
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_6_TableNumberPrep is Modified
+
+* Deleted items
+  * Method `CustomPriming()`
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_60_AppointmentMother is Modified
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_66_PrimingData_Zip_Translations is Modified
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_69_PrimingData_Country_Language_RLD_GECompany is Modified
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_7_TableNumberFieldId is Modified
+
+* Deleted items
+  * Method `CustomPriming()`
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_9_PrimingData is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_90_ResetTagsFiltering is Modified
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_96_SOCompany is Modified
+
+#### SuperOffice.CD.DSL.Database.SuperOffice_98_EntityCounts is Modified
+
+#### SuperOffice.CD.DSL.Database.SuperOffice80_2 is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.SuperOffice80_3_CD2 is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.SuperOffice80_4_Upgrade is Modified
+
+* Deleted items
+  * Field `State`
+
+#### SuperOffice.CD.DSL.Database.TechnicalDebt_01_DuplicateUserPreference is Modified
+
+* Deleted items
+  * Field `State`

--- a/release-notes/api/changes/changes-webapi-12.1.1412.md
+++ b/release-notes/api/changes/changes-webapi-12.1.1412.md
@@ -1,0 +1,92 @@
+---
+uid: version_12.1.1412_changes_webapi
+date: 19.06.2026
+---
+
+Changes from v12.0.342 and v12.1.1412
+
+## Web API
+
+The following represent changes to the core Web API assembly.
+
+### Assembly: SuperOffice.WebApi
+
+### New Types
+
+* `SuperOffice.WebApi.Agents.CustomObjectAgent`
+* `SuperOffice.WebApi.Agents.ICustomObjectAgent`
+* `SuperOffice.WebApi.Data.CustomObject`
+* `SuperOffice.WebApi.Data.CustomObject_CreateDefaultCustomObjectRequest`
+* `SuperOffice.WebApi.Data.CustomObject_DeleteCustomObjectRequest`
+* `SuperOffice.WebApi.Data.CustomObject_GetCustomObjectDefinitionRequest`
+* `SuperOffice.WebApi.Data.CustomObject_GetCustomObjectRequest`
+* `SuperOffice.WebApi.Data.CustomObject_GetCustomObjectsIconsRequest`
+* `SuperOffice.WebApi.Data.CustomObject_GetCustomObjectsMetadataRequest`
+* `SuperOffice.WebApi.Data.CustomObject_HasScreenChooserRequest`
+* `SuperOffice.WebApi.Data.CustomObject_SaveCustomObjectRequest`
+* `SuperOffice.WebApi.Data.CustomObjectDefinition`
+* `SuperOffice.WebApi.Data.CustomObjectField`
+* `SuperOffice.WebApi.Data.CustomObjectMetadata`
+* `SuperOffice.WebApi.Data.CustomObjectRelation`
+* `SuperOffice.WebApi.Data.KbAccessLevel`
+* `SuperOffice.WebApi.Data.List_GetAllTicketRelationDefinitionEntitiesRequest`
+
+### Modified Types
+
+#### SuperOffice.WebApi.Agents.CustomerServiceAgent is Modified
+
+* Deleted items
+  * Method `CreateTicketFromMailDataAsync(Int32, String, RequestOptions)`
+* New items
+  * Method `CreateTicketFromMailDataAsync(Int32, String, Int32, RequestOptions)`
+
+#### SuperOffice.WebApi.Agents.ICustomerServiceAgent is Modified
+
+* Deleted items
+  * Method `CreateTicketFromMailDataAsync(Int32, String, RequestOptions)`
+* New items
+  * Method `CreateTicketFromMailDataAsync(Int32, String, Int32, RequestOptions)`
+
+#### SuperOffice.WebApi.Agents.IListAgent is Modified
+
+* New items
+  * Method `GetAllTicketRelationDefinitionEntitiesAsync(RequestOptions)`
+
+#### SuperOffice.WebApi.Agents.ListAgent is Modified
+
+* New items
+  * Method `GetAllTicketRelationDefinitionEntitiesAsync(RequestOptions)`
+
+#### SuperOffice.WebApi.Data.CustomerService_CreateTicketFromMailDataRequest is Modified
+
+* New items
+  * Property `PersonId`
+
+#### SuperOffice.WebApi.Data.PreviewFaqEntry is Modified
+
+* New items
+  * Property `AccessLevel`
+  * Property `AccessLevel_String`
+
+#### SuperOffice.WebApi.Data.UserPreferenceStrings is Modified
+
+* Deleted items
+
+##### SuperOffice.WebApi.Data.UserPreferenceStrings.Phone is Deleted
+
+##### SuperOffice.WebApi.Data.UserPreferenceStrings.SentryAddonNames is Deleted
+
+* Modified items
+
+##### SuperOffice.WebApi.Data.UserPreferenceStrings.Mail is Modified
+
+* New items
+  * Field `.MailShowMyEmails`
+
+* New items
+
+##### SuperOffice.WebApi.Data.UserPreferenceStrings.License is New
+
+## Web API Authorization
+
+The following represent changes to Web API authorization assemblies.

--- a/release-notes/database/changes-12.0.342.md
+++ b/release-notes/database/changes-12.0.342.md
@@ -5,7 +5,7 @@ description: What's new in database version 12.0.342.0.
 generated: true
 keywords: database
 content_type: reference
-envir: onsite, online
+envir: online
 ---
 
 # Released database changes in version 12.0.342.0
@@ -26,18 +26,15 @@ foreignKey
 Upgrade Oracle databases from 8.0 to 8.1: We are no longer using the CLOB datatype for fields shorter than 4k.
 For other databases this is a no-op. On large customers this will take quite some time!
 
-
 **Step 12**
 
-This step will add two new functional rights to the system. One for controlling wheter a user can manage consents for a customer, and one for controlling wheter a user can override consent/subscription checks in Mailings.
+This step will add two new functional rights to the system. One for controlling whether a user can manage consents for a customer, and one for controlling whether a user can override consent/subscription checks in Mailings.
 In addition, this step will give these two rights to all roles with the general admin right.
-
 
 **Step 14**
 
-<b>NB: Due to a Merge/RedAlert f...up, the functionality in this step has been moved to the Optimization name; and should properly live there!</b>
+NB: Due to a Merge/RedAlert f...up, the functionality in this step has been moved to the Optimization name; and should properly live there!
 Modify indexes that have a major impact on performance in Online
-
 
 **Step 18**
 
@@ -68,7 +65,6 @@ generationStart, lastGenerated
 Priming step for upgrading databases from whatever earlier 8.0 version
 We must handle upgrade from 8.0 RC2, since that is the version Online database migration uses.
 
-
 **Step 23**
 
 Add UserName to Associate
@@ -81,12 +77,10 @@ userName
 Priming step for upgrading databases from whatever earlier 8.0 version
 We must handle upgrade from 8.0 RC2, since that is the version Online database migration uses.
 
-
 **Step 25**
 
 Priming step for upgrading databases from whatever earlier 8.0 version
 We must handle upgrade from 8.0 RC2, since that is the version Online database migration uses.
-
 
 **Step 26**
 
@@ -95,7 +89,6 @@ Minor update in ZipCity; update of preference descriptions; update of FI address
 Priming step for upgrading databases from whatever earlier 8.0 version
 We must handle upgrade from 8.0 RC2, since that is the version Online database migration uses.
 NB When this step was submitted, some updated imp files for new databases were also submitted.
-
 
 **Step 27**
 
@@ -116,7 +109,6 @@ Add the Tags MDO list, a new Function Right to directly define tags, and assign 
 
 Reload the CacheTabs table, to add new lists
 
-
 **Step 30**
 
 It is now possible to turn off trailing-whitespace trimming of string fields in the database; and specify this and TimeZone processing in a generic manner
@@ -132,11 +124,9 @@ name
 
 Preference descriptions for the R project
 
-
 **Step 32**
 
 Transfer any password rules set in the now-obsolete preference System/PasswordPolicy into the password_rules table with id=1
-
 
 **Step 33**
 
@@ -149,11 +139,9 @@ includeSignature, showCurrents, senderEmailMode, senderEmailAddress
 
 Re-add the Tags MDO list in UdListDefinition table.
 
-
 **Step 35**
 
 Preference descriptions for the R project
-
 
 **Step 36**
 
@@ -166,36 +154,29 @@ ownerTable, ownerRecord, group\_id, configurationName
 
 Preference descriptions for invitation support
 
-
 **Step 38**
 
 Preference descriptions for invitation support and cleanup of UserPreference table
-
 
 **Step 39**
 
 New preference: default appointment type for incoming invitations
 
-
 **Step 40**
 
 This step has been made obsolete by later changes
-
 
 **Step 41**
 
 This step has been made obsolete by later changes
 
-
 **Step 42**
 
 Updated preferences, and translated name of functional right to create Tags
 
-
 **Step 43**
 
 Updated ZipCity for Norway
-
 
 **Step 44**
 
@@ -215,7 +196,6 @@ cautionWarning
 **Step 46**
 
 Updated preferences
-
 
 **Step 47**
 
@@ -243,7 +223,6 @@ suggestedCategory\_id
 
 Fix inconsistent Main Contact (supportPersonId) after bug in Sales.Web GUI
 
-
 **Step 51**
 
 Add a virtual field on contact (dotsyntax)
@@ -262,7 +241,6 @@ invitationDocType, privacyDocType
 
 Update Red Letter Days, table is overwritten, adding Red days for 2005-2030 for 23 countries
 
-
 **Step 54**
 
 Add a virtual field on person and contact (dotsyntax): emailLastBounce
@@ -276,10 +254,9 @@ emailLastBounce
 
 Reset bounceCount and lastBounce on the Email table for rows where lastBounce is before the start of year 2020
 
-
 **Step 56**
 
-Remove several sections and some individual preferences, that were only relevant to the Windows client. 
+Remove several sections and some individual preferences, that were only relevant to the Windows client.
 Remove never-used fields in searchcriterionvalue and replace with a string field for valueType
 
 * Modify table searchcriterionvalue
@@ -289,7 +266,7 @@ valueType
 
 **Step 57**
 
-Add TimeSpan=Minutes markers to relevant fields on the ticket, ej_message, invoice and ticket_priority tables; controls behaviour in Archives including Selection
+Add TimeSpan=Minutes markers to relevant fields on the ticket, ej_message, invoice and ticket_priority tables; controls behavior in Archives including Selection
 
 * Modify table ticket
 * Modify table ej\_message
@@ -308,7 +285,6 @@ updatedCount
 **Step 58**
 
 Update SOCompany information for new Online databases based on what is in the template and what data is wanted spring 2020
-
 
 **Step 60**
 
@@ -330,41 +306,33 @@ contact\_id
 
 New preference for disabling Image editor in Unlayer mailings editor
 
-
 **Step 63**
 
 New functional right for hiding Service and Mailings button and screen
-
 
 **Step 64**
 
 New preference for invitations, no tentative appointments for others
 
-
 **Step 65**
 
 New preference for mailing, disable image library for royalty-free images
-
 
 **Step 66**
 
 Add starting 0 to german zipcodes where it missed. Update N_List for US, remove duplicate MrMrs.
 
-
 **Step 67**
 
 , Remove duplicate of LowerLimitsaletypecat, new preference for mailing, disable image library for royalty-free images, translations
-
 
 **Step 68**
 
 New preference for document dialog in SOFO (and possible later OML, GmailLink and WEB)
 
-
 **Step 69**
 
-Update some languageinfo and languageinfocountry for correct detecting of language for GDPR confirmation mail. Update RedLetterDay and SOCompany address for Germany. Add a zipcode for DK: Orø. Set group for quote documents for new dbs. 
-
+Update some languageinfo and languageinfocountry for correct detecting of language for GDPR confirmation mail. Update RedLetterDay and SOCompany address for Germany. Add a zipcode for DK: Orø. Set group for quote documents for new dbs.
 
 **Step 70**
 
@@ -377,7 +345,6 @@ FileName
 
 New preference for Mailing, DisableFormsPoweredBy. Rename Mailing header to Marketing. Some fixes of quotes to single quotes.
 
-
 **Step 72**
 
 New field in Document-table for URL to external documents. Should be used internally by DocPlugins only!
@@ -389,7 +356,6 @@ ExtUrl
 
 Turn on freetext index in online.
 
-
 **Step 74**
 
 * Add table CacheInvalidation
@@ -398,52 +364,42 @@ Turn on freetext index in online.
 
 New preference: disable export of tile data
 
-
 **Step 76**
 
 Cleanup LocaleText - Reinsert all data
-
 
 **Step 77**
 
 Cleanup Prefdesc and prefdescline: Only partner-added rows are left, all SuperOffice-maintained preferences are now described in code
 
-
 **Step 78**
 
 Updated ZipToCity for Norway and Sweden
-
 
 **Step 79**
 
 New complete LocaleText - with new ticket notifications
 
-
 **Step 80**
 
-LocaleText - with LanguageRows for detection of supported GUI languages 
-
+LocaleText - with LanguageRows for detection of supported GUI languages
 
 **Step 81**
 
-Add functional right 'Lock / Unlock Target Assignment' 
-
+Add functional right 'Lock / Unlock Target Assignment'
 
 **Step 82**
 
 Index names for extrafields need to be as the Service code creates them; SDB import did not conform. This step will locate and rename any wrongly-named physical indexes (only applicable to databases that have been SDB-imported).
 There was also another bug where index-creation logic for extrafields was inverted, such that a field would get an index when it should not have, and vice versa. This is also corrected, both ways.
 
-
 **Step 83**
 
 Historically, extra-fields of type 'long text' where 'ntext' in Sql Server. This data type is obsolete and such steps will be converted to 'nvarchar(max)', though without reallocating storage space as that might take a long time depending on the amount of data
 
-
 **Step 84**
 
 Update translations for functional right 'Can lock and unlock target assignment'
-
 
 **Step 85**
 
@@ -467,11 +423,9 @@ New list tables to define quote approval and quote denied reasons
 
 Add quote approval push notification texts
 
-
 **Step 88**
 
-Add functional right 'Targets Administrator' 
-
+Add functional right 'Targets Administrator'
 
 **Step 89**
 
@@ -484,7 +438,6 @@ description, searchPhoneNumber
 
 Reset possible flag that says TAGS list is MDO grouped - not supported and should always be off
 
-
 **Step 91**
 
 Change code-generation flags for the ticket and ej_message tables, to give a custome Row implementation in NetServer. No changes to physical DB schema.
@@ -496,21 +449,17 @@ Change code-generation flags for the ticket and ej_message tables, to give a cus
 
 Add invitation declined push notification texts
 
-
 **Step 93**
 
-Update userpreference for Mirroring rows.Technical update of some imp files. 
-
+Update userpreference for Mirroring rows.Technical update of some imp files.
 
 **Step 95**
 
 Correct a red date for UK.
 
-
 **Step 96**
 
 Update SOCompany information for new Online databases based on data wanted december 2022
-
 
 **Step 97**
 
@@ -529,11 +478,9 @@ This table will contain the number of different entities an associate has create
 
 Repair missing ForeignKey relations for person.associate_id and person.group_id
 
-
 **Step 100**
 
 Update SOCompany information for new Online databases based on data wanted april 2023
-
 
 **Step 101**
 
@@ -556,11 +503,9 @@ Mark udef number fields as freetext index sources.
 
 Correct spelling for danish city Aarhus
 
-
 **Step 104**
 
 FreetextWords and FreetextIndex tables used random primary keys during incremental indexing. This is now changing to ordinary PK's from the sequence table. During the transition we need to "make room at the top" of the id space, to ensure we avoid collisions until the next full reindexing
-
 
 **Step 105**
 
@@ -579,11 +524,9 @@ Add new index on freetext index table to improve query performance.
 
 (No longer valid) Remove old index on freetext index table so we can create new fresh indexes.
 
-
 **Step 108**
 
 (No longer valid) Create new clustered index on freetext index table to improve query performance.
-
 
 **Step 109**
 
@@ -598,16 +541,13 @@ ns\_secret
 
 Workflow add 2 functional rights, moved from workflows
 
-
 **Step 111**
 
 Remove user-specific unsafe file types. It should only be settable on the group level.
 
-
 **Step 112**
 
 Clear bit 22 in ejUser.flags. It will be reused for storing 'includeOwnTicketsInGetNext'.
-
 
 **Step 113**
 
@@ -617,8 +557,7 @@ Modify Message table to support new yellow banner messaging system
 
 **Step 114**
 
-Update requiredModule for cs-listextratablecontent and cs-editextratablecontent to 'superoffice.expander-services'
-
+Update requiredModule for cs-listextratablecontent and cs-editextratablecontent to 'SuperOffice.expander-services'
 
 **Step 115**
 
@@ -631,11 +570,9 @@ contentSetCount
 
 As reporter is removed, customers with saved report documents want an easy way to retrieve them, so we give them a dynamic selection to do that
 
-
 **Step 117**
 
 Update ejuser.num_expanded_messages
-
 
 **Step 118**
 
@@ -656,11 +593,9 @@ owned\_externally
 
 Copy SR_ARCHIVE_NUMBER to SR_SALESARCHIVE_NUMBER and SR_PL_INTERESTS_PERSON to SR_PL_INTERESTS_1 in resourceoverride table to make different labelsubstitution possible for those two resources
 
-
 **Step 121**
 
 Update RedLetterDays for Denmark, remove Store Bededag as red day from 2024, but keep it as named day
-
 
 **Step 122**
 
@@ -707,11 +642,9 @@ leadstatus\_id
 
 Corrects the DatabaseModel for three indexes that were incorrectly marked as unique after a previous upgrade. This step inspects the model for indexes on 'target_revision_history.target_group_id', 'email_account.email_address', and 'email_folder.account_id' and sets their IsUnique property to false if found to be true.
 
-
 **Step 129**
 
 Remove ServiceAssociates rows from history. They are redundant and not used anymore.
-
 
 **Step 130**
 
@@ -723,7 +656,6 @@ stage\_when\_closed\_id
 **Step 131**
 
 Adding values for category_group, enable_lead_status in category table. (For new customers only)
-
 
 **Step 132**
 
@@ -782,11 +714,9 @@ deleted
 
 Add fonts for use in forms
 
-
 **Step 141**
 
 Add fonts for use in forms, this time sorted alphabetically
-
 
 **Step 142**
 
@@ -821,7 +751,6 @@ event\_participant\_status
 
 Remove eventual Reporter specific preferences from the UserPreference table
 
-
 **Step 145**
 
 Remove unique index on productversion.(ownername, codename, version) that no longer makes sense
@@ -832,7 +761,6 @@ Remove unique index on productversion.(ownername, codename, version) that no lon
 
 Remove obsolete (and empty) backup tables that only exists in One, after an earlier GDPR cleaning process that is no longer in use
 
-
 **Step 147**
 
 Remove obsolete table 'usagestats', that contains usage statistics from the discontinued Windows Desktop client
@@ -841,13 +769,11 @@ Remove obsolete table 'usagestats', that contains usage statistics from the disc
 
 **Step 148**
 
-Add functional right 'Can mark requests as Spam' 
-
+Add functional right 'Can mark requests as Spam'
 
 **Step 149**
 
 Update translations for functional right 'Can mark requests as Spam'
-
 
 ## ai
 
@@ -1015,7 +941,6 @@ deltaState
 
 Clear out all rows in SystemEvent, in preparation for a unique index to be defined
 
-
 **Step 4**
 
 Create unique index on SystemEvent, to support multi-user-safe event locking
@@ -1024,7 +949,7 @@ Create unique index on SystemEvent, to support multi-user-safe event locking
 
 **Step 5**
 
-This table will contain a mapping on which type of data (appliesToKey) will be used to differ between layouts in the given recipeId 
+This table will contain a mapping on which type of data (appliesToKey) will be used to differ between layouts in the given recipeId
 
 * Add table ConfigurableScreenAppliesTo
 
@@ -1047,21 +972,17 @@ encoding
 
 Move webpanels that are actually task menu items to new table taskmenu
 
-
 **Step 9**
 
 Update Ticket tab pane container ID from 'CardPanes' to 'TicketTabPanes'
-
 
 **Step 10**
 
 Remove reference to FeatureToggle:NSTicketType
 
-
 **Step 11**
 
 Update existing ticket status related CONFIGURABLESCREENDELTA because of the new TicketStatusComponent
-
 
 ## ConsentManagement
 
@@ -1097,7 +1018,6 @@ rfc822\_content
 **Step 9**
 
 One-time "migration" from person.nomailing and s_shipment_addr to become ConsentPerson rows
-
 
 **Step 10**
 
@@ -1135,21 +1055,17 @@ ConsentSourceId, LegalBaseId
 
 Set the #STORE consent on all person records that do not already have it; we assume that all persons in the customers database are there for a legitimate reason
 
-
 **Step 16**
 
 As we now set the #STORE consent on all person records that do not already have it, we also set a default consent and legal base for new persons, thus we set the Default legal base preference.
-
 
 **Step 22**
 
 Remove confirmation mail links for consent sources where SuperOffice does not send privacy confirmation email by design.
 
-
 **Step 23**
 
 Update document template to sync emailmode with privacytype
-
 
 ## Copilot
 
@@ -1162,7 +1078,6 @@ Add tables for Copilot
 **Step 2**
 
 Add initial Copilot
-
 
 ## CRMScript
 
@@ -1211,7 +1126,6 @@ autosave
 **Step 7**
 
 Fix triggers with screen_type = 130. Set to 113 and disable.
-
 
 **Step 8**
 
@@ -1290,11 +1204,9 @@ tags, contact\_id
 
 Transfer mobile phone from ticket to person if no phone on person
 
-
 **Step 10**
 
 Set ticket.contact_id to be consistent with ticket.cust_id.contact_id; and copy the person classifiers (associate_id, group_id, business_idx, category_idx) from contact to person unless person.contact_id = 0
-
 
 **Step 11**
 
@@ -1314,7 +1226,6 @@ attachment\_location\_id
 **Step 13**
 
 Create and enable password rules if they have not been changed from the default
-
 
 **Step 14**
 
@@ -1343,7 +1254,6 @@ suggestedCategory\_id, origHumanCategory\_id
 **Step 17**
 
 Add details clob to ticket_log_action table for JSON logging
-
 
 **Step 18**
 
@@ -1383,7 +1293,6 @@ ai\_suggest\_category, ai\_text\_analysis
 **Step 23**
 
 Change ticket notification expiry from 10 minutes to 24 hours
-
 
 **Step 24**
 
@@ -1496,7 +1405,6 @@ ticket\_type, request\_type
 
 Remove priming data for RequestType list that we wish to move to another table
 
-
 **Step 41**
 
 Remove tables for never-implemented TicketType functionality. The motivation is to clear out junk, as well as keep a consistent naming scheme for ticket functionality
@@ -1544,7 +1452,6 @@ time\_spent
 
 Remove primary key constraint from now-obsolete tables, to prevent faults during Database Mirroring. Only relevant for Online
 
-
 **Step 46**
 
 Add ticket_type.is_default column and insert the first, default, request type
@@ -1565,7 +1472,6 @@ new\_ticket\_type
 
 This step has been superseded by a later step
 
-
 **Step 49**
 
 Update ticket_type.icon column with default icon value
@@ -1577,11 +1483,9 @@ icon
 
 Ticket type priming data used to set default tooltip. We remove it by setting tooltip empty where ticket_type_id = 1
 
-
 **Step 51**
 
 Change CreatedBy criteria to be based on EjUser instead of Associate
-
 
 **Step 52**
 
@@ -1664,26 +1568,21 @@ table\_number
 
 Fill extra_tables.table_number
 
-
 **Step 64**
 
 Recalculate Model.NextTableNumber
-
 
 **Step 65**
 
 Recalculate Model.NextTableNumber
 
-
 **Step 66**
 
 Generate Dataright rows for CustomObjects for all applicable roles
 
-
 **Step 67**
 
 Updates custom object selection table number to correct one
-
 
 **Step 68**
 
@@ -1722,7 +1621,6 @@ Drop tables previously made obsolete (we couldn't delete them in earlier version
 
 Insert new default status for TicketBaseStatus.Spam. Insert new registry row
 
-
 ## customerCenter
 
 Create new table for storing customer center styling and configuration options
@@ -1732,7 +1630,6 @@ Create new table for storing customer center styling and configuration options
 **Step 2**
 
 Prime in default Customer Center Config
-
 
 **Step 3**
 
@@ -1751,121 +1648,97 @@ payload
 
 Upgrade cc_template formFrame2.html
 
-
 **Step 6**
 
 Upgrade cc_template formFrame2.html
-
 
 **Step 7**
 
 Upgrade cc_template formFrame2.html
 
-
 **Step 8**
 
 Upgrade cc_template formFrame2.html
-
 
 **Step 9**
 
 Upgrade cc_template formFrame2.html, form.js
 
-
 **Step 10**
 
 Delete cc_template formFrame2.html, form.js with type=1
-
 
 **Step 11**
 
 Upgrade cc_template formFrame2.html, form.js
 
-
 **Step 12**
 
 Upgrade cc_template formFrame2.html, form.js
-
 
 **Step 13**
 
 Upgrade cc_template formFrame2.html
 
-
 **Step 14**
 
 Upgrade cc_template formFrame2.html
-
 
 **Step 15**
 
 Upgrade cc_template formFrame2.html
 
-
 **Step 16**
 
 Upgrade cc_template updateSubscriptionsFrame2.html
-
 
 **Step 17**
 
 Upgrade cc_template updateSubscriptionsFrame2.html
 
-
 **Step 18**
 
 Upgrade cc_template updateSubscriptionsFrame2.html
-
 
 **Step 19**
 
 Upgrade cc_template updateSubscriptionsFrame2.html
 
-
 **Step 20**
 
 Upgrade cc_template formFrame2.html
-
 
 **Step 21**
 
 Upgrade cc_template updateSubscriptionsFrame2.html
 
-
 **Step 22**
 
 Upgrade cc_template updateSubscriptionsFrame2.html
-
 
 **Step 23**
 
 Upgrade cc_template formFrame2.html
 
-
 **Step 24**
 
 Upgrade cc_template formFrame2.html
-
 
 **Step 25**
 
 Upgrade cc_template formFrame2.html
 
-
 **Step 26**
 
 Upgrade cc_template formFrame2.html
-
 
 **Step 27**
 
 Upgrade cc_template formFrame2.html
 
-
 **Step 28**
 
 Upgrade cc_template formFrame2.html
-
 
 ## dashboard
 
@@ -1910,7 +1783,6 @@ rank
 **Step 6**
 
 Add functional right
-
 
 **Step 7**
 
@@ -1974,11 +1846,9 @@ Set the required attributes to activate Sentry functionality on dashboard, dashb
 
 Update dashboard theme data with fixed IDs
 
-
 **Step 16**
 
 Generate Dataright rows for the new Dashboard, in the data right matrix in Admin
-
 
 **Step 17**
 
@@ -1991,7 +1861,6 @@ style
 
 Update big number colors in dark mode for built-in dashboard themes
 
-
 **Step 19**
 
 Update DashboardTileDefinition with information about where it can be used
@@ -2003,11 +1872,9 @@ usage
 
 Update colors for stalled and open sales in dashboards.
 
-
 **Step 21**
 
 Update DashboardTheme with resource symbols.
-
 
 **Step 22**
 
@@ -2019,11 +1886,9 @@ Add table for QuickFilters
 
 Superseded by DashboardStep24_DefaultDashboardNoOwner
 
-
 **Step 24**
 
 Change associate_id of existing default dashboards to -1.
-
 
 ## ExternalOwner
 
@@ -2156,7 +2021,6 @@ cal\_data
 
 Ensure all email-IDs used as foreignkeys in the foreignkey-table are enclosed in tags. Update all rows as needed, in one operation
 
-
 **Step 12**
 
 * Modify table email\_account
@@ -2189,7 +2053,6 @@ organizer\_email, organizer\_fullname, recurring\_end\_date
 **Step 3**
 
 Set preference "Diary sync active" if Infobridge synchronizer seem to be in use.
-
 
 **Step 4**
 
@@ -2240,7 +2103,6 @@ flags
 **Step 3**
 
 Remove the old SOEditor mailing templates for new Online installations
-
 
 **Step 4**
 
@@ -2379,7 +2241,6 @@ html\_text
 
 The typical search table is an owner of a set of predefined selection criteria
 
-
 **Step 2**
 
 Cleanup after initial (obsolete) table definition
@@ -2410,11 +2271,9 @@ chartKey, lastLoaded, lastLoadedBy, lastMembershipChange, lastMembershipChangeBy
 
 SelectionForFind creates a dynamic selection for each entity/associate as needed; they were missing the required VisibleFor row; those are added here
 
-
 **Step 7**
 
 Update targetTableNumber to 5 where it was 0, and reset membercounts to -1 where we have no recent data
-
 
 **Step 8**
 
@@ -2472,7 +2331,6 @@ Add table OnlineApp, to echo information about authorizations and usage. Optimiz
 
 Deleting obsolete counter-preferences
 
-
 ## Pocket
 
 * Add table PushNotificationService
@@ -2512,11 +2370,9 @@ flags
 
 Change value of registry entry for maximum width of components
 
-
 **Step 3**
 
 Make sure the row with id=1 in ejuser contains the '(System)' user
-
 
 ## SubscriptionMgmt
 
@@ -2571,7 +2427,6 @@ waiting\_for\_approval
 
 Add tables for Targets (Sales, Project, Selection....
 
-
 **Step 2**
 
 Some further normalization
@@ -2587,7 +2442,6 @@ Some further normalization
 **Step 3**
 
 Generate Dataright rows for Targets, in the data right matrix in Admin
-
 
 **Step 4**
 
@@ -2638,26 +2492,21 @@ dimension\_list
 
 In this step we would like to remove userpreference entries with duplicate primary key!
 
-
 ## UserPreference
 
 Migrate EjUser.num_expanded_messaged to UserPreference table
-
 
 **Step 2**
 
 Migrate EjUser default_status_new_ticket, default_status_add_message, default_category, default_user to UserPreference table
 
-
 **Step 3**
 
 Migrate EjUser flags to UserPreference table
 
-
 **Step 4**
 
 Migrate EjUser NotifyMask to UserPreference table
-
 
 ## Webhooks
 
@@ -2781,7 +2630,6 @@ Email flow content (connected message assets)
 
 Store datetimes as UTC and disable automatic time zone conversion
 
-
 **Step 10**
 
 Locking system for concurrency control needed by workflows (and others)
@@ -2832,7 +2680,6 @@ WorkflowWaitForAction new table
 
 Workflow add 2 functional rights (obsolete)
 
-
 **Step 18**
 
 Email flow content (more assets)
@@ -2879,4 +2726,3 @@ created\_by\_workflow\_id
 created\_by\_workflow\_id
 * Modify table appointment
 created\_by\_workflow\_id
-

--- a/release-notes/database/changes-12.1.1412.md
+++ b/release-notes/database/changes-12.1.1412.md
@@ -1,14 +1,14 @@
 ---
-uid: database-whats-new-12.2.2072.0
-title: What's new in version 12.2.2072.0
-description: What's new in database version 12.2.2072.0.
+uid: database-whats-new-12.1.1412.0
+title: What's new in version 12.1.1412.0
+description: What's new in database version 12.1.1412.0.
 generated: true
 keywords: database
 content_type: reference
 envir: online
 ---
 
-# Released database changes in version 12.2.2072.0
+# Released database changes in version 12.1.1412.0
 
 ## SuperOffice
 
@@ -32,7 +32,7 @@ In addition, this step will give these two rights to all roles with the general 
 
 **Step 14**
 
-NB: Due to a Merge/RedAlert f...up, the functionality in this step has been moved to the Optimization name; and should properly live there!
+<b>NB: Due to a Merge/RedAlert f...up, the functionality in this step has been moved to the Optimization name; and should properly live there!</b>
 Modify indexes that have a major impact on performance in Online
 
 **Step 18**
@@ -265,7 +265,7 @@ valueType
 
 **Step 57**
 
-Add TimeSpan=Minutes markers to relevant fields on the ticket, ej_message, invoice and ticket_priority tables; controls behaviour in Archives including Selection
+Add TimeSpan=Minutes markers to relevant fields on the ticket, ej_message, invoice and ticket_priority tables; controls behavior in Archives including Selection
 
 * Modify table ticket
 * Modify table ej\_message
@@ -774,28 +774,11 @@ Add functional right 'Can mark requests as Spam'
 
 Update translations for functional right 'Can mark requests as Spam'
 
-**Step 150**
-
-Updated ZipToCity for Norway
-
-**Step 151**
-
-Add `sale.sale_cycle` and the mirroring `sale_hist.sale_cycle`. Number of days from a sale being registered until it entered its current closed (Sold or Lost) state; 0/empty while open. Back-fills existing closed sales from salehist. Save-time maintenance lives in SaleRowImplementation.OnSaveAsync.
-
-* Modify table sale
-sale\_cycle
-* Modify table SaleHist
-sale\_cycle
-
 ## ai
 
 The `ai_chat_turn` table contains chat history for user's chatbot sessions with GPT. Chats are keyed by the chat_id and associate_id, and ordered by timestamp. Chat Messages are automatically added to the history as the bot generates answers.
 
 * Add table ai\_chat\_turn
-
-**Step 2**
-
-Set default values for AI preferences.
 
 ## chat
 
@@ -1091,17 +1074,6 @@ Remove confirmation mail links for consent sources where SuperOffice does not se
 **Step 23**
 
 Update document template to sync emailmode with privacytype
-
-**Step 24**
-
-Improve GDPR field descriptions: adopt the more meaningful list-specific text for LegalBase and ConsentSource (name/rank/tooltip/key), and fix the copy/paste ConsentPerson.consentPurpose_id description ('Legal base' -> 'Consent purpose').
-
-* Modify table LegalBase
-name, tooltip, rank, key
-* Modify table ConsentSource
-name, tooltip, rank, key
-* Modify table ConsentPerson
-consentPurpose\_id
 
 ## Copilot
 
@@ -2336,30 +2308,6 @@ Making time_keeping table compatible with our standard generated code, easier cl
 
 * Modify table time\_keeping
 ownerTable, ownerRecord, entity\_id
-
-**Step 12**
-
-Bug 105828: migrate the 'Owned by user group' criterion from '<prefix>/otherGroups' (matched any group membership via usergrouplink) to '<prefix>/usergroup' (the owner's primary group, associate.group_idx) for the associate, contactAssociate, contactSupportAssociate, personAssociate and projectAssociate prefixes. Only the stored criterion column name changes; operators and values are unaffected. Bare 'otherGroups' is not migrated.
-
-Bug 105828: the "Owned by user group" criterion must filter on the owner's current PRIMARY group.
-It used to be bound to the '.../otherGroups' column, which restricts via the usergrouplink table
-and therefore also matched owners that merely had the group as a secondary group. The criterion is
-now bound to '.../usergroup' (associate.group_idx, the owner's primary group).
-
-This step migrates every already-saved criterion, rewriting the stored criterion column from
-'&lt;prefix&gt;/otherGroups' to '&lt;prefix&gt;/usergroup' for each associate-owner prefix used by the
-archive providers. Both columns use the same UserGroup operators and store a user-group id as the
-value, so only the column name changes - operators, operatorId and the SearchCriterionValue rows
-are untouched. The bare 'otherGroups' column is intentionally NOT migrated.
-
-## NewsFeed
-
-The `NewsFeedItem` and related tables allow agents and other systems to post news items to a user-oriented feed that can be rendered in start pages and dashboards.
-
-* Add table NewsFeedItem
-* Add table NewsFeedItemHtml
-* Add table NewsFeedItemCta
-* Add table NewsFeedItemRecipient
 
 ## Notifications
 


### PR DESCRIPTION
## Summary
Extracts just the release-notes content from `api-files-12.1.1412-20260619.1`, excluding that branch's `docs/en/api` updates — main has already moved on to 12.2, so we only want to preserve the 12.1 changelog history, not roll back the API reference.

- Adds the 12.1 changelog pages (`release-notes/12/api/12.1/*`, `release-notes/api/changes/changes-{netserver,webapi}-12.1.1412.md`, `release-notes/database/changes-12.1.1412.md`)
- Merges the 12.1 entries into `release-notes/12/api/index.md` and `release-notes/12/toc.yml` alongside the existing 12.0/12.2 entries, instead of overwriting them (the source branch's version of these two files was based on an older main and would have regressed the 12.2 references)
- Fixes a duplicate `uid` — `changes-webapi-12.1.1412.md` collided with the NetServer file's uid; renamed to `version_12.1.1412_changes_webapi` to match the existing `_webapi` suffix convention
- Cleans up blank-line whitespace (MD012/MD022/MD032) in the new changelog files, and applies the same blank-line + minor typo cleanup to `changes-12.0.342.md` and `changes-12.2.2072.md`
- Adds missing `language: en` frontmatter to the three new 12.1 pages, matching their 12.0/12.2 siblings

## Test plan
- [ ] Confirmed no duplicate `uid` values introduced (repo-wide check)
- [ ] Spot-check `release-notes/12/toc.yml` and `release-notes/12/api/index.md` render correctly with 12.0/12.1/12.2 entries in order